### PR TITLE
check if altLabel array already contains the label to handle redundancy

### DIFF
--- a/src/com/cdd/bao/template/SchemaVocab.java
+++ b/src/com/cdd/bao/template/SchemaVocab.java
@@ -92,7 +92,7 @@ public class SchemaVocab
 			termList[n].uri = termURI[n];
 			termList[n].label = vocab.getLabel(termURI[n]);
 			termList[n].descr = vocab.getDescr(termURI[n]);
-			termList[n].altLabels = ArrayUtils.removeElement(vocab.getAltLabels(termURI[n]), termList[n].label); // tries to remove the first occurence of the label from altLabels (already duplicate-free)
+			termList[n].altLabels = ArrayUtils.removeElement(vocab.getAltLabels(termURI[n]), termList[n].label);
 			termList[n].externalURLs = vocab.getExternalURLs(termURI[n]);
 			termList[n].pubchemSource = vocab.getPubChemSource(termURI[n]);	
 			termList[n].pubchemImport = vocab.getPubChemImport(termURI[n]);

--- a/src/com/cdd/bao/template/SchemaVocab.java
+++ b/src/com/cdd/bao/template/SchemaVocab.java
@@ -9,6 +9,7 @@ package com.cdd.bao.template;
 import com.cdd.bao.util.*;
 import static com.cdd.bao.template.Schema.*;
 import static com.cdd.bao.template.Vocabulary.*;
+import org.apache.commons.lang3.*;
 
 import java.util.*;
 import java.io.*;
@@ -91,7 +92,9 @@ public class SchemaVocab
 			termList[n].uri = termURI[n];
 			termList[n].label = vocab.getLabel(termURI[n]);
 			termList[n].descr = vocab.getDescr(termURI[n]);
-			termList[n].altLabels = vocab.getAltLabels(termURI[n]);
+			List<String> myList = new ArrayList<>(Arrays.asList(vocab.getAltLabels(termURI[n]))); // convert array of altLabels to a list
+			myList.remove(vocab.getLabel(termURI[n])); // removes any first occurence of a primary label from the list of altLabels (should only be uo to 1 match since list is already made to be unique)
+			termList[n].altLabels = myList.toArray(new String[0]); // convert list back to an array and add it to the termList
 			termList[n].externalURLs = vocab.getExternalURLs(termURI[n]);
 			termList[n].pubchemSource = vocab.getPubChemSource(termURI[n]);	
 			termList[n].pubchemImport = vocab.getPubChemImport(termURI[n]);

--- a/src/com/cdd/bao/template/SchemaVocab.java
+++ b/src/com/cdd/bao/template/SchemaVocab.java
@@ -92,9 +92,7 @@ public class SchemaVocab
 			termList[n].uri = termURI[n];
 			termList[n].label = vocab.getLabel(termURI[n]);
 			termList[n].descr = vocab.getDescr(termURI[n]);
-			List<String> myList = new ArrayList<>(Arrays.asList(vocab.getAltLabels(termURI[n]))); // convert array of altLabels to a list
-			myList.remove(vocab.getLabel(termURI[n])); // removes any first occurence of a primary label from the list of altLabels (should only be uo to 1 match since list is already made to be unique)
-			termList[n].altLabels = myList.toArray(new String[0]); // convert list back to an array and add it to the termList
+			termList[n].altLabels = ArrayUtils.removeElement(vocab.getAltLabels(termURI[n]), termList[n].label); // tries to remove the first occurence of the label from altLabels (already duplicate-free)
 			termList[n].externalURLs = vocab.getExternalURLs(termURI[n]);
 			termList[n].pubchemSource = vocab.getPubChemSource(termURI[n]);	
 			termList[n].pubchemImport = vocab.getPubChemImport(termURI[n]);

