### PR TITLE
[WIP] Logistics for allowing duplicate groups

### DIFF
--- a/data/template/schema.json
+++ b/data/template/schema.json
@@ -796,6 +796,7 @@
                 "name": "measurement",
                 "descr": "Compound activity measurements: which field defines activity and how so.",
                 "groupURI": "http://www.bioassayontology.org/bao#BAX_0000017",
+                "canDuplicate": true,
                 "assignments": 
                 [
                     {

--- a/src/com/cdd/bao/editor/DetailPane.java
+++ b/src/com/cdd/bao/editor/DetailPane.java
@@ -62,6 +62,7 @@ public class DetailPane extends ScrollPane implements URIRowLine.Delegate
 	private TextField fieldPrefix = null;
 	private CheckBox chkIsBranch = null;
 	private TextField fieldBranches = null;
+	private CheckBox chkDuplicate = null;
 	private TextField fieldName = null;
 	private TextArea fieldDescr = null;
 	private URIRowLine fieldURI = null;
@@ -188,12 +189,16 @@ public class DetailPane extends ScrollPane implements URIRowLine.Delegate
 			sameGroup = userURI.equals(Util.safeString(group.groupURI));
 		}
 		
-		if (group.name.equals(fieldName.getText()) && group.descr.equals(fieldDescr.getText()) && sameGroup) return null;
+		boolean canDuplicate = chkDuplicate == null ? false : chkDuplicate.isSelected();
+		
+		if (group.name.equals(fieldName.getText()) && group.descr.equals(fieldDescr.getText()) && sameGroup &&
+			group.canDuplicate == canDuplicate) return null;
 		
 		Schema.Group mod = group.clone(null); // duplicates all of the subordinate content (not currently editing this, so stays unchanged)
 		mod.name = fieldName.getText();
 		mod.descr = fieldDescr.getText();
 		mod.groupURI = fieldURI == null ? null : ModelSchema.expandPrefix(fieldURI.getText());
+		mod.canDuplicate = canDuplicate;
 		
 		return mod;
 	}
@@ -460,6 +465,7 @@ public class DetailPane extends ScrollPane implements URIRowLine.Delegate
 			boolean isBranch = schema.getBranchGroups() != null;
 			chkIsBranch = new CheckBox("Branch template");
 			chkIsBranch.setSelected(isBranch);
+			
 			fieldBranches = new TextField();
 			fieldBranches.setMaxWidth(Double.MAX_VALUE);
 			if (isBranch) fieldBranches.setText(String.join(",", schema.getBranchGroups()));
@@ -497,6 +503,10 @@ public class DetailPane extends ScrollPane implements URIRowLine.Delegate
 		{
 			fieldURI = new URIRowLine(group.groupURI, "The group URI used to disambiguate this group", -1, PADDING, this);
 			line.add(fieldURI, "URI:", 1, 0);
+			
+			chkDuplicate = new CheckBox("Allow duplication");
+			chkDuplicate.setSelected(group.canDuplicate);
+			line.add(chkDuplicate, null);
 		}
 
 		vbox.getChildren().add(line);

--- a/src/com/cdd/bao/editor/SearchSchema.java
+++ b/src/com/cdd/bao/editor/SearchSchema.java
@@ -60,7 +60,7 @@ public class SearchSchema
 			String[] altLabels = v.getAltLabels(uri);
 			if (altLabels != null)
 			{
-				for (int k = 0; k < altLabels.length; ++k)
+				for (int k = 0; k < altLabels.length; k++)
 					if (StringUtils.indexOfIgnoreCase(altLabels[k], searchText) >= 0) return true;
 			}
 		}

