### PR TITLE
Command line option to export to vocab.json

### DIFF
--- a/data/template/schema.json
+++ b/data/template/schema.json
@@ -776,6 +776,13 @@
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0000539",
                 "suggestions": "id",
                 "values": []
+            }, 
+            {
+                "name": "status",
+                "descr": "Curation workflow status of the assay.",
+                "propURI": "http://purl.org/spar/pso/withStatus",
+                "suggestions": "full",
+                "values": []
             }
         ],
         "subGroups": 

--- a/data/template/schema.json
+++ b/data/template/schema.json
@@ -776,13 +776,6 @@
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0000539",
                 "suggestions": "id",
                 "values": []
-            }, 
-            {
-                "name": "status",
-                "descr": "Curation workflow status of the assay.",
-                "propURI": "http://purl.org/spar/pso/withStatus",
-                "suggestions": "full",
-                "values": []
             }
         ],
         "subGroups": 

--- a/src/com/cdd/bao/Main.java
+++ b/src/com/cdd/bao/Main.java
@@ -25,6 +25,7 @@ import java.util.*;
 import java.io.*;
 
 import org.apache.commons.lang3.*;
+import org.json.*;
 
 import com.cdd.bao.template.*;
 import com.cdd.bao.template.Schema.*;
@@ -143,8 +144,8 @@ public class Main
 		Util.writeln("    geneont {infile} {outfile}");
 		Util.writeln("    filter {infile.owl/ttl} {outfile.ttl}");
 		Util.writeln("    compare {old.dump} {new.dump}");
-		Util.writeln("    compile {schema*.ttl} {vocab.dump}");
-		Util.writeln("    check {schema.ttl}");
+		Util.writeln("    compile {schema*.json} {vocab.dump/json}");
+		Util.writeln("    check {schema.json}");
 		Util.writeln("    import {cfg.json}");
 		Util.writeln("    scanaxioms");
 		Util.writeln("    --onto {files...}");
@@ -235,7 +236,23 @@ public class Main
 		Util.writeln("Loaded: " + schvoc.numTerms() + " terms.");
 		try (OutputStream ostr = new FileOutputStream(outputFile))
 		{
-			schvoc.serialise(ostr);
+			if (outputFile.endsWith(".json"))
+			{
+				JSONArray templates = new JSONArray();
+				for (Schema schema : schemata)
+				{
+					SchemaVocab subset = schvoc.singleTemplate(schema.getSchemaPrefix());
+				
+					JSONObject json = new JSONObject();
+					json.put("schemaPrefix", schema.getSchemaPrefix());
+					json.put("root", ClipboardSchema.composeGroup(schema.getRoot(), subset));
+					templates.put(json);
+				}
+				Writer wtr = new BufferedWriter(new OutputStreamWriter(ostr));
+				templates.write(wtr);
+				wtr.flush();
+			}
+			else schvoc.serialise(ostr);
 		}
 		Util.writeln("Done.");
 	}

--- a/src/com/cdd/bao/editor/DetailPane.java
+++ b/src/com/cdd/bao/editor/DetailPane.java
@@ -366,7 +366,7 @@ public class DetailPane extends ScrollPane implements URIRowLine.Delegate
 				}
 			}
 		}
-		else if (assignment != null || group != null)
+		else if (assignment != null || group != null && fieldURI != null)
 		{
 			if (!Vocabulary.globalInstance().isLoaded()) return;
 			LookupPanel lookup = new LookupPanel(true, fieldName.getText(), new HashSet<>(), new HashSet<>(), false);

--- a/src/com/cdd/bao/template/SchemaTree.java
+++ b/src/com/cdd/bao/template/SchemaTree.java
@@ -210,7 +210,15 @@ public class SchemaTree
 		}
 
 		// grab all of the branches from the original hierarchy: start by populating the new tree; then fill in the parents; then fill in the children
-		for (Branch br : hier.uriToBranch.values()) if (everything.contains(br.uri)) tree.put(br.uri, new Node(br, vocab.getDescr(br.uri)));
+		for (Branch br : hier.uriToBranch.values()) if (everything.contains(br.uri)) 
+		{
+			Node node = new Node(br, vocab.getDescr(br.uri));
+			node.altLabels = vocab.getAltLabels(br.uri);
+			node.externalURLs = vocab.getExternalURLs(br.uri);
+			node.pubchemSource = vocab.getPubChemSource(br.uri);
+			node.pubchemImport = vocab.getPubChemImport(br.uri);
+			tree.put(br.uri, node);
+		}
 		for (Node node : tree.values())
 		{
 			node.inSchema = includeBranch.contains(node.uri);

--- a/src/com/cdd/bao/template/SchemaVocab.java
+++ b/src/com/cdd/bao/template/SchemaVocab.java
@@ -112,6 +112,17 @@ public class SchemaVocab
 		for (String pfx : prefixes) Util.writeln("    " + pfx);*/
 	}
 	
+	// returns an instance that has only the trees for the indicated schema prefix
+	public SchemaVocab singleTemplate(String schemaPrefix)
+	{
+		SchemaVocab dup = new SchemaVocab();
+		dup.prefixes = new String[]{schemaPrefix};
+		dup.termList = Arrays.copyOf(termList, termList.length);
+		for (int n = 0; n < termList.length; n++) dup.termLookup.put(termList[n].uri, n);
+		for (StoredTree tree : treeList) if (tree.schemaPrefix.equals(schemaPrefix)) dup.treeList.add(tree);
+		return dup;
+	}
+	
 	// write the content as raw binary
 	public void serialise(OutputStream ostr) throws IOException
 	{


### PR DESCRIPTION
For debugging/analytics purposes: when using the command line to export to a scrunched up vocab file, giving it a suffix of .json switches the logic to exporting a JSON file instead of binary; this basically includes the template content + the whole schema tree for all the values within each assignment. It's mainly for the benefit of external tools that need a single download of the whole schema definition.

Also fixed a few minor bugs.