### PR TITLE
Make import into API jar file for BAO code explicit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -59,8 +59,12 @@
 	</target>
 
 	<target name="pkgAPI" depends="buildAPI" description="generate the package without the GUI">
-		<jar jarfile="pkg/BioAssayTemplateAPI.jar" basedir="bin">
-			<fileset dir="bin" excludes="com/cdd/bao/editor/**,com/cdd/bao/importer/**,com/cdd/bao/*.class" />
+		<jar jarfile="pkg/BioAssayTemplateAPI.jar">
+			<fileset dir="bin">
+				<include name="com/cdd/bao/template/**" />
+				<include name="com/cdd/bao/util/Util.class" />
+				<include name="com/cdd/bao/validator/TemplateChecker*.class" />
+			</fileset>
 			<zipgroupfileset dir="lib" includes="*.jar" />
 		</jar>
 	</target>


### PR DESCRIPTION
The duplicate import of classes was caused by the `basedir` parameter in this line
```
<jar jarfile="pkg/BioAssayTemplateAPI.jar" basedir="bin">
```
Otherwise, the import of `com.cdd.bao` code is now explicit.