--- a/src/com/cdd/bao/importer/ImportControlledVocab.java
+++ b/src/com/cdd/bao/importer/ImportControlledVocab.java
@@ -261,7 +261,7 @@ public class ImportControlledVocab
 		if (num > 0 && num <= assnidx.length)
 		{
 			Schema.Assignment assn = assignments[assnidx[num - 1]];
-			Property prop = Property.create(colName, assn.propURI, assn.groupNest());
+			Property prop = Property.create(colName, assn.propURI, Schema.groupNestString(assn.groupNest()));
 			Util.writeln("Mapping property to: [" + assn.name + "] <" + ModelSchema.collapsePrefix(assn.propURI) + ">");
 			String[] groupLabel = assn.groupLabel();
 			for (int n = 0; n < prop.groupNest.length; n++)
@@ -292,7 +292,7 @@ public class ImportControlledVocab
 			{
 				Schema.Assignment assn = assnList.get(0);
 				Util.writeln("Matched exactly one assignment: [" + assn.name + "]");
-				map.properties.add(Property.create(colName, assn.propURI, assn.groupNest()));
+				map.properties.add(Property.create(colName, assn.propURI, Schema.groupNestString(assn.groupNest())));
 				map.save();
 				return;
 			}
@@ -319,7 +319,7 @@ public class ImportControlledVocab
 				{
 					Schema.Assignment assn = assnList.get(num - 1);
 					Util.writeln("Adding assignment mapping.");
-					map.properties.add(Property.create(colName, assn.propURI, assn.groupNest()));
+					map.properties.add(Property.create(colName, assn.propURI, Schema.groupNestString(assn.groupNest())));
 					map.save();
 					return;
 				}
@@ -331,7 +331,7 @@ public class ImportControlledVocab
 	private void matchValue(Property prop, String key, String value) throws IOException
 	{
 		String[] groupNest = KeywordMapping.expandPrefixes(prop.groupNest);
-		Schema.Assignment[] assnList = schema.findAssignmentByProperty(ModelSchema.expandPrefix(prop.propURI), groupNest);
+		Schema.Assignment[] assnList = schema.findAssignmentByProperty(ModelSchema.expandPrefix(prop.propURI), Schema.groupNestPosition(groupNest));
 		if (assnList.length == 0) return;
 		Schema.Assignment assn = assnList[0];
 	

--- a/src/com/cdd/bao/importer/KeywordMapping.java
+++ b/src/com/cdd/bao/importer/KeywordMapping.java
@@ -522,7 +522,7 @@ public class KeywordMapping
 			String propURI = obj.getString("propURI"), valueURI = obj.optString("valueURI");
 			if (valueURI == null) continue;
 			String[] groupNest = obj.getJSONArray("groupNest").toStringArray();
-			Schema.Assignment[] assnList = schema.findAssignmentByProperty(ModelSchema.expandPrefix(propURI), groupNest);
+			Schema.Assignment[] assnList = schema.findAssignmentByProperty(ModelSchema.expandPrefix(propURI), Schema.groupNestPosition(groupNest));
 			if (assnList.length == 0) continue;
 			SchemaTree tree = treeCache.get(assnList[0]);
 			if (tree == null) continue;

--- a/src/com/cdd/bao/template/ClipboardSchema.java
+++ b/src/com/cdd/bao/template/ClipboardSchema.java
@@ -152,6 +152,7 @@ public class ClipboardSchema
 		json.put("name", group.name);
 		json.put("descr", group.descr);
 		json.put("groupURI", group.groupURI);
+		if (group.canDuplicate) json.put("canDuplicate", true);
 		
 		JSONArray jassignments = new JSONArray(), jsubgroups = new JSONArray();
 		for (Schema.Assignment assn : group.assignments)
@@ -259,6 +260,7 @@ public class ClipboardSchema
 		Schema.Group group = new Schema.Group(parent, json.getString("name"));
 		group.descr = json.optString("descr", "");
 		group.groupURI = json.optString("groupURI", "");
+		group.canDuplicate = json.optBoolean("canDuplicate", false);
 		
 		JSONArray jassignments = json.getJSONArray("assignments"), jsubgroups = json.getJSONArray("subGroups");
 		for (int n = 0; n < jassignments.length(); n++)

--- a/src/com/cdd/bao/template/ClipboardSchema.java
+++ b/src/com/cdd/bao/template/ClipboardSchema.java
@@ -122,7 +122,10 @@ public class ClipboardSchema
 		lines.add("name\t" + assn.name);
 		lines.add("description\t" + assn.descr.replace("\n", " "));
 		lines.add("property URI\t" + assn.propURI);
-		lines.add("group nest\t" + String.join("\t", assn.groupNest()));
+		
+		List<String> nest = new ArrayList<>();
+		for (Position pos : assn.groupNest()) {nest.add(pos.uri); nest.add(String.valueOf(pos.idx));}
+		lines.add("group nest\t" + String.join("\t", nest));
 		lines.add("");
 		lines.add("value hierarchy");
 		lines.add("");
@@ -186,7 +189,7 @@ public class ClipboardSchema
 		
 		if (schvoc != null) 
 		{
-			String[] groupNest = assn.groupNest();
+			Position[] groupNest = assn.groupNest();
 			for (SchemaVocab.StoredTree tree : schvoc.getTrees()) if (assn.propURI.equals(tree.propURI) && Objects.deepEquals(groupNest, tree.groupNest))
 			{
 				json.put("tree", formatTree(tree.tree));
@@ -350,7 +353,11 @@ public class ClipboardSchema
 		cols.add(group.name);
 		cols.add(group.descr.replace("\n", " "));
 		cols.add("");
-		for (String g : group.groupNest()) cols.add(g);
+		for (Position pos : group.groupNest()) 
+		{
+			cols.add(pos.uri);
+			cols.add(String.valueOf(pos.idx));
+		}
 		cols.add(Util.safeString(group.groupURI));
 		lines.add(String.join("\t", cols));
 		
@@ -360,7 +367,11 @@ public class ClipboardSchema
 			cols.add(assn.name);
 			cols.add(assn.descr.replace("\n", " "));
 			cols.add(assn.propURI);
-			for (String g : assn.groupNest()) cols.add(g);
+			for (Position pos : assn.groupNest()) 
+			{
+				cols.add(pos.uri);
+				cols.add(String.valueOf(pos.idx));
+			}
 			lines.add(String.join("\t", cols));
 		}
 		for (Schema.Group subgrp : group.subGroups) formatGroupTSV(lines, subgrp);

--- a/src/com/cdd/bao/template/Schema.java
+++ b/src/com/cdd/bao/template/Schema.java
@@ -53,8 +53,10 @@ public class Schema
 			this.uri = uri;
 			this.idx = idx;
 		}
+		
 		@Override
 		public Position clone() {return new Position(uri, idx);}
+		
 		@Override
 		public boolean equals(Object o)
 		{
@@ -78,6 +80,7 @@ public class Schema
 		public String name, descr = "";
 		public String groupURI = ""; // formal identity for the group
 		public int groupIndex = 0; // additional disambiguation, in case of duplicated groups
+		public boolean canDuplicate = false; // if true, permit duplication of the group when used for annotation
 		public List<Assignment> assignments = new ArrayList<>();
 		public List<Group> subGroups = new ArrayList<>();
 		
@@ -92,6 +95,7 @@ public class Schema
 			this.name = name == null ? "" : name;
 			this.groupURI = groupURI == null ? "" : groupURI;
 		}
+		
 		@Override
 		public Group clone() {return clone(parent);}
 		public Group clone(Group parent)
@@ -109,7 +113,7 @@ public class Schema
 			if (o == null || getClass() != o.getClass()) return false;
 			Group other = (Group)o;
 			return name.equals(other.name) && descr.equals(other.descr) && groupURI.equals(other.groupURI) &&
-					assignments.equals(other.assignments) && subGroups.equals(other.subGroups);
+				   canDuplicate == other.canDuplicate && assignments.equals(other.assignments) && subGroups.equals(other.subGroups);
 		}
 		
 		@Override
@@ -161,7 +165,7 @@ public class Schema
 			}
 			return list.toArray(new Assignment[list.size()]);
 		}
