### PR TITLE
Issue #110: load properties from build.properties; optionally build for JDK 1.8 or JDK 11.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,21 +2,42 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="test"/>
-	<classpathentry exported="true" kind="lib" path="lib/commons-cli-1.3.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/commons-codec-1.9.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/commons-csv-1.0.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/commons-lang3-3.3.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/fontbox-2.0.0-RC2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/httpclient-4.2.6.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/httpclient-cache-4.2.6.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/httpcore-4.2.5.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jackson-annotations-2.3.0.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jackson-core-2.3.3.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jackson-databind-2.3.3.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/libthrift-0.9.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/pdfbox-2.0.0-RC2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/xercesImpl-2.11.0.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/xml-apis-1.4.01.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+			<attribute name="owner.project.facets" value="java"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/usr/local/javafx-sdk-11.0.1/lib/javafx.base.jar">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/usr/local/javafx-sdk-11.0.1/lib/javafx.controls.jar">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/usr/local/javafx-sdk-11.0.1/lib/javafx.graphics.jar">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib/commons-cli-1.3.jar"/>
+	<classpathentry kind="lib" path="lib/commons-codec-1.9.jar"/>
+	<classpathentry kind="lib" path="lib/commons-csv-1.0.jar"/>
+	<classpathentry kind="lib" path="lib/commons-lang3-3.3.2.jar"/>
+	<classpathentry kind="lib" path="lib/fontbox-2.0.0-RC2.jar"/>
+	<classpathentry kind="lib" path="lib/httpclient-4.2.6.jar"/>
+	<classpathentry kind="lib" path="lib/httpclient-cache-4.2.6.jar"/>
+	<classpathentry kind="lib" path="lib/httpcore-4.2.5.jar"/>
+	<classpathentry kind="lib" path="lib/jackson-annotations-2.3.0.jar"/>
+	<classpathentry kind="lib" path="lib/jackson-core-2.3.3.jar"/>
+	<classpathentry kind="lib" path="lib/jackson-databind-2.3.3.jar"/>
+	<classpathentry kind="lib" path="lib/libthrift-0.9.2.jar"/>
+	<classpathentry kind="lib" path="lib/pdfbox-2.0.0-RC2.jar"/>
+	<classpathentry kind="lib" path="lib/xercesImpl-2.11.0.jar"/>
+	<classpathentry kind="lib" path="lib/xml-apis-1.4.01.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.module.container"/>
 	<classpathentry kind="con" path="org.eclipse.jst.server.core.container/org.eclipse.jst.server.tomcat.runtimeTarget/Apache Tomcat v8.0">
 		<attributes>
@@ -31,10 +52,9 @@
 	<classpathentry kind="lib" path="lib/jena-shaded-guava-3.0.0.jar"/>
 	<classpathentry kind="lib" path="lib/jena-tdb-3.0.0.jar"/>
 	<classpathentry kind="lib" path="lib/jsonld-java-0.5.1.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry exported="true" kind="lib" path="lib/log4j-1.2.17.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/slf4j-api-1.7.25.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/slf4j-log4j12-1.7.25.jar"/>
+	<classpathentry kind="lib" path="lib/log4j-1.2.17.jar"/>
+	<classpathentry kind="lib" path="lib/slf4j-api-1.7.25.jar"/>
+	<classpathentry kind="lib" path="lib/slf4j-log4j12-1.7.25.jar"/>
 	<classpathentry kind="lib" path="lib/apache-log4j-extras-1.2.17.jar"/>
 	<classpathentry kind="lib" path="lib/junit-4.12.jar"/>
 	<classpathentry kind="lib" path="lib/hamcrest-core-1.3.jar"/>

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore environment-specific build properties.
+build.properties
+
 *.class
 .DS_Store
 

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,13 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=11

--- a/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -4,5 +4,5 @@
   <fixed facet="java"/>
   <fixed facet="jst.utility"/>
   <installed facet="jst.utility" version="1.0"/>
-  <installed facet="java" version="1.8"/>
+  <installed facet="java" version="11"/>
 </faceted-project>

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,2 @@
+jdk.version=jdk11
+jfx.module.home=/usr/local/javafx-sdk-11.0.1/lib

--- a/build.xml
+++ b/build.xml
@@ -13,6 +13,13 @@
 	<description>Collaborative Drug Discovery</description>
 
 	<property name="pkg" location="pkg" />
+	<property file="${basedir}/build.properties" />
+	<condition property="requires-jdk1.8">
+		<equals arg1="${jdk.version}" arg2="jdk1.8"/>
+	</condition>
+	<condition property="requires-jdk11">
+		<equals arg1="${jdk.version}" arg2="jdk11"/>
+	</condition>
 
 	<path id="project.class.path">
 		<fileset dir="lib">
@@ -27,10 +34,30 @@
 	</target>
 
 	<target name="build" depends="init" description="build the source">