--- a/src/com/cdd/bao/template/Vocabulary.java
+++ b/src/com/cdd/bao/template/Vocabulary.java
@@ -461,8 +461,7 @@ public class Vocabulary
 			else if (predicate.equals(altLabel1) || predicate.equals(altLabel2) || predicate.equals(altLabel3) || predicate.equals(altLabel4))
 			{
 				String[] list = uriToAlternateLabels.get(uri);
-				String primaryLabel = uriToLabel.get(uri); // get primaryLabel for this uri to check for redundancy against this putatuve altLabel
-				if (!ArrayUtils.contains(list, label) && !label.equals(primaryLabel)) // doesn't add label to the altLabels list for this uri if it already contains it as an altLabel or it's the same as a primaryLabel
+				if (!ArrayUtils.contains(list, label)) // doesn't add label to the altLabels list for this uri if it already contains it as an altLabel
 					uriToAlternateLabels.put(uri, ArrayUtils.add(list, label));
 			}
 		}

--- a/src/com/cdd/bao/template/Vocabulary.java
+++ b/src/com/cdd/bao/template/Vocabulary.java
@@ -461,8 +461,7 @@ public class Vocabulary
 			else if (predicate.equals(altLabel1) || predicate.equals(altLabel2) || predicate.equals(altLabel3) || predicate.equals(altLabel4))
 			{
 				String[] list = uriToAlternateLabels.get(uri);
-				if (!ArrayUtils.contains(list, label))
-					uriToAlternateLabels.put(uri, ArrayUtils.add(list, label));
+				if (!ArrayUtils.contains(list, label)) uriToAlternateLabels.put(uri, ArrayUtils.add(list, label));
 			}
 		}
 		

--- a/src/com/cdd/bao/template/Vocabulary.java
+++ b/src/com/cdd/bao/template/Vocabulary.java
@@ -461,7 +461,7 @@ public class Vocabulary
 			else if (predicate.equals(altLabel1) || predicate.equals(altLabel2) || predicate.equals(altLabel3) || predicate.equals(altLabel4))
 			{
 				String[] list = uriToAlternateLabels.get(uri);
-				if (!ArrayUtils.contains(list, label)) // doesn't add label to the altLabels list for this uri if it already contains it as an altLabel
+				if (!ArrayUtils.contains(list, label))
 					uriToAlternateLabels.put(uri, ArrayUtils.add(list, label));
 			}
 		}

--- a/src/com/cdd/bao/template/Vocabulary.java
+++ b/src/com/cdd/bao/template/Vocabulary.java
@@ -461,8 +461,10 @@ public class Vocabulary
 			else if (predicate.equals(altLabel1) || predicate.equals(altLabel2) || predicate.equals(altLabel3) || predicate.equals(altLabel4))
 			{
 				String[] list = uriToAlternateLabels.get(uri);
-				uriToAlternateLabels.put(uri, ArrayUtils.add(list, label));
-			}			
+				String primaryLabel = uriToLabel.get(uri); // get primaryLabel for this uri to check for redundancy against this putatuve altLabel
+				if (!ArrayUtils.contains(list, label) && !label.equals(primaryLabel)) // doesn't add label to the altLabels list for this uri if it already contains it as an altLabel or it's the same as a primaryLabel
+					uriToAlternateLabels.put(uri, ArrayUtils.add(list, label));
+			}
 		}
 		
 		// pull out the equivalences


### PR DESCRIPTION
also, checks that the altLabel doesn't match the uri's label before
before keeping it as an altLabel.

**Handled this by checking if the array list for a uri's altLabels already contains the label or not**

The "altLabels" should be pruned of duplicates in two separate places: when loading initially (Vocabulary.java), alter the condition so that the alt-label isn't added if it is already in the list...

Vocabulary.java:

String[] list = uriToAlternateLabels.get(uri);
uriToAlternateLabels.put(uri, ArrayUtils.add(list, label));

**I think the below part is fixed by just not adding labels as altLabels if they are already being used as the label for a URI (see code changes and comments)**

Then in the part where it writes the compiled content to the file, exclude any entries that happen to be the same as the primary label:

SchemaVocab.java:

termList[n].label = vocab.getLabel(termURI[n]);
termList[n].descr = vocab.getDescr(termURI[n]);
termList[n].altLabels = vocab.getAltLabels(termURI[n]);