-	};
+	}
 
 	// used within assignments: used to indicate how building of models to make suggestions is handled
 	public enum Suggestions

--- a/src/com/cdd/bao/template/SchemaVocab.java
+++ b/src/com/cdd/bao/template/SchemaVocab.java
@@ -60,7 +60,7 @@ public class SchemaVocab
 	{
 		public String schemaPrefix; // unique identifier for the template
 		public String propURI; // together with groupNest, uniquely identifies
-		public String[] groupNest; // an assignment part of a schema dumped to a file 
+		public Position[] groupNest; // an assignment part of a schema dumped to a file 
 		public Assignment assignment;
 		public SchemaTree tree;
 	}
@@ -196,9 +196,9 @@ public class SchemaVocab
 			data.writeUTF(stored.schemaPrefix);
 			data.writeUTF(stored.assignment.propURI);
 
-			String[] groupNest = stored.assignment.groupNest();
+			Position[] groupNest = stored.assignment.groupNest();
 			data.writeInt(groupNest.length);
-			for (int k = 0; k < groupNest.length; ++k) data.writeUTF(groupNest[k]);
+			for (int k = 0; k < groupNest.length; k++) data.writeUTF(groupNest[k].uri);
 
 			SchemaTree.Node[] flat = stored.tree.getFlat();
 			data.writeInt(flat.length);
@@ -281,8 +281,8 @@ public class SchemaVocab
 			stored.propURI = data.readUTF();
 
 			int lenGroupNest = data.readInt();