-		<javac srcdir="src" destdir="bin" debug="on" encoding="8859_1" listfiles="on" includeantruntime="false" source="1.8" target="1.8">
-			<classpath refid="project.class.path" />
-		</javac>
+		<antcall target="build-jdk11"/>
+		<antcall target="build-jdk1.8"/>
 		<copy file="cfg/log4j.properties" todir="bin" />
+	</target>
+	
+	<target name="build-jdk11" if="requires-jdk11">
+		<antcall target="build-javac">
+			<param name="java.version" value="11"/>
+			<param name="compilerarg" value="--module-path ${jfx.module.home} --add-modules=javafx.controls"/>
+		</antcall>
+	</target>
+
+	<target name="build-jdk1.8" if="requires-jdk1.8">
+		<antcall target="build-javac">
+			<param name="java.version" value="1.8"/>
+			<param name="compilerarg" value=""/> <!-- intentionally empty -->
+		</antcall>
+	</target>
+
+	<target name="build-javac">
+		<javac srcdir="src" destdir="bin" debug="on" encoding="8859_1" listfiles="on" includeantruntime="false" source="${java.version}" target="${java.version}">
+			<compilerarg line="${compilerarg}"/>
+			<classpath refid="project.class.path"/>
+		</javac>
 	</target>
 
 	<target name="pkg" depends="build" description="generate the packages">
@@ -45,7 +72,28 @@
 	</target>
 
 	<target name="buildAPI" depends="init" description="build the source (API only)">
-		<javac srcdir="src" destdir="bin" debug="on" encoding="8859_1" listfiles="on" includeantruntime="false" source="1.8" target="1.8">
+		<antcall target="buildAPI-jdk11"/>
+		<antcall target="buildAPI-jdk1.8"/>
+		<copy file="cfg/log4j.properties" todir="bin" />
+	</target>
+
+	<target name="buildAPI-jdk11" if="requires-jdk11">
+		<antcall target="build-javac">
+			<param name="java.version" value="11"/>
+			<param name="compilerarg" value="--module-path ${jfx.module.home} --add-modules=javafx.controls"/>
+		</antcall>
+	</target>
+
+	<target name="buildAPI-jdk1.8" if="requires-jdk1.8">
+		<antcall target="build-javac">
+			<param name="java.version" value="1.8"/>
+			<param name="compilerarg" value=""/> <!-- intentionally empty -->
+		</antcall>
+	</target>
+
+	<target name="buildAPI-javac">
+		<javac srcdir="src" destdir="bin" debug="on" encoding="8859_1" listfiles="on" includeantruntime="false" source="${java.version}" target="${java.version}">
+			<compilerarg line="${compilerarg}"/>
 			<exclude name="com/cdd/bao/editor/**" />
 			<exclude name="com/cdd/bao/importer/**" />
 			<exclude name="com/cdd/bao/*.java" />
@@ -55,7 +103,6 @@
 			<exclude name="com/cdd/bao/util/UtilGUI.java" />
 			<classpath refid="project.class.path" />
 		</javac>
-		<copy file="cfg/log4j.properties" todir="bin" />
 	</target>
 
 	<target name="pkgAPI" depends="buildAPI" description="generate the package without the GUI">
@@ -120,18 +167,38 @@
 
 	<target name="test-compile" depends="build">
 		<mkdir dir="${test.build.dir}" />
-		<javac srcdir="${test.src.dir}" destdir="${test.build.dir}" includeantruntime="false" debug="on">
-			<classpath>
-				<path refid="classpath.main" />
-				<path refid="classpath.test" />
-			</classpath>
-		</javac>
+		<antcall target="test-compile-jdk11"/>
+		<antcall target="test-compile-jdk1.8"/>
 		<copy todir="${test.build.dir}">
 			<fileset dir="test">
 				<include name="testData/**" />
 				<include name="mockito-extensions/**" />
 			</fileset>
 		</copy>
+	</target>
+
+	<target name="test-compile-jdk11" if="requires-jdk11">
+		<antcall target="test-compile-javac">
+			<param name="java.version" value="11"/>
+			<param name="compilerarg" value="--module-path ${jfx.module.home} --add-modules=javafx.controls"/>
+		</antcall>
+	</target>
+
+	<target name="test-compile-jdk1.8" if="requires-jdk1.8">
+		<antcall target="test-compile-javac">
+			<param name="java.version" value="1.8"/>
+			<param name="compilerarg" value=""/> <!-- intentionally empty -->
+		</antcall>
+	</target>
+
+	<target name="test-compile-javac">
+		<javac srcdir="${test.src.dir}" destdir="${test.build.dir}" includeantruntime="false" debug="on" source="${java.version}" target="${java.version}">
+			<compilerarg line="${compilerarg}"/>
+			<classpath>
+				<path refid="classpath.main" />
+				<path refid="classpath.test" />
+			</classpath>
+		</javac>
 	</target>
 
 	<target name="junit" depends="test-compile" description="run junit">

