### PR TITLE
Template compilation outputs stats

### DIFF
--- a/src/com/cdd/bao/Main.java
+++ b/src/com/cdd/bao/Main.java
@@ -26,6 +26,7 @@ import com.cdd.bao.editor.*;
 import com.cdd.bao.importer.*;
 import com.cdd.bao.template.*;
 import com.cdd.bao.template.Schema.*;
+import com.cdd.bao.template.SchemaVocab.*;
 import com.cdd.bao.util.*;
 import com.cdd.bao.validator.*;
 
@@ -335,6 +336,13 @@ public class Main
 		SchemaVocab schvoc = new SchemaVocab(vocab, schemata);
 
 		Util.writeln("Loaded: " + schvoc.numTerms() + " terms.");
+		
+		for (Schema schema : schemata) 
+		{
+			Util.writeln("Schema [" + schema.getRoot().name + "] <" + schema.getSchemaPrefix() + ">");
+			summariseSchemaGroup(schema.getRoot(), 4, schvoc);
+		}
+		
 		try (OutputStream ostr = new FileOutputStream(outputFile))
 		{
 			if (outputFile.endsWith(".json"))
@@ -356,6 +364,26 @@ public class Main
 			else schvoc.serialise(ostr);
 		}
 		Util.writeln("Done.");
+	}
+
+	// display overview of schema contents
+	private static void summariseSchemaGroup(Group group, int indent, SchemaVocab schvoc)
+	{
+		for (Assignment assn : group.assignments)
+		{
+			Util.write(Util.rep(' ', indent) + "[" + assn.name + "] <" + ModelSchema.collapsePrefix(assn.propURI) + ">");
+			for (StoredTree stored : schvoc.getTrees()) if (stored.assignment == assn) 
+			{
+				Util.write(" terms=" + stored.tree.getTree().size());
+				break;
+			}
+			Util.writeln();
+		}
+		for (Group subgrp : group.subGroups)
+		{
+			Util.writeln(Util.rep(' ', indent) + "{" + subgrp.name + "} <" + ModelSchema.collapsePrefix(subgrp.groupURI) + ">");
+			summariseSchemaGroup(subgrp, indent + 4, schvoc);
+		}
 	}
 
 	// evaluates a schema template, looking for obvious shortcomings


### PR DESCRIPTION
When compiling templates, output shows a preview of the template content and how many terms each one gets, e.g.

```
Compiling schema files:
    data/template/schema.json
    data/template/branch/measurement_details.json
Output to:
    data/template/vocab.dump
Loading ontologies ..................................
Loaded: 109841 terms.
Schema [common assay template] <http://www.bioassayontology.org/bas#>
    [assay title] <bao:BAO_0002853> terms=0
    [bioassay type] <bao:BAO_0002854> terms=13
    [bioassay] <bao:BAO_0002855> terms=155
    [assay format] <bao:BAO_0000205> terms=32
    [assay design method] <bao:BAO_0095009> terms=117
    [assay supporting method] <bao:BAO_0095010> terms=231
    [assay cell line] <bao:BAO_0002800> terms=41631
    [organism] <bao:BAO_0002921> terms=99
    [biological process] <bao:BAO_0002009> terms=38247
    [target] <bao:BAO_0000211> terms=5057
    [applies to disease] <bao:BAO_0002848> terms=4072
    [assay mode of action] <bao:BAO_0000196> terms=51
    [result] <bao:BAO_0000208> terms=179
    [screening campaign stage] <bao:BAO_0000210> terms=33
    [assay footprint] <bao:BAO_0002867> terms=45
    [assay kit] <bao:BAO_0002663> terms=141
    [physical detection method] <bao:BAO_0000207> terms=79
    [detection instrument] <bao:BAO_0002865> terms=146
    [perturbagen type] <bao:BAO_0000185> terms=31
    [protein identity] <bao:BAX_0000012> terms=8348
    [gene identity] <bao:BAX_0000011> terms=853
    [GO terms] <bao:BAO_0003107> terms=42122
    [assay sources] <bao:BAO_0002852> terms=106
    [related assays] <bao:BAO_0000539> terms=0
    {measurement} <bao:BAX_0000017>
        [field] <bao:BAX_0000015> terms=0
        [units] <bao:BAO_0002874> terms=330
        [operator] <bao:BAX_0000016> terms=6
        [threshold] <bao:BAO_0002916> terms=0
Schema [measurement details] <http://www.bioassayontology.org/bas/MeasurementDetails#>
    {measurement details} <bao:BAO_0000209>
        [signal direction] <bao:BAO_0002857> terms=7
        [excitation wavelength] <bao:BAO_0002917> terms=0
        [emission wavelength] <bao:BAO_0002918> terms=0
        [absorbance wavelength] <bao:BAO_0002919> terms=0
        [detection instrument manufacturer] <bao:BAO_0000737> terms=58
        [assay readout type] <bao:BAO_0002856> terms=9
        [assay readout parameter] <bao:BAX_0000052> terms=5
        [endpoint modifier] <bao:BAO_0002858> terms=7
        [detected entity] <bao:BAO_0002797> terms=362
        [measurement quality] <bao:BAO_0002662> terms=39
        [location of measurement] <bao:BAO_0002861> terms=3875
Done.
```