-			stored.groupNest = new String[lenGroupNest];
-			for (int i = 0; i < stored.groupNest.length; i++) stored.groupNest[i] = data.readUTF();
+			stored.groupNest = new Position[lenGroupNest];
+			for (int i = 0; i < stored.groupNest.length; i++) stored.groupNest[i] = new Position(data.readUTF());
 			
 			for (Schema schema : templates) if (stored.schemaPrefix.equals(schema.getSchemaPrefix()))
 			{

--- a/src/com/cdd/bao/util/Util.java
+++ b/src/com/cdd/bao/util/Util.java
@@ -290,6 +290,17 @@ public class Util
 	}
 	
 	/**
+	 * Converts an array to a human-readable string, for debugging purposes.
+	 */
+	public static String arrayStr(Object[] arr) 
+	{
+		if (arr == null) return "{null}";
+		String str = "";
+		for (int n = 0; n < arr.length; n++) str += arr[n] == null ? "{null}" : "{" + arr[n] + "}";
+		return str;
+	}
+
+	/**
 	 * Joins an array of strings together, in a reasonably performant way.
 	 * @param list strings to join
 	 * @param sep separator to insert between each two strings

--- a/test/com/cdd/bao/template/SchemaTest.java
+++ b/test/com/cdd/bao/template/SchemaTest.java
@@ -137,11 +137,11 @@ public class SchemaTest
 		Schema.Assignment assn = new Schema.Assignment(g4, "assn", "propURI");
 		Schema.Assignment assn1 = new Schema.Assignment(g1, "assn1", "propURI");
 
-		assertArrayEquals(new String[]{"u3", "u2", "u1"}, g4.groupNest());
+		assertArrayEquals(new String[]{"u3", "u2", "u1"}, Schema.groupNestString(g4.groupNest()));
 		assertArrayEquals(new String[]{"g3", "g2", "g1"}, g4.groupLabel());
-		assertArrayEquals(new String[]{"u4", "u3", "u2", "u1"}, assn.groupNest());
+		assertArrayEquals(new String[]{"u4", "u3", "u2", "u1"}, Schema.groupNestString(assn.groupNest()));
 		assertArrayEquals(new String[]{"g4", "g3", "g2", "g1"}, assn.groupLabel());
-		assertArrayEquals(new String[]{"u1"}, assn1.groupNest());
+		assertArrayEquals(new String[]{"u1"}, Schema.groupNestString(assn1.groupNest()));
 		assertArrayEquals(new String[]{"g1"}, assn1.groupLabel());
 
 		root = new Group(null, "root");
@@ -152,9 +152,9 @@ public class SchemaTest
 		assn = new Schema.Assignment(g4, "assn", "propURI");
 		assn1 = new Schema.Assignment(g1, "assn1", "propURI");
 
-		assertArrayEquals("groups close to the root with missing URI are ignored", new String[]{"u3", "u2"}, g4.groupNest());
+		assertArrayEquals("groups close to the root with missing URI are ignored", new String[]{"u3", "u2"}, Schema.groupNestString(g4.groupNest()));
 		assertArrayEquals("but not in the groupLabel", new String[]{"g3", "g2", "g1"}, g4.groupLabel());
-		assertArrayEquals(new String[]{"u4", "u3", "u2"}, assn.groupNest());
+		assertArrayEquals(new String[]{"u4", "u3", "u2"}, Schema.groupNestString(assn.groupNest()));
 		assertArrayEquals(new String[]{"g4", "g3", "g2", "g1"}, assn.groupLabel());
 	}
 
@@ -344,11 +344,11 @@ public class SchemaTest
 		Group g3a = new Schema.Group(g2a, "g3", "uri3");
 
 		Schema.Assignment assn2 = new Schema.Assignment(g2a, "name", "propURI");
-		assertArrayEquals(new String[]{"uri2"}, assn2.groupNest());
+		assertArrayEquals(new String[]{"uri2"}, Schema.groupNestString(assn2.groupNest()));
 		assertArrayEquals(new String[]{"g2"}, assn2.groupLabel());
 
 		Schema.Assignment assn3 = new Schema.Assignment(g3a, "name", "propURI");
-		assertArrayEquals(new String[]{"uri3", "uri2"}, assn3.groupNest());
+		assertArrayEquals(new String[]{"uri3", "uri2"}, Schema.groupNestString(assn3.groupNest()));
 		assertArrayEquals(new String[]{"g3", "g2"}, assn3.groupLabel());
 
 		Schema.Annotation annot2 = new Schema.Annotation(assn2, "literal");


### PR DESCRIPTION
The `groupNest` designation has an optional way to disambiguate between duplicates, by adding an index. This allows groups to be cloned in place, and multiple instances to be distinguished.