--- a/src/com/cdd/bao/template/SchemaVocab.java
+++ b/src/com/cdd/bao/template/SchemaVocab.java
@@ -407,7 +407,7 @@ public class SchemaVocab
 		StoredTerm[] newTermList = (StoredTerm[]) ArrayUtils.addAll(termList, newTerms.toArray(new StoredTerm[0]));
 		for (int k = termList.length; k < newTermList.length; k++)
 		{
-			termLookup.put(newTermList[k].uri, new Integer(k));
+			termLookup.put(newTermList[k].uri, Integer.valueOf(k));
 			
 			StoredRemapTo srt = newTermRemappings.get(newTermList[k].uri);
 			if (srt != null) remappings.put(newTermList[k].uri, srt);

--- a/src/org/json/JSONArray.java
+++ b/src/org/json/JSONArray.java
@@ -919,7 +919,7 @@ public class JSONArray implements Iterable<Object>
 	 */
 	public JSONArray put(double value) throws JSONException
 	{
-		Double d = new Double(value);
+		Double d = Double.valueOf(value);
 		JSONObject.testValidity(d);
 		put(d);
 		return this;
@@ -934,7 +934,7 @@ public class JSONArray implements Iterable<Object>
 	 */
 	public JSONArray put(int value)
 	{
-		put(new Integer(value));
+		put(Integer.valueOf(value));
 		return this;
 	}
 
@@ -947,7 +947,7 @@ public class JSONArray implements Iterable<Object>
 	 */
 	public JSONArray put(long value)
 	{
-		put(new Long(value));
+		put(Long.valueOf(value));
 		return this;
 	}
 
@@ -1033,7 +1033,7 @@ public class JSONArray implements Iterable<Object>
 	 */
 	public JSONArray put(int index, double value) throws JSONException
 	{
-		put(index, new Double(value));
+		put(index, Double.valueOf(value));
 		return this;
 	}
 
@@ -1052,7 +1052,7 @@ public class JSONArray implements Iterable<Object>
 	 */
 	public JSONArray put(int index, int value) throws JSONException
 	{
-		put(index, new Integer(value));
+		put(index, Integer.valueOf(value));
 		return this;
 	}
 
@@ -1071,7 +1071,7 @@ public class JSONArray implements Iterable<Object>
 	 */
 	public JSONArray put(int index, long value) throws JSONException
 	{
-		put(index, new Long(value));
+		put(index, Long.valueOf(value));
 		return this;
 	}
 

--- a/src/org/json/JSONObject.java
+++ b/src/org/json/JSONObject.java
@@ -1285,7 +1285,7 @@ public class JSONObject
 	 */
 	public JSONObject put(String key, double value) throws JSONException
 	{
-		put(key, new Double(value));
+		put(key, Double.valueOf(value));
 		return this;
 	}
 
@@ -1302,7 +1302,7 @@ public class JSONObject
 	 */
 	public JSONObject put(String key, int value) throws JSONException
 	{
-		put(key, new Integer(value));
+		put(key, Integer.valueOf(value));
 		return this;
 	}
 
@@ -1319,7 +1319,7 @@ public class JSONObject
 	 */
 	public JSONObject put(String key, long value) throws JSONException
 	{
-		put(key, new Long(value));
+		put(key, Long.valueOf(value));
 		return this;
 	}
 
@@ -1602,7 +1602,7 @@ public class JSONObject
 				}
 				else
 				{
-					Long myLong = new Long(string);
+					Long myLong = Long.valueOf(string);
 					if (string.equals(myLong.toString()))
 					{
 						if (myLong == myLong.intValue())

--- a/src/org/json/JSONWriter.java
+++ b/src/org/json/JSONWriter.java
@@ -295,7 +295,7 @@ public class JSONWriter
 	 */
 	public JSONWriter value(double d) throws JSONException
 	{
-		return value(new Double(d));
+		return value(Double.valueOf(d));
 	}
 
 	/**


### PR DESCRIPTION
This is a 1st draft of how we will resolve compilation for either Java 1.8 or Java 11.  Changes to `build.xml` assume the existence of `build.properties`.  Latter file has these contents on my setup:
```
jdk.version=jdk1.8
jfx.module.home=/opt/local/javafx-sdk-11.0.1/lib
```

If we approve these changes, then we will need to install the JFX module for Java 11 on the server responsible for building / testing WIP-PRs; I am using the JFX module from `openjfx.io`, which is available [here](https://gluonhq.com/products/javafx/) (yes, it's downloaded from a different domain).  As well, we will need to create said `build.properties` for that environment; it must reside in the same place as `build.xml`.

I am now testing this approach for Java 11 builds within a more recent snapshot for Eclipse that supports Java 11.