### PR TITLE
Copy jar files to AWS after successful build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,6 @@ jobs:
           name: Trigger bioassay-data build
           command: |
             if [ "${CIRCLE_BRANCH}" == "build_to_S3" ]; then
-              aws s3 cp bax/pkg/BioAssayTemplate.jar s3://cdd-bioassay-template
-              aws s3 cp bax/pkg/BioAssayTemplateAPI.jar s3://cdd-bioassay-template
+              cd ~/bax/pkg; aws s3 cp BioAssayTemplate.jar s3://cdd-bioassay-template
+              cd ~/bax/pkg; aws s3 cp BioAssayTemplateAPI.jar s3://cdd-bioassay-template
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,6 @@ jobs:
           name: Trigger bioassay-data build
           command: |
             if [ "${CIRCLE_BRANCH}" == "build_to_S3" ]; then
-              cd ~/bax/pkg; aws s3 cp BioAssayTemplate.jar s3://cdd-bioassay-template
-              cd ~/bax/pkg; aws s3 cp BioAssayTemplateAPI.jar s3://cdd-bioassay-template
+              cd ~/bax/pkg; aws s3 cp BioAssayTemplate.jar s3://cdd-bioassay-template/lib/BioAssayTemplate.jar
+              cd ~/bax/pkg; aws s3 cp BioAssayTemplateAPI.jar s3://cdd-bioassay-template/lib/BioAssayTemplateAPI.jar
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - deploy:
           name: Trigger bioassay-data build
           command: |
-            if [ "${CIRCLE_BRANCH}" == "build_to_S3" ]; then
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
               cd ~/bax/pkg; aws s3 cp BioAssayTemplate.jar s3://cdd-bioassay-template/lib/BioAssayTemplate.jar
               cd ~/bax/pkg; aws s3 cp BioAssayTemplateAPI.jar s3://cdd-bioassay-template/lib/BioAssayTemplateAPI.jar
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,11 @@ jobs:
       - run: ls -alh
       - run: cd ~/bax; ant clean check pkgAPI
       - run: sudo apt-get install openjfx
-      - run: cd ~/bax; ant clean junit check pkg
+      - run: cd ~/bax; ant clean junit check pkg pkgAPI
+      - deploy:
+          name: Trigger bioassay-data build
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "build_to_S3" ]; then
+              aws s3 cp bax/pkg/BioAssayTemplate.jar s3://cdd-bioassay-template
+              aws s3 cp bax/pkg/BioAssayTemplateAPI.jar s3://cdd-bioassay-template
+            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs:
       - image: circleci/openjdk:8
     working_directory: ~/bax
     steps:
+      - run: sudo apt-get install python3-pip
+      - run: sudo pip3 install awscli
       - checkout
       - run: ls -alh
       - run: cd ~/bax; ant clean check pkgAPI

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ hs_err_pid*
 #bin/
 #pkg/
 pkg/BioAssayTemplateAPI.jar
+pkg/BioAssayTemplate.jar
 
 /bin/
 run*.sh

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ included in the project.
 
 To get started quickly without compiling, download two files:
 
-  * the pre-built package: [pkg/BioAssayTemplate.jar](https://github.com/cdd/bioassay-template/blob/master/pkg/BioAssayTemplate.jar)
+  * the pre-built package: [pkg/BioAssayTemplate.jar](https://s3.us-east-2.amazonaws.com/cdd-bioassay-template/lib/BioAssayTemplate.jar)
   * the Common Assay Template: [data/template/schema.json](https://github.com/cdd/bioassay-template/blob/master/data/template/schema.json)
   
 Run the application by double clicking on the `BioAssayTemplate.jar` file within the appropriate file manager tool, or run it with the


### PR DESCRIPTION
As discussed, use S3 to store builds:

- https://s3.us-east-2.amazonaws.com/cdd-bioassay-template/lib/BioAssayTemplate.jar
- https://s3.us-east-2.amazonaws.com/cdd-bioassay-template/lib/BioAssayTemplateAPI.jar

Closes #78