### PR TITLE
Improved test coverage and bug fixes

### DIFF
--- a/src/com/cdd/bao/util/Util.java
+++ b/src/com/cdd/bao/util/Util.java
@@ -21,7 +21,6 @@
 
 package com.cdd.bao.util;
 
-import java.awt.Color;
 import java.io.*;
 import java.lang.reflect.*;
 import java.text.*;

--- a/src/com/cdd/bao/util/Util.java
+++ b/src/com/cdd/bao/util/Util.java
@@ -321,22 +321,6 @@ public class Util
 	}
 	
 	/**
-	 * Converts an array to a human-readable string, where each value is represented as an 8-digit padded hex string.
-	 */
-	public static String arrayStrHex(int[] arr)
-	{
-		if (arr == null) return "{null}";
-		String str = "";
-		for (int n = 0; n < arr.length; n++)
-		{
-			long v = arr[n] >= 0 ? arr[n] : ((arr[n] & 0x7FFFFFFF) | (1L << 31));
-			String hex = Long.toString(v, 16);
-			str += (n > 0 ? "," : "") + "0x" + strrpad(hex, 8, '0');
-		}
-		return str;
-	}
-	
-	/**
 	 * Returns true if the given string represents a parseable numeric value, either integer or floating point.
 	 */
 	public static boolean isNumeric(String str)
@@ -777,97 +761,7 @@ public class Util
 		String str = Integer.toHexString(col);
 		return "#" + rep('0', 6 - str.length()) + str;
 	}
