### PR TITLE
Added List-to-PrimArray methods

### DIFF
--- a/src/com/cdd/bao/util/Util.java
+++ b/src/com/cdd/bao/util/Util.java
@@ -173,20 +173,16 @@ public class Util
 	 */
 	public static String[] primString(List<String> vec)
 	{
-		String[] arr = new String[vec.size()]; 
-		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
-		return arr;
+		return (String[])vec.toArray();
 	}
 
 	/**
 	 * Converts an array of arbitrary objects directly to a primitive array of same object type.
 	 */
+	@SuppressWarnings("unchecked")
 	public static <T> T[] primObject(List<T> vec)
 	{
-		@SuppressWarnings("unchecked")
-		T[] arr = (T[])new Object[vec.size()]; 
-		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
-		return arr;
+		return (T[])vec.toArray();
 	}
 	
 	/**

--- a/src/com/cdd/bao/util/Util.java
+++ b/src/com/cdd/bao/util/Util.java
@@ -99,6 +99,97 @@ public class Util
 	public static int length(Object arr) {return arr == null ? 0 : Array.getLength(arr);}
 	
 	/**
+	 * Converts an array of Byte objects directly to a primitive array.
+	 */
+	public static byte[] primByte(List<Byte> vec) 
+	{
+		byte[] arr = new byte[vec.size()]; 
+		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
+		return arr;
+	}
+
+	/**
+	 * Converts an array of Integer objects directly to a primitive array.
+	 */
+	public static int[] primInt(List<Integer> vec)
+	{
+		int[] arr = new int[vec.size()]; 
+		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
+		return arr;
+	}
+
+	/**
+	 * Converts an array of Long objects directly to a primitive array.
+	 */
+	public static long[] primLong(List<Long> vec)
+	{
+		long[] arr = new long[vec.size()]; 
+		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
+		return arr;
+	}
+	
+	/**
+	 * Converts an array of Float objects directly to a primitive array.
+	 */	
+	public static float[] primFloat(List<Float> vec)
+	{
+		float[] arr = new float[vec.size()]; 
+		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
+		return arr;
+	}
+
+	/**
+	 * Converts an array of Double objects directly to a primitive array.
+	 */
+	public static double[] primDouble(List<Double> vec)
+	{
+		double[] arr = new double[vec.size()]; 
+		for (int n = 0; n < arr.length; n++) arr[n] = 
+		vec.get(n); return arr;
+	}
+
+	/**
+	 * Converts an array of Boolean objects directly to a primitive array.
+	 */
+	public static boolean[] primBoolean(List<Boolean> vec)
+	{
+		boolean[] arr = new boolean[vec.size()]; 
+		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
+		return arr;
+	}
+
+	/**
+	 * Converts an array of Character objects directly to a primitive array.
+	 */
+	public static char[] primChar(List<Character> vec)
+	{
+		char[] arr = new char[vec.size()]; 
+		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
+		return arr;
+	}
+
+	/**
+	 * Converts an array of String objects directly to a primitive array.
+	 */
+	public static String[] primString(List<String> vec)
+	{
+		String[] arr = new String[vec.size()]; 
+		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
+		return arr;
+	}
+
+	/**
+	 * Converts an array of arbitrary objects directly to a primitive array of same object type.
+	 */
+	public static <T> T[] primObject(List<T> vec)
+	{
+		@SuppressWarnings("unchecked")
+		T[] arr = (T[])new Object[vec.size()]; 
+		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
+		return arr;
+	}
+	
+	/**
 	 * Converts an array to a human-readable string, for debugging purposes.
 	 */
 	public static String arrayStr(int[] arr)


### PR DESCRIPTION
The Util class now has methods to convert from List<BoxedObject> to scalar[], which is a very common use case. The present lesser evil syntax using Apache ArrayUtils is long and ugly, whereas this is short and relatively pleasant. Unfortunately it needs a different function for each type, but this is a Java limitation (until Java 10 comes out ;-) )