### PR TITLE
prevents redundancy for altLabels that already exist or are a primaryLabel

### DIFF
--- a/src/com/cdd/bao/template/SchemaTree.java
+++ b/src/com/cdd/bao/template/SchemaTree.java
@@ -26,8 +26,8 @@ public class SchemaTree
 		public Branch source = null;
 		public String uri = null, label = null, descr = null;
 		
-		public String[] altLabels = null;
-		public String[] externalURLs = null;
+		public HashSet<String> altLabels = null;
+		public HashSet<String> externalURLs = null;
 		public String pubchemSource = null;
 		public boolean pubchemImport = false;
 		

--- a/src/com/cdd/bao/template/SchemaVocab.java
+++ b/src/com/cdd/bao/template/SchemaVocab.java
@@ -29,8 +29,8 @@ public class SchemaVocab
 	{
 		public String uri;
 		public String label, descr;
-		public HashSet<String> altLabels;
-		public HashSet<String> externalURLs;
+		public HashSet<String> altLabels = new HashSet<>();
+		public HashSet<String> externalURLs = new HashSet<>();
 		public String pubchemSource;
 		public boolean pubchemImport;
 	}
@@ -187,15 +187,10 @@ public class SchemaVocab
 			
 			int numAltLabels = data.readInt();
 			if (numAltLabels > 0)
-			{
-
 				for (int i = 0; i < numAltLabels; i++) term.altLabels.add(data.readUTF());
-			}
 			int numURLs = data.readInt();
 			if (numURLs > 0)
-			{
 				for (int i = 0; i < numURLs; i++) term.externalURLs.add(data.readUTF());
-			}
 			term.pubchemSource = data.readUTF();
 			term.pubchemImport = data.readBoolean();
 			

--- a/src/com/cdd/bao/template/SchemaVocab.java
+++ b/src/com/cdd/bao/template/SchemaVocab.java
@@ -29,8 +29,8 @@ public class SchemaVocab
 	{
 		public String uri;
 		public String label, descr;
-		public String[] altLabels;
-		public String[] externalURLs;
+		public HashSet<String> altLabels;
+		public HashSet<String> externalURLs;
 		public String pubchemSource;
 		public boolean pubchemImport;
 	}
@@ -188,14 +188,13 @@ public class SchemaVocab
 			int numAltLabels = data.readInt();
 			if (numAltLabels > 0)
 			{
-				term.altLabels = new String[numAltLabels];
-				for (int i = 0; i < numAltLabels; i++) term.altLabels[i] = data.readUTF();
+
+				for (int i = 0; i < numAltLabels; i++) term.altLabels.add(data.readUTF());
 			}
 			int numURLs = data.readInt();
 			if (numURLs > 0)
 			{
-				term.externalURLs = new String[numURLs];
-				for (int i = 0; i < numURLs; i++) term.externalURLs[i] = data.readUTF();
+				for (int i = 0; i < numURLs; i++) term.externalURLs.add(data.readUTF());
 			}
 			term.pubchemSource = data.readUTF();
 			term.pubchemImport = data.readBoolean();


### PR DESCRIPTION
Did this by changing stored lists of labels from arrays to
hashsets which only contain unique elements. Also, the hashsets are
easily checked for .contains in order to not add an altlabel for when
primaryLabels.contains(altLabel). 

Please check logic. I'm not sure how to test this...