-	
-	/**
-	 * Merges two Color instances, to return a new Color with averaged values for red, green & blue.
-	 */
-	public static Color mergeCols(Color col1, Color col2)
-	{
-		int r = col1.getRed() + col2.getRed(), g = col1.getGreen() + col2.getGreen(), b = col1.getBlue() + col2.getBlue();
-		return new Color(r / 2, g / 2, b / 2);
-	}
-	
-	/**
-	 * Converts an integer colour of the form 0xTTRRGGBB into the Color object.
-	 */
-	public static Color intToCol(int trgb)
-	{
-		int t = (trgb >> 24) & 0xFF, r = (trgb >> 16) & 0xFF, g = (trgb >> 8) & 0xFF, b = trgb & 0xFF;
-		return new Color(r, g, b, 0xFF - t);
-	}
-	
-	/**
-	 * Converts a Color object into an integer colour specifier of the form 0xTTRRGGBB.
-	 */
-	public static int colToInt(Color col)
-	{
-		int t = 0xFF - col.getAlpha(), r = col.getRed(), g = col.getGreen(), b = col.getBlue();
-		return (t << 24) | (r << 16) | (g << 8) | b;
-	}
-	
-	/**
-	 * Takes a colour of the form 0xTTRRGGBB and applies the offset for each of the three colour channels, making sure
-	 * each is still in the single byte range.
-	 * @param col original colour in 0xTTRRGGBB format
-	 * @param dr value to add to the red channel
-	 * @param dg value to add to the green channel
-	 * @param db value to add to the blue channel
-	 */
-	public static int tintCol(int col, int dr, int dg, int db)
-	{
-		float r = ((col >> 16) & 0xFF) + dr, g = ((col >> 8) & 0xFF) + dg, b = (col & 0xFF) + db;
-		if (r < 0) {g -= r; b -= r; r = 0;}
-		if (g < 0) {r -= g; b -= g; g = 0;}
-		if (b < 0) {r -= b; g -= b; b = 0;}
-		if (r < 0) r = 0;
-		if (g < 0) g = 0;
-		if (r > 255) {float m = 255.0f / r; r = 255; g *= m; b *= m;}
-		if (g > 255) {float m = 255.0f / g; g = 255; r *= m; b *= m;}
-		if (b > 255) {float m = 255.0f / b; b = 255; r *= m; g *= m;}
-		return (col & 0xFF000000) | (Util.iround(r) << 16) | (Util.iround(r) << 8) | Util.iround(b);
-	}
-	
-	/**
-	 * Converts the given integer into a string by adding spaces to the left.
-	 * @param val number to be formatted
-	 * @param len total length desired for the result
-	 * */
-	public static String intrpad(int val, int len) {return intrpad(val, len, ' ');}
-	
-	/**
-	 * Converts the given integer into a string by adding the necessary number of characters to the left.
-	 * @param val number to be formatted
-	 * @param len total length desired for the result
-	 * @param ch character to be prepended
-	 */
-	public static String intrpad(int val, int len, char ch)
-	{
-		String str = Integer.toString(val);
-		str = rep(ch, len - str.length()) + str;
-		if (str.length() > len) str = str.substring(0, len);
-		return str;
-	}
-	
-	/**
-	 * Pads the string to be right justified, by adding the given number of characters to the left.
-	 * */
-	public static String strrpad(String str, int len, char ch)
-	{
-		str = rep(ch, len - str.length()) + str;
-		if (str.length() > len) str = str.substring(0, len);
-		return str;
-	}
-	
-	/**
-	 * Pads the string by adding a specified numbers of characters to the right.
-	 */
-	public static String padstr(String str, int len, char ch)
-	{
-		if (str.length() == len) return str;
-		if (str.length() > len) return str.substring(0, len);
-		return str + rep(ch, len - str.length());
-	}
-	
+		
 	/**
 	 * Repeats the given character a certain number of times.
 	 * @param ch character to repeat
@@ -894,118 +788,7 @@ public class Util
 		for (int n = 0; n < len; n++) buff.append(str);
 		return buff.toString();
 	}
-	
-	/**
-	 * Splits up a string according to a supplied mask.
-	 * @param str string to be split
-	 * @param mask an array of size equal to length of string, for which true means that the character is to be used to split
-	 * @return an array of separated strings of size at least 1
-	 */
-	public static String[] split(String str, final boolean[] sepmask)
-	{
-		int sz = 1;
-		for (int n = 0; n < str.length(); n++) if (sepmask[n]) sz++;
-		if (sz == 1) return new String[]{str};
-		
-		String[] ret = new String[sz];
-		sz = 0;
-		for (int n = 0, last = 0; n <= str.length(); n++) if (n == str.length() || sepmask[n])
-		{
-			ret[sz++] = str.substring(last, n);
-			last = n + 1;
-		}
-		return ret;
-	}
-	
-	/**
-	 * Splits a string by exactly one possible character.
-	 * @param str string to be split
-	 * @param ch character to split by
-	 */
-	public static String[] split(String str, char sep)
-	{
-		final boolean[] sepmask = new boolean[str.length()];
-		for (int n = 0; n < str.length(); n++) sepmask[n] = str.charAt(n) == sep;
-		return split(str, sepmask);
-	}
-	
-	/** 
-	 * Splits a string based on a list of possible splitting characters (literals, not a regular expression).
-	 * @param str string to be split
-	 * @param seplist list of possible split characters (literal)
-	 */
-	public static String[] split(String str, String seplist)
-	{
-		boolean[] sepmask = new boolean[str.length()];
-		for (int n = 0; n < str.length(); n++) sepmask[n] = seplist.indexOf(str.charAt(n)) >= 0;
-		return split(str, sepmask);
-	}
-	
-	/**
-	 * Splits a string by linebreaks, being tolerant of Unix vs. Windows formats.
-	 */
-	public static String[] splitLines(String str)
-	{
-		return str.split("\\r?\\n");
-	}
-	
-	/**
-	 * Returns the "parent" directory of the given file; if this is already a directory (ends with "/"), rolls it back one further,
-	 * unless it is already down to "/", in which case it returns the input. If there is no directory, returns a null string. 
-	 * No checking is done for validity or file existence
-	 */
-	public static String parentDir(String fn)
-	{
-		if (fn.equals("/")) return fn;
-		if (fn.endsWith("/")) fn = fn.substring(0, fn.length() - 1);
-		int i = fn.lastIndexOf('/');
-		if (i < 0) return "/";
-		return fn.substring(0, i + 1);
-	}
-	
-	/**
-	 * Returns the given file without any directory prefix.
-	 */
-	public static String fileName(String fn)
-	{
-		int i = fn.lastIndexOf('/');
-		if (i >= 0) return fn.substring(i + 1);
-		return fn;
-	}
-	
-	/**
-	 * Returns the suffix of the file, if any; e.g. "foo.bar" will return "bar".
-	 */
-	public static String fileSuffix(String fn)
-	{
-		fn = fileName(fn);
-		int i = fn.lastIndexOf('.');
-		if (i >= 0) return fn.substring(i + 1);
-		return "";
-	}
-	
-	/**
-	 * If the filename has a suffix, returns the same without; e.g. "/wibble/foo.bar" will return "/wibble/foo".
-	 */
-	public static String fileWithoutSuffix(String fn)
-	{
-		int i = fn.lastIndexOf('.'), j = fn.lastIndexOf('/');
-		if (i < 0 || i < j) return fn;
-		return fn.substring(0, i);
-	}
-	
-	/**
-	 * Adds something before the file suffix, e.g. adding "_001" to "foo.bar" will return "foo_001.bar".
-	 * @param fn original filename
-	 * @param psfx presuffix to insert before the file suffix
-	 */
-	public static String insertPreSuffix(String fn, String psfx)
-	{
-		int i = fn.lastIndexOf('.');
-		if (i < 0) i = fn.length();
-		return fn.substring(0, i) + psfx + fn.substring(i);
-	}
-	
+			
 	public static final String UTF8 = "UTF-8";
 	
 	/**
@@ -1038,76 +821,7 @@ public class Util
 	{
 		if (rdr instanceof BufferedReader) return (BufferedReader)rdr;
 		return new BufferedReader(rdr);
-	}
-	
-	/**
-	 * Closes a stream and ignores any exceptions. Useful for within catch blocks.
-	 */
-	public static void silentClose(InputStream istr)
-	{
-		try {if (istr != null) istr.close();} 
-		catch (IOException ex) {}
-	}
-	
-	/**
-	 * Closes a stream and ignores any exceptions. Useful for within catch blocks.
-	 */
-	public static void silentClose(OutputStream ostr)
-	{
-		try {if (ostr != null) ostr.close();} 
-		catch (IOException ex) {}
-	}
-	
-	/**
-	 * Closes a stream and ignores any exceptions. Useful for within catch blocks.
-	 */
-	public static void silentClose(Reader rdr)
-	{
-		try {if (rdr != null) rdr.close();} 
-		catch (IOException ex) {}
-	}
-	
-	/**
-	 * Closes a stream and ignores any exceptions. Useful for within catch blocks.
-	 */
-	public static void silentClose(Writer wtr)
-	{
-		try {if (wtr != null) wtr.close();} 
-		catch (IOException ex) {}
-	}
-	
-	/**
-	 * Convenience method for determining the number of days since the beginning of 1970, GMT.
-	 */
-	public static int daysSince1970()
-	{
-		long time = new Date().getTime(); // in milliseconds
-		final long DIVIDER = 1000 * 60 * 60 * 24;
-		return (int)(time / DIVIDER);
-	}
-	
-	/**
-	 * Returns the number of non-null objects in an array.
-	 */
-	public static int packedLength(Object[] loose)
-	{
-		if (loose == null || loose.length == 0) return 0;
-		int len = 0;
-		for (int n = loose.length - 1; n >= 0; n--) if (loose[n] != null) len++;
-		return len;
-	}
-	
-	/**
-	 * Packs one array into another by removing nulls.
-	 * @param loose the array with the source content, may contain nulls
-	 * @param packed the destination array, which must be long enough to contain all the non-null objects
-	 */
-	public static void packArray(Object[] loose, Object[] packed)
-	{
-		if (loose == null) return;
-		int len = 0;
-		for (int n = 0; n < loose.length; n++) if (loose[n] != null) packed[len++] = loose[n];
-	}
+	}	
 	
 	/**
 	 * Opens a file resource which may be incorporated into the current .jar file, or it may be a file relative to the current
@@ -1131,7 +845,6 @@ public class Util
 		if (istr == null) throw new IOException("Missing resource: " + fn);
 		return istr;
 	}
-	
 	
 	/**
 	 * Increments the value corresponding to a mapped key: if the value does not currently exist or is null, will set it to 1.

--- a/src/com/cdd/bao/util/Util.java
+++ b/src/com/cdd/bao/util/Util.java
@@ -99,23 +99,13 @@ public class Util
 	public static int length(Object arr) {return arr == null ? 0 : Array.getLength(arr);}
 	
 	/**
-	 * Converts a list of Byte objects directly to a primitive array.
+	 * Converts a collection of Byte objects directly to a primitive array.
 	 */
-	public static byte[] primByte(List<Byte> vec) 
+	public static byte[] primByte(Collection<Byte> coll) 
 	{
-		byte[] arr = new byte[vec.size()]; 
-		for (int n = 0; n < arr.length; n++) arr[n] = vec.get(n); 
-		return arr;
-	}
-
-	/**
-	 * Converts a set of Z objects directly to a primitive array.
-	 */
-	public static byte[] primByte(Set<Byte> set) 
-	{
-		byte[] arr = new byte[set.size()];
+		byte[] arr = new byte[coll.size()]; 
 		int n = 0;
-		for (byte v : set) arr[n++] = v;
+		for (byte v : coll) arr[n++] = v;
 		return arr;
 	}
 
@@ -243,9 +233,9 @@ public class Util
 	public static String arrayStr(String[] arr)
 	{
 		if (arr == null) return "{null}";
-		String str = "";
-		for (int n = 0; n < arr.length; n++) str += (n > 0 ? "," : "") + "\"" + arr[n] + "\"";
-		return str;
+		StringJoiner sj = new StringJoiner("\",\"", "\"", "\"");
+		for (String s : arr) sj.add(s);
+		return sj.toString();
 	}
 	
 	/**
@@ -254,9 +244,9 @@ public class Util
 	public static String arrayStr(boolean[] arr)
 	{
 		if (arr == null) return "{null}";
-		String str = "{";
-		for (int n = 0; n < arr.length; n++) str += arr[n] ? "1" : "0";
-		return str + "}";
+		StringJoiner sj = new StringJoiner("", "{", "}");
+		for (boolean b : arr) sj.add(b ? "1" : "0");
+		return sj.toString();
 	}
 	
 	/**
@@ -305,13 +295,9 @@ public class Util
 		if (list == null || list.length == 0) return null;
 		if (list.length == 1) return list[0];
 		if (list.length == 2) return list[0] + sep + list[1];
-		StringBuilder buff = new StringBuilder(list[0]);
-		for (int n = 1; n < list.length; n++)
-		{
-			buff.append(sep);
-			buff.append(list[n]);
-		}
-		return buff.toString();
+		StringJoiner sj = new StringJoiner(sep);
+		for (String s : list) sj.add(s);
+		return sj.toString();
 	}
 	
 	/**
@@ -345,7 +331,7 @@ public class Util
 		{
 			long v = arr[n] >= 0 ? arr[n] : ((arr[n] & 0x7FFFFFFF) | (1L << 31));
 			String hex = Long.toString(v, 16);
-			str += (n > 0 ? "," : "") + "0x" + padstr(hex, 8, '0');
+			str += (n > 0 ? "," : "") + "0x" + strrpad(hex, 8, '0');
 		}
 		return str;
 	}
@@ -369,7 +355,7 @@ public class Util
 	public static int safeInt(String str, int def) 
 	{
 		if (str == null) return def;
-		try {return Integer.valueOf(str).intValue();} 
+		try {return Integer.parseInt(str);} 
 		catch (NumberFormatException e) {return def;}
 	}
 	
@@ -387,7 +373,7 @@ public class Util
 	public static long safeLong(String str, long def) 
 	{
 		if (str == null) return def;
-		try {return Long.valueOf(str).longValue();} 
+		try {return Long.parseLong(str);}
 		catch (NumberFormatException e) {return def;}
 	}
 	
@@ -405,7 +391,7 @@ public class Util
 	public static float safeFloat(String str, float def) 
 	{
 		if (str == null) return def;
-		try {return Float.valueOf(str).floatValue();} 
+		try {return Float.parseFloat(str);} 
 		catch (NumberFormatException e) {return def;}
 	}
 	
@@ -423,7 +409,7 @@ public class Util
 	public static double safeDouble(String str, double def) 
 	{
 		if (str == null) return def;
-		try {return Double.valueOf(str).doubleValue();} 
+		try {return Double.parseDouble(str);} 
 		catch (NumberFormatException e) {return def;}
 	}
 	
@@ -475,9 +461,10 @@ public class Util
 	 */
 	public static String formatDouble(double val, int maxSigFig)
 	{
-		String str = String.format("%." + maxSigFig + "g", val);
+		String fmt = "%." + maxSigFig + "g";
+		String str = String.format(fmt, val);
 		if (str.indexOf('.') < 0) return str;
-		while (str.endsWith("0")) str = str.substring(0, str.length() - 1);
+		if (str.indexOf('e') < 0) while (str.endsWith("0")) str = str.substring(0, str.length() - 1);
 		if (str.endsWith(".")) str = str.substring(0, str.length() - 1);
 		return str;
 	}
@@ -598,12 +585,12 @@ public class Util
 	public static float norm(float x, float y, float z) {return (float)Math.sqrt(x * x + y * y + z * z);}
 	
 	/**
-	 * Returns the reciprocal of a number, or zero if undefined.
+	 * Returns the reciprocal of a number, or one if undefined.
 	 */
 	public static double divZ(double z) {return z == 0 ? 1 : 1 / z;}
 	
 	/**
-	 * Returns the reciprocal of a number, or zero if undefined.
+	 * Returns the reciprocal of a number, or one if undefined.
 	 */
 	public static float divZ(float z) {return z == 0 ? 1 : 1 / z;}
 	
@@ -724,7 +711,7 @@ public class Util
 	 */
 	public static double angleNormDeg(double th)
 	{
-		if (th == -180) return th = 180;
+		if (th == -180) return 180;
 		if (th < -180)
 		{
 			int mod = Util.iceil((-th - 180) * (1.0 / 360));
@@ -743,7 +730,7 @@ public class Util
 	 */
 	public static float angleNormDeg(float th)
 	{
-		if (th == -180) return th = 180;
+		if (th == -180) return 180;
 		if (th < -180)
 		{
 			int mod = Util.iceil((-th - 180) * (1f / 360));

--- a/test/com/cdd/bao/template/SerialisationTest.java
+++ b/test/com/cdd/bao/template/SerialisationTest.java
@@ -21,11 +21,11 @@
 
 package com.cdd.bao.template;
 
-import com.cdd.bao.template.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
 import java.io.*;
+
 import org.junit.*;
 
 /*

--- a/test/com/cdd/bao/util/UtilTest.java
+++ b/test/com/cdd/bao/util/UtilTest.java
@@ -142,10 +142,8 @@ public class UtilTest
 	{
 		int[] intArr = null;
 		assertEquals("null handling", "{null}", Util.arrayStr(intArr));
-		assertEquals("null handling", "{null}", Util.arrayStrHex(intArr));
 		intArr = new int[]{1, 2, 3, 4};
 		assertEquals("1,2,3,4", Util.arrayStr(intArr));
-		assertEquals("0x00000400,0x00000001,0x00000000,0xffffffff,0xfffffc00", Util.arrayStrHex(new int[]{1024, 1, 0, -1, -1024}));
 
 		long[] longArr = null;
 		assertEquals("null handling", "{null}", Util.arrayStr(longArr));
@@ -504,81 +502,10 @@ public class UtilTest
 	@Test
 	public void testStringHandling()
 	{
-		assertEquals("     1", Util.intrpad(1, 6));
-		assertEquals("xxxxx1", Util.intrpad(1, 6, 'x'));
-		assertEquals("123456", Util.intrpad(123456, 6, 'x'));
-		assertEquals("123456", Util.intrpad(1234567, 6, 'x'));
-
-		assertEquals("xxxxx1", Util.strrpad("1", 6, 'x'));
-		assertEquals("123456", Util.strrpad("123456", 6, 'x'));
-		assertEquals("123456", Util.strrpad("1234567", 6, 'x'));
-
-		assertEquals("1xxxxx", Util.padstr("1", 6, 'x'));
-		assertEquals("123456", Util.padstr("123456", 6, 'x'));
-		assertEquals("123456", Util.padstr("1234567", 6, 'x'));
-
 		assertEquals("", Util.rep("ab", 0));
 		assertEquals("ab", Util.rep("ab", 1));
 		assertEquals("abab", Util.rep("ab", 2));
 		assertEquals("ababab", Util.rep("ab", 3));
-
-		boolean[] mask = new boolean[]{false, true, false, true, false};
-		assertArrayEquals(new String[]{"a", "c", "e"}, Util.split("abcde", mask));
-		mask = new boolean[]{false, false, false, false, false};
-		assertArrayEquals(new String[]{"abcde"}, Util.split("abcde", mask));
-		mask = new boolean[]{true, true, true, true, true};
-		assertArrayEquals(new String[]{"", "", "", "", "", ""}, Util.split("abcde", mask));
-		mask = new boolean[]{true, false, false, false, true};
-		assertArrayEquals(new String[]{"", "bcd", ""}, Util.split("abcde", mask));
-
-		assertArrayEquals(new String[]{"ab", "c", "de"}, Util.split("ab c de", ' '));
-		assertArrayEquals(new String[]{"ab", "", "de"}, Util.split("ab  de", ' '));
-
-		assertArrayEquals(new String[]{"ab", "c-de"}, Util.split("ab c-de", " "));
-		assertArrayEquals(new String[]{"ab", "c", "de"}, Util.split("ab c-de", " -"));
-
-		assertArrayEquals(new String[]{"ab", "cde"}, Util.splitLines("ab\ncde"));
-		assertArrayEquals(new String[]{"ab", "cde"}, Util.splitLines("ab\r\ncde"));
-	}
-
-	@Test
-	public void testFileHandling()
-	{
-		assertEquals("/", Util.parentDir("/"));
-		assertEquals("/abc/def/", Util.parentDir("/abc/def/ghi.txt"));
-		assertEquals("/abc/", Util.parentDir("/abc/def/"));
-		assertEquals("/", Util.parentDir("/abc"));
-		assertEquals("/", Util.parentDir("abc"));
-
-		assertEquals("ghi.txt", Util.fileName("/abc/def/ghi.txt"));
-		assertEquals("ghi.txt", Util.fileName("ghi.txt"));
-
-		assertEquals("txt", Util.fileSuffix("ghi.txt"));
-		assertEquals("", Util.fileSuffix("ghi"));
-
-		assertEquals("/abc/def/ghi", Util.fileWithoutSuffix("/abc/def/ghi.txt"));
-		assertEquals("/abc/def/ghi", Util.fileWithoutSuffix("/abc/def/ghi"));
-		assertEquals("/abc/def.ignore/ghi", Util.fileWithoutSuffix("/abc/def.ignore/ghi"));
-		assertEquals("ghi", Util.fileWithoutSuffix("ghi.txt"));
-
-		assertEquals("/abc/def_001.txt", Util.insertPreSuffix("/abc/def.txt", "_001"));
-		assertEquals("/abc/def_001", Util.insertPreSuffix("/abc/def", "_001"));
-	}
-
-	@Test
-	public void testPacked()
-	{
-		String[] s = new String[]{null, "a", null, "b", "", "c", null};
-		assertEquals(4, Util.packedLength(s));
-		assertEquals(0, Util.packedLength((Object[])null));
-		assertEquals(0, Util.packedLength(new Object[0]));
-
-		String[] packed = new String[]{null, null, null, null};
-		Util.packArray(s, packed);
-		assertEquals("a", packed[0]);
-		assertEquals("b", packed[1]);
-		assertEquals("", packed[2]);
-		assertEquals("c", packed[3]);
 	}
 
 	@Test

--- a/test/com/cdd/bao/util/UtilTest.java
+++ b/test/com/cdd/bao/util/UtilTest.java
@@ -34,6 +34,26 @@ import org.junit.*;
 public class UtilTest
 {
 	@Test
+	public void testLength()
+	{
+		assertEquals("handling of null", 0, Util.length(null));
+		assertEquals("handling of null", 0, Util.length(new int[0]));
+		assertEquals("handling of null", 3, Util.length(new int[]{1, 2, 3}));
+	}
+
+	@Test
+	public void testPrimByte()
+	{
+		List<Byte> list = Arrays.asList((byte)1, (byte)2, (byte)3, (byte)4);
+		byte[] primArray = Util.primByte(list);
+		assertArrayEquals(new byte[]{1, 2, 3, 4}, primArray);
+
+		Set<Byte> set = new TreeSet<>(list);
+		primArray = Util.primByte(set);
+		assertArrayEquals(new byte[]{1, 2, 3, 4}, primArray);
+	}
+
+	@Test
 	public void testPrimInt()
 	{
 		List<Integer> list = Arrays.asList(1, 2, 3, 4);
@@ -115,5 +135,462 @@ public class UtilTest
 		Set<String> set = new TreeSet<>(list);
 		primArray = Util.primString(set);
 		assertArrayEquals(new String[]{"a", "b", "c"}, primArray);
+	}
+
+	@Test
+	public void testArrayStr()
+	{
+		int[] intArr = null;
+		assertEquals("null handling", "{null}", Util.arrayStr(intArr));
+		assertEquals("null handling", "{null}", Util.arrayStrHex(intArr));
+		intArr = new int[]{1, 2, 3, 4};
+		assertEquals("1,2,3,4", Util.arrayStr(intArr));
+		assertEquals("0x00000400,0x00000001,0x00000000,0xffffffff,0xfffffc00", Util.arrayStrHex(new int[]{1024, 1, 0, -1, -1024}));
+
+		long[] longArr = null;
+		assertEquals("null handling", "{null}", Util.arrayStr(longArr));
+		longArr = new long[]{2, 3, 4, 1};
+		assertEquals("2,3,4,1", Util.arrayStr(longArr));
+
+		float[] floatArr = null;
+		assertEquals("null handling", "{null}", Util.arrayStr(floatArr));
+		floatArr = new float[]{3, 4, 1, 2};
+		assertEquals("3.0,4.0,1.0,2.0", Util.arrayStr(floatArr));
+		assertEquals("6.0,8.0,2.0,4.0", Util.arrayStr(floatArr, 2));
+
+		double[] doubleArr = null;
+		assertEquals("null handling", "{null}", Util.arrayStr(doubleArr));
+		doubleArr = new double[]{4, 1, 2, 3};
+		assertEquals("4.0,1.0,2.0,3.0", Util.arrayStr(doubleArr));
+		assertEquals("12.0,3.0,6.0,9.0", Util.arrayStr(doubleArr, 3));
+
+		String[] stringArr = null;
+		assertEquals("null handling", "{null}", Util.arrayStr(stringArr));
+		stringArr = new String[]{"a", "b", "c", "d"};
+		assertEquals("\"a\",\"b\",\"c\",\"d\"", Util.arrayStr(stringArr));
+
+		boolean[] boolArr = null;
+		assertEquals("null handling", "{null}", Util.arrayStr(boolArr));
+		boolArr = new boolean[]{true, false, false, true};
+		assertEquals("{1001}", Util.arrayStr(boolArr));
+
+		int[][] intArr2D = null;
+		assertEquals("null handling", "{null}", Util.arrayStr(intArr2D));
+		intArr2D = new int[3][];
+		intArr2D[0] = null;
+		intArr2D[1] = new int[]{1};
+		intArr2D[2] = new int[]{1, 2};
+		assertEquals("{null}{1}{1,2}", Util.arrayStr(intArr2D));
+	}
+
+	@Test
+	public void testJoin()
+	{
+		assertEquals(null, Util.join((String[])null, ","));
+		assertEquals(null, Util.join(new String[0], ","));
+		assertEquals("a", Util.join(new String[]{"a"}, ","));
+		assertEquals("a,b", Util.join(new String[]{"a", "b"}, ","));
+		assertEquals("a,b,c,d", Util.join(new String[]{"a", "b", "c", "d"}, ","));
+
+		assertEquals(null, Util.join((int[])null, ","));
+		assertEquals(null, Util.join(new int[0], ","));
+		assertEquals("1", Util.join(new int[]{1}, ","));
+		assertEquals("1,2", Util.join(new int[]{1, 2}, ","));
+		assertEquals("1,2,3,4", Util.join(new int[]{1, 2, 3, 4}, ","));
+	}
+
+	@Test
+	public void testIsNumeric()
+	{
+		assertTrue(Util.isNumeric("1.0"));
+		assertTrue(Util.isNumeric("12"));
+		assertTrue(Util.isNumeric("3.1415"));
+		assertTrue(Util.isNumeric("-3.1415"));
+
+		assertFalse(Util.isNumeric("abc"));
+		assertFalse(Util.isNumeric(" 3.1415"));
+		assertFalse(Util.isNumeric("+3.1415"));
+		assertFalse(Util.isNumeric("3.1415 "));
+	}
+
+	@Test
+	public void testSafeConversion()
+	{
+		assertEquals(123, Util.safeInt("123"));
+		assertEquals("Default for null values", 0, Util.safeInt(null));
+		assertEquals("Default for non-numeric strings", 0, Util.safeInt("abc"));
+
+		assertEquals(123, Util.safeInt("123", 11));
+		assertEquals("Default for null values", 11, Util.safeInt(null, 11));
+		assertEquals("Default for non-numeric strings", 11, Util.safeInt("abc", 11));
+
+		assertEquals(123L, Util.safeLong("123"));
+		assertEquals("Default for null values", 0, Util.safeLong(null));
+		assertEquals("Default for non-numeric strings", 0, Util.safeLong("abc"));
+
+		assertEquals(123L, Util.safeLong("123", 11));
+		assertEquals("Default for null values", 11L, Util.safeLong(null, 11L));
+		assertEquals("Default for non-numeric strings", 11L, Util.safeLong("abc", 11L));
+
+		assertEquals(3.14f, Util.safeFloat("3.14"), 0.001);
+		assertEquals("Default for null values", 0.0f, Util.safeFloat(null), 0.001);
+		assertEquals("Default for non-numeric strings", 0.0f, Util.safeFloat("abc"), 0.001);
+
+		assertEquals(3.14f, Util.safeFloat("3.14", 11.0f), 0.001);
+		assertEquals("Default for null values", 11.0f, Util.safeFloat(null, 11.0f), 0.001);
+		assertEquals("Default for non-numeric strings", 11.0f, Util.safeFloat("abc", 11.0f), 0.001);
+
+		assertEquals(3.14, Util.safeDouble("3.14"), 0.001);
+		assertEquals("Default for null values", 0.0, Util.safeDouble(null), 0.001);
+		assertEquals("Default for non-numeric strings", 0.0, Util.safeDouble("abc"), 0.001);
+
+		assertEquals(3.14, Util.safeDouble("3.14", 11.0), 0.001);
+		assertEquals("Default for null values", 11.0, Util.safeDouble(null, 11.0), 0.001);
+		assertEquals("Default for non-numeric strings", 11.0, Util.safeDouble("abc", 11.0), 0.001);
+	}
+
+	@Test
+	public void testSafeStringHandling()
+	{
+		assertEquals("null handling", "", Util.safeString((String)null));
+		assertEquals("", Util.safeString(""));
+		assertEquals("abc", Util.safeString("abc"));
+
+		assertEquals(null, Util.nullOrString((String)null));
+		assertEquals(null, Util.nullOrString(""));
+		assertEquals("abc", Util.nullOrString("abc"));
+
+		assertTrue(null, Util.isBlank((String)null));
+		assertTrue(null, Util.isBlank(""));
+		assertFalse("abc", Util.isBlank("abc"));
+
+		assertFalse(null, Util.notBlank((String)null));
+		assertFalse(null, Util.notBlank(""));
+		assertTrue("abc", Util.notBlank("abc"));
+
+		assertTrue(Util.equals((String)null, (String)null));
+		assertTrue(Util.equals((String)null, ""));
+		assertFalse(Util.equals((String)null, "abc"));
+		assertTrue(Util.equals("", (String)null));
+		assertFalse(Util.equals("abc", (String)null));
+
+		assertFalse(Util.equals("abc", "def"));
+		assertTrue(Util.equals("abc", "abc"));
+	}
+
+	@Test
+	public void testFormatDouble()
+	{
+		assertEquals("100000", Util.formatDouble(100000.0));
+		assertEquals("100000.1", Util.formatDouble(100000.1));
+		assertEquals("100000.12345", Util.formatDouble(100000.12345));
+		assertEquals("1e+40", Util.formatDouble(1e40));
+		assertEquals("0.001", Util.formatDouble(0.001));
+		assertEquals("1e-11", Util.formatDouble(0.00000000001));
+
+		assertEquals("1", Util.formatDouble(1, 3));
+		assertEquals("0.123", Util.formatDouble(0.1234, 3));
+		assertEquals("0.0123", Util.formatDouble(0.01234, 3));
+		assertEquals("0.00123", Util.formatDouble(0.001234, 3));
+		assertEquals("0.000123", Util.formatDouble(0.0001234, 3));
+		assertEquals("12", Util.formatDouble(12, 3));
+		assertEquals("123", Util.formatDouble(123, 3));
+		assertEquals("1.23e+03", Util.formatDouble(1234, 3));
+		assertEquals("1.24e+03", Util.formatDouble(1236, 3));
+		assertEquals("1.00e+05", Util.formatDouble(100000.0, 3));
+		assertEquals("1.00e+05", Util.formatDouble(100000.1, 3));
+		assertEquals("1.01e+05", Util.formatDouble(100999, 3));
+		assertEquals("1.00e+40", Util.formatDouble(1e40, 3));
+		assertEquals("1.00e+100", Util.formatDouble(1e100, 3));
+		assertEquals("1.00e-11", Util.formatDouble(0.00000000001, 3));
+	}
+
+	@Test
+	public void testNumberHandling()
+	{
+		assertEquals(0L, Util.unsigned(0));
+		assertEquals(1L, Util.unsigned(1));
+		assertEquals(2L, Util.unsigned(2));
+		assertEquals(4294967295L, Util.unsigned(-1));
+		assertEquals(4294967294L, Util.unsigned(-2));
+
+		assertEquals(0, Util.iround(0.1f));
+		assertEquals(0, Util.iround(0.4f));
+		assertEquals(1, Util.iround(0.5f));
+		assertEquals(1, Util.iround(0.8f));
+		assertEquals(0, Util.iround(-0.1f));
+		assertEquals(0, Util.iround(-0.4f));
+		assertEquals(0, Util.iround(-0.5f));
+		assertEquals(-1, Util.iround(-0.8f));
+
+		assertEquals(0, Util.iround(0.1));
+		assertEquals(0, Util.iround(0.4));
+		assertEquals(1, Util.iround(0.5));
+		assertEquals(1, Util.iround(0.8));
+		assertEquals(0, Util.iround(-0.1));
+		assertEquals(0, Util.iround(-0.4));
+		assertEquals(0, Util.iround(-0.5));
+		assertEquals(-1, Util.iround(-0.8));
+
+		assertEquals(0, Util.ifloor(0.1f));
+		assertEquals(0, Util.ifloor(0.8f));
+		assertEquals(1, Util.ifloor(1.1f));
+		assertEquals(-1, Util.ifloor(-0.1f));
+		assertEquals(-2, Util.ifloor(-1.1f));
+
+		assertEquals(0, Util.ifloor(0.1));
+		assertEquals(0, Util.ifloor(0.8));
+		assertEquals(1, Util.ifloor(1.1));
+		assertEquals(-1, Util.ifloor(-0.1));
+		assertEquals(-2, Util.ifloor(-1.1));
+
+		assertEquals(1, Util.iceil(0.1f));
+		assertEquals(1, Util.iceil(0.8f));
+		assertEquals(2, Util.iceil(1.1f));
+		assertEquals(0, Util.iceil(-0.1f));
+		assertEquals(-1, Util.iceil(-1.1f));
+
+		assertEquals(1, Util.iceil(0.1));
+		assertEquals(1, Util.iceil(0.8));
+		assertEquals(2, Util.iceil(1.1));
+		assertEquals(0, Util.iceil(-0.1));
+		assertEquals(-1, Util.iceil(-1.1));
+
+		assertEquals(0f, Util.ffloor(0.1f), 0.001);
+		assertEquals(0f, Util.ffloor(0.8f), 0.001);
+		assertEquals(1f, Util.ffloor(1.1f), 0.001);
+		assertEquals(-1f, Util.ffloor(-0.1f), 0.001);
+		assertEquals(-2f, Util.ffloor(-1.1f), 0.001);
+
+		assertEquals(1f, Util.fceil(0.1f), 0.001);
+		assertEquals(1f, Util.fceil(0.8f), 0.001);
+		assertEquals(2f, Util.fceil(1.1f), 0.001);
+		assertEquals(0f, Util.fceil(-0.1f), 0.001);
+		assertEquals(-1f, Util.fceil(-1.1f), 0.001);
+
+		assertEquals(9, Util.sqr(3));
+		assertEquals(0, Util.sqr(0));
+		assertEquals(9, Util.sqr(-3));
+
+		assertEquals(9f, Util.sqr(3f), 0.001);
+		assertEquals(0f, Util.sqr(0f), 0.001);
+		assertEquals(9f, Util.sqr(-3f), 0.001);
+
+		assertEquals(9.0, Util.sqr(3.0), 0.001);
+		assertEquals(0.0, Util.sqr(0.0), 0.001);
+		assertEquals(9.0, Util.sqr(-3.0), 0.001);
+
+		assertEquals(25, Util.norm2(3, 4));
+		assertEquals(25f, Util.norm2(3f, 4f), 0.001);
+		assertEquals(29f, Util.norm2(3f, 4f, 2f), 0.001);
+		assertEquals(25.0, Util.norm2(3.0, 4.0), 0.001);
+		assertEquals(29.0, Util.norm2(3.0, 4.0, 2.0), 0.001);
+
+		assertEquals(5.0, Util.norm(3.0, 4.0), 0.001);
+		assertEquals(Math.sqrt(29.0), Util.norm(3.0, 4.0, 2.0), 0.001);
+
+		assertEquals(5.0, Util.norm(-3.0f, -4.0f), 0.001);
+		assertEquals(3.0, Util.norm(-3.0f, 0.0f), 0.001);
+		assertEquals(4.0, Util.norm(0.0f, -4.0f), 0.001);
+		assertEquals(Math.sqrt(29.0), Util.norm(3.0f, 4.0f, 2.0f), 0.001);
+
+		assertEquals(1.0, Util.divZ(0.0f), 0.0001);
+		assertEquals(0.5, Util.divZ(2.0f), 0.0001);
+		assertEquals(Float.POSITIVE_INFINITY, Util.divZ(1e-40f), 0.0001);
+
+		assertEquals(1.0, Util.divZ(0.0), 0.0001);
+		assertEquals(0.5, Util.divZ(2.0), 0.0001);
+		assertEquals(1e40, Util.divZ(1e-40), 0.0001);
+
+		assertEquals(-1, Util.signum(-4));
+		assertEquals(0, Util.signum(0));
+		assertEquals(1, Util.signum(2));
+		assertEquals(-1, Util.signum(-4.0f));
+		assertEquals(0, Util.signum(0.0f));
+		assertEquals(1, Util.signum(2.0f));
+		assertEquals(-1, Util.signum(-4.0));
+		assertEquals(0, Util.signum(0.0));
+		assertEquals(1, Util.signum(2.0));
+	}
+
+	@Test
+	public void testAngleManipulations()
+	{
+		for (double angle : new double[]{0.0, Math.PI, 0.369})
+		{
+			String msg = "angle " + angle;
+			assertEquals(msg, angle, Util.angleNorm(angle), 0.001);
+			assertEquals(msg, angle, Util.angleNorm(angle + Util.TWOPI), 0.001);
+			assertEquals(msg, angle, Util.angleNorm(angle + 2 * Util.TWOPI), 0.001);
+			assertEquals(msg, angle, Util.angleNorm(angle - Util.TWOPI), 0.001);
+		}
+		assertEquals(Math.PI, Util.angleNorm(-Math.PI), 0.001);
+
+		for (float angle : new float[]{0.0f, Util.PI_F, 0.369f})
+		{
+			String msg = "angle " + angle;
+			assertEquals(msg, angle, Util.angleNorm(angle), 0.001);
+			assertEquals(msg, angle, Util.angleNorm(angle + Util.TWOPI_F), 0.001);
+			assertEquals(msg, angle, Util.angleNorm(angle + 2 * Util.TWOPI_F), 0.001);
+			assertEquals(msg, angle, Util.angleNorm(angle - Util.TWOPI_F), 0.001);
+		}
+		assertEquals(Util.PI_F, Util.angleNorm(-Util.PI_F), 0.001);
+
+		assertEquals(-0.5 * Math.PI, Util.angleDiff(0, 0.5 * Math.PI), 0.001);
+		assertEquals(0.5 * Math.PI, Util.angleDiff(0, 1.5 * Math.PI), 0.001);
+		assertEquals(0.5 * Math.PI, Util.angleDiff(0.5 * Math.PI, 0), 0.001);
+		assertEquals(-0.5 * Math.PI, Util.angleDiff(1.5 * Math.PI, 0), 0.001);
+		assertEquals(Math.PI, Util.angleDiff(1.5 * Math.PI, -1.5 * Math.PI), 0.001);
+		assertEquals(Math.PI, Util.angleDiff(-1.5 * Math.PI, 1.5 * Math.PI), 0.001);
+		assertEquals(Math.PI - 0.1, Util.angleDiff(1.5 * Math.PI, -1.5 * Math.PI + 0.1), 0.001);
+		assertEquals(-Math.PI + 0.1, Util.angleDiff(-1.5 * Math.PI + 0.1, 1.5 * Math.PI), 0.001);
+
+		assertEquals(-0.5 * Util.PI_F, Util.angleDiff(0f, 0.5f * Util.PI_F), 0.001);
+		assertEquals(0.5 * Util.PI_F, Util.angleDiff(0f, 1.5f * Util.PI_F), 0.001);
+		assertEquals(0.5 * Util.PI_F, Util.angleDiff(0.5f * Util.PI_F, 0f), 0.001);
+		assertEquals(-0.5 * Util.PI_F, Util.angleDiff(1.5f * Util.PI_F, 0f), 0.001);
+		assertEquals(Util.PI_F, Util.angleDiff(1.5f * Util.PI_F, -1.5f * Util.PI_F), 0.001);
+		assertEquals(Util.PI_F - 0.1, Util.angleDiff(1.5f * Util.PI_F, -1.5f * Util.PI_F + 0.1f), 0.001);
+		assertEquals(-Util.PI_F + 0.1, Util.angleDiff(-1.5f * Util.PI_F + 0.1f, 1.5f * Util.PI_F), 0.001);
+	}
+
+	@Test
+	public void testAngleManipulationsDeg()
+	{
+		for (double angle : new double[]{0.0, 180, 45})
+		{
+			String msg = "angle " + angle;
+			assertEquals(msg, angle, Util.angleNormDeg(angle), 0.001);
+			assertEquals(msg, angle, Util.angleNormDeg(angle + 360), 0.001);
+			assertEquals(msg, angle, Util.angleNormDeg(angle + 720), 0.001);
+			assertEquals(msg, angle, Util.angleNormDeg(angle - 360), 0.001);
+		}
+		assertEquals(180, Util.angleNormDeg(-180), 0.001);
+
+		for (float angle : new float[]{0.0f, Util.PI_F, 0.369f})
+		{
+			String msg = "angle " + angle;
+			assertEquals(msg, angle, Util.angleNormDeg(angle), 0.001);
+			assertEquals(msg, angle, Util.angleNormDeg(angle + 360f), 0.001);
+			assertEquals(msg, angle, Util.angleNormDeg(angle + 720f), 0.001);
+			assertEquals(msg, angle, Util.angleNormDeg(angle - 360f), 0.001);
+		}
+		assertEquals(180f, Util.angleNormDeg(-180f), 0.001);
+
+		assertEquals(-90, Util.angleDiffDeg(0.0, 90.0), 0.001);
+		assertEquals(90, Util.angleDiffDeg(0.0, 270.0), 0.001);
+		assertEquals(90, Util.angleDiffDeg(90.0, 0.0), 0.001);
+		assertEquals(-90, Util.angleDiffDeg(270.0, 0.0), 0.001);
+		assertEquals(170, Util.angleDiffDeg(270.0, -260.0), 0.001);
+		assertEquals(-170, Util.angleDiffDeg(-260.0, 270.0), 0.001);
+
+		assertEquals(-90, Util.angleDiffDeg(0.0f, 90.0f), 0.001);
+		assertEquals(90, Util.angleDiffDeg(0.0f, 270.0f), 0.001);
+		assertEquals(90, Util.angleDiffDeg(90.0f, 0.0f), 0.001);
+		assertEquals(-90, Util.angleDiffDeg(270.0f, 0.0f), 0.001);
+		assertEquals(170, Util.angleDiffDeg(270.0f, -260.0f), 0.001);
+		assertEquals(-170, Util.angleDiffDeg(-260.0f, 270.0f), 0.001);
+	}
+
+	@Test
+	public void testColorHandling()
+	{
+		assertEquals("#000001", Util.colourHTML(0x1));
+		assertEquals("#000101", Util.colourHTML(0x101));
+		assertEquals("#010101", Util.colourHTML(0x10101));
+		assertEquals("#ffffff", Util.colourHTML(0xffffff));
+	}
+
+	@Test
+	public void testStringHandling()
+	{
+		assertEquals("     1", Util.intrpad(1, 6));
+		assertEquals("xxxxx1", Util.intrpad(1, 6, 'x'));
+		assertEquals("123456", Util.intrpad(123456, 6, 'x'));
+		assertEquals("123456", Util.intrpad(1234567, 6, 'x'));
+
+		assertEquals("xxxxx1", Util.strrpad("1", 6, 'x'));
+		assertEquals("123456", Util.strrpad("123456", 6, 'x'));
+		assertEquals("123456", Util.strrpad("1234567", 6, 'x'));
+
+		assertEquals("1xxxxx", Util.padstr("1", 6, 'x'));
+		assertEquals("123456", Util.padstr("123456", 6, 'x'));
+		assertEquals("123456", Util.padstr("1234567", 6, 'x'));
+
+		assertEquals("", Util.rep("ab", 0));
+		assertEquals("ab", Util.rep("ab", 1));
+		assertEquals("abab", Util.rep("ab", 2));
+		assertEquals("ababab", Util.rep("ab", 3));
+
+		boolean[] mask = new boolean[]{false, true, false, true, false};
+		assertArrayEquals(new String[]{"a", "c", "e"}, Util.split("abcde", mask));
+		mask = new boolean[]{false, false, false, false, false};
+		assertArrayEquals(new String[]{"abcde"}, Util.split("abcde", mask));
+		mask = new boolean[]{true, true, true, true, true};
+		assertArrayEquals(new String[]{"", "", "", "", "", ""}, Util.split("abcde", mask));
+		mask = new boolean[]{true, false, false, false, true};
+		assertArrayEquals(new String[]{"", "bcd", ""}, Util.split("abcde", mask));
+
+		assertArrayEquals(new String[]{"ab", "c", "de"}, Util.split("ab c de", ' '));
+		assertArrayEquals(new String[]{"ab", "", "de"}, Util.split("ab  de", ' '));
+
+		assertArrayEquals(new String[]{"ab", "c-de"}, Util.split("ab c-de", " "));
+		assertArrayEquals(new String[]{"ab", "c", "de"}, Util.split("ab c-de", " -"));
+
+		assertArrayEquals(new String[]{"ab", "cde"}, Util.splitLines("ab\ncde"));
+		assertArrayEquals(new String[]{"ab", "cde"}, Util.splitLines("ab\r\ncde"));
+	}
+
+	@Test
+	public void testFileHandling()
+	{
+		assertEquals("/", Util.parentDir("/"));
+		assertEquals("/abc/def/", Util.parentDir("/abc/def/ghi.txt"));
+		assertEquals("/abc/", Util.parentDir("/abc/def/"));
+		assertEquals("/", Util.parentDir("/abc"));
+		assertEquals("/", Util.parentDir("abc"));
+
+		assertEquals("ghi.txt", Util.fileName("/abc/def/ghi.txt"));
+		assertEquals("ghi.txt", Util.fileName("ghi.txt"));
+
+		assertEquals("txt", Util.fileSuffix("ghi.txt"));
+		assertEquals("", Util.fileSuffix("ghi"));
+
+		assertEquals("/abc/def/ghi", Util.fileWithoutSuffix("/abc/def/ghi.txt"));
+		assertEquals("/abc/def/ghi", Util.fileWithoutSuffix("/abc/def/ghi"));
+		assertEquals("/abc/def.ignore/ghi", Util.fileWithoutSuffix("/abc/def.ignore/ghi"));
+		assertEquals("ghi", Util.fileWithoutSuffix("ghi.txt"));
+
+		assertEquals("/abc/def_001.txt", Util.insertPreSuffix("/abc/def.txt", "_001"));
+		assertEquals("/abc/def_001", Util.insertPreSuffix("/abc/def", "_001"));
+	}
+
+	@Test
+	public void testPacked()
+	{
+		String[] s = new String[]{null, "a", null, "b", "", "c", null};
+		assertEquals(4, Util.packedLength(s));
+		assertEquals(0, Util.packedLength((Object[])null));
+		assertEquals(0, Util.packedLength(new Object[0]));
+
+		String[] packed = new String[]{null, null, null, null};
+		Util.packArray(s, packed);
+		assertEquals("a", packed[0]);
+		assertEquals("b", packed[1]);
+		assertEquals("", packed[2]);
+		assertEquals("c", packed[3]);
+	}
+
+	@Test
+	public void testMiscellaneous()
+	{
+		Map<String, Integer> counts = new HashMap<>();
+		assertEquals(1, Util.incr(counts, "a"));
+		assertEquals(2, Util.incr(counts, "a"));
+		assertEquals(1, Util.incr(counts, "b"));
+
+		List<Integer> list = Arrays.asList(1, 2, 3);
+		Util.swap(list, 0, 1);
+		assertEquals(Arrays.asList(2, 1, 3), list);
 	}
 }

--- a/test/com/cdd/bao/util/UtilTest.java
+++ b/test/com/cdd/bao/util/UtilTest.java
@@ -1,0 +1,119 @@
+/*
+ * BioAssay Ontology Annotator Tools
+ * 
+ * (c) 2014-2017 Collaborative Drug Discovery Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License 2.0
+ * as published by the Free Software Foundation:
+ * 
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.cdd.bao.util;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.junit.*;
+
+/*
+	Test for BAO utilities
+ */
+
+public class UtilTest
+{
+	@Test
+	public void testPrimInt()
+	{
+		List<Integer> list = Arrays.asList(1, 2, 3, 4);
+		int[] primArray = Util.primInt(list);
+		assertArrayEquals(new int[]{1, 2, 3, 4}, primArray);
+
+		Set<Integer> set = new TreeSet<>(list);
+		primArray = Util.primInt(set);
+		assertArrayEquals(new int[]{1, 2, 3, 4}, primArray);
+	}
+
+	@Test
+	public void testPrimLong()
+	{
+		List<Long> list = Arrays.asList(4L, 3L, 2L, 1L);
+		long[] primArray = Util.primLong(list);
+		assertArrayEquals(new long[]{4L, 3L, 2L, 1L}, primArray);
+
+		Set<Long> set = new TreeSet<>(list);
+		primArray = Util.primLong(set);
+		assertArrayEquals(new long[]{1L, 2L, 3L, 4L}, primArray);
+	}
+
+	@Test
+	public void testPrimFloat()
+	{
+		List<Float> list = Arrays.asList(4.0f, 3.0f, 2.0f, 1.0f);
+		float[] primArray = Util.primFloat(list);
+		assertArrayEquals(new float[]{4f, 3f, 2f, 1f}, primArray, 0.1f);
+
+		Set<Float> set = new TreeSet<>(list);
+		primArray = Util.primFloat(set);
+		assertArrayEquals(new float[]{1f, 2f, 3f, 4f}, primArray, 0.1f);
+	}
+
+	@Test
+	public void testPrimDouble()
+	{
+		List<Double> list = Arrays.asList(4.0d, 3.0, 2.0, 1.0);
+		double[] primArray = Util.primDouble(list);
+		assertArrayEquals(new double[]{4d, 3d, 2d, 1d}, primArray, 0.1);
+
+		Set<Double> set = new TreeSet<>(list);
+		primArray = Util.primDouble(set);
+		assertArrayEquals(new double[]{1d, 2d, 3d, 4d}, primArray, 0.1);
+	}
+
+	@Test
+	public void testPrimBoolean()
+	{
+		List<Boolean> list = Arrays.asList(false, true, false);
+		boolean[] primArray = Util.primBoolean(list);
+		assertArrayEquals(new boolean[]{false, true, false}, primArray);
+
+		Set<Boolean> set = new TreeSet<>(list);
+		primArray = Util.primBoolean(set);
+		assertArrayEquals(new boolean[]{false, true}, primArray);
+	}
+
+	@Test
+	public void testPrimChar()
+	{
+		List<Character> list = Arrays.asList('c', 'b', 'a', 'a', 'b', 'c');
+		char[] primArray = Util.primCharacter(list);
+		assertArrayEquals(new char[]{'c', 'b', 'a', 'a', 'b', 'c'}, primArray);
+
+		Set<Character> set = new TreeSet<>(list);
+		primArray = Util.primCharacter(set);
+		assertArrayEquals(new char[]{'a', 'b', 'c'}, primArray);
+	}
+
+	@Test
+	public void testPrimString()
+	{
+		List<String> list = Arrays.asList("c", "b", "a", "a", "b", "c");
+		String[] primArray = Util.primString(list);
+		assertArrayEquals(new String[]{"c", "b", "a", "a", "b", "c"}, primArray);
+
+		Set<String> set = new TreeSet<>(list);
+		primArray = Util.primString(set);
+		assertArrayEquals(new String[]{"a", "b", "c"}, primArray);
+	}
+}


### PR DESCRIPTION
In addition to tests, following changes to code:

- Combine List and Set version of primByte
- Use StringJoiner in arrayStr and join (Java 8)
- Fix arrayStrHex (#76)
- replace `XXX.valueOf(s).xxxValue()` with relevant `XXX.parseXxx(s)` to avoid boxing/unboxing
- fix a bug in formatDouble where 1.0e+40 was converted to 1.0e+4
- fix incorrect return value in documentation for `divZ`
- remove unnecessary assignment in `angleNormDeg`

Closes #76