### PR TITLE
Imported extra organisms from NCBI taxon

### DIFF
--- a/data/ontology/extra_organisms.ttl
+++ b/data/ontology/extra_organisms.ttl
@@ -1,0 +1,5281 @@
+@prefix bao:   <http://www.bioassayontology.org/bao#> .
+@prefix bat:   <http://www.bioassayontology.org/bat#> .
+@prefix src:   <http://www.bioassayexpress.org/sources#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix bae:   <http://www.bioassayexpress.org/bae#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix obo:   <http://purl.obolibrary.org/obo/> .
+@prefix dto:   <http://www.drugtargetontology.org/dto/> .
+
+obo:NCBITaxon_55194  rdfs:label  "Malassezia furfur" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Pityriasis (Tinea) versicolor infection agent" .
+
+obo:NCBITaxon_217992  rdfs:label  "Escherichia coli O6" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_238  rdfs:label  "Elizabethkingia meningoseptica" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_505518  rdfs:label  "Influenza A virus (A/Georgia/20/2006(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_67828  rdfs:label  "Citrobacter gillenii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_9989  rdfs:label  "Rodentia" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "rodent" .
+
+obo:NCBITaxon_147683  rdfs:label  "Human rhinovirus B42" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_12331  rdfs:label  "Rice stripe tenuivirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_46503  rdfs:label  "Parabacteroides merdae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_4013  rdfs:label  "Toxicodendron vernicifluum" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "Japanese lacquer-tree" , "varnish tree" , "Japanese lacquer tree" , "Chinese lacquer" .
+
+obo:NCBITaxon_10366  rdfs:label  "Murid betaherpesvirus 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 ;
+        bae:altLabel     "Murine cytomegalovirus" .
+
+obo:NCBITaxon_6956  rdfs:label  "Dermatophagoides pteronyssinus" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "European house dust mite" .
+
+obo:NCBITaxon_1780  rdfs:label  "Mycobacterium malmoense" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_545  rdfs:label  "Citrobacter koseri" ;
+        rdfs:subClassOf  obo:NCBITaxon_544 .
+
+obo:NCBITaxon_11235  rdfs:label  "Measles virus strain Edmonston" ;
+        rdfs:subClassOf  obo:NCBITaxon_11234 .
+
+obo:NCBITaxon_383603  rdfs:label  "Influenza A virus (A/turkey/Minnesota/833/1980(H4N2))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_2102  rdfs:label  "Mycoplasma mycoides" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_66861  rdfs:label  "Vibrio cholerae non-O1" ;
+        rdfs:subClassOf  obo:NCBITaxon_666 .
+
+obo:NCBITaxon_305  rdfs:label  "Ralstonia solanacearum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_312175  rdfs:label  "Leptospira interrogans serovar Bataviae" ;
+        rdfs:subClassOf  obo:NCBITaxon_173 .
+
+obo:NCBITaxon_1718  rdfs:label  "Corynebacterium glutamicum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_11070  rdfs:label  "Dengue virus 4" ;
+        rdfs:subClassOf  obo:NCBITaxon_12637 .
+
+obo:NCBITaxon_7113  rdfs:label  "Helicoverpa zea" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "tomato fruitworm" , "corn earworm" , "bollworm" .
+
+obo:NCBITaxon_2190  rdfs:label  "Methanocaldococcus jannaschii" ;
+        rdfs:subClassOf  bae:BAE_0000065 .
+
+obo:NCBITaxon_29058  rdfs:label  "Helicoverpa armigera" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "cotton bollworm" , "tobacco budworm" , "scarce bordered straw" , "American bollworm" , "corn ear worm" .
+
+obo:NCBITaxon_308994  rdfs:label  "Dialister propionicifaciens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_12104  rdfs:label  "Encephalomyocarditis virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_461739  rdfs:label  "Influenza B virus (B/Florida/4/2006)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11520 .
+
+obo:NCBITaxon_2115  rdfs:label  "Mycoplasma fermentans" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_100226  rdfs:label  "Streptomyces coelicolor A3(2)" ;
+        rdfs:subClassOf  obo:NCBITaxon_1902 .
+
+obo:NCBITaxon_329183  rdfs:label  "Influenza A virus (A/gull/Pennsylvania/4175/83(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_11083  rdfs:label  "Powassan virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_147469  rdfs:label  "Staphylococcus sciuri subsp. rodentium" ;
+        rdfs:subClassOf  obo:NCBITaxon_1296 .
+
+obo:NCBITaxon_82524  rdfs:label  "Trichosporon ovoides" ;
+        rdfs:subClassOf  obo:NCBITaxon_5552 .
+
+obo:NCBITaxon_36351  rdfs:label  "Human herpesvirus 6 strain Z29" ;
+        rdfs:subClassOf  obo:NCBITaxon_32604 .
+
+obo:NCBITaxon_1019  rdfs:label  "Capnocytophaga sputigena" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1313  rdfs:label  "Streptococcus pneumoniae" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_625  rdfs:label  "Shigella sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_620 .
+
+obo:NCBITaxon_170187  rdfs:label  "Streptococcus pneumoniae TIGR4" ;
+        rdfs:subClassOf  obo:NCBITaxon_1313 .
+
+obo:NCBITaxon_143450  rdfs:label  "Mycosphaerella arachidis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_126157  rdfs:label  "Psychrobacillus psychrodurans" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1579  rdfs:label  "Lactobacillus acidophilus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_31654  rdfs:label  "Hepatitis C virus subtype 5a" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_10294  rdfs:label  "Simplexvirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_40324  rdfs:label  "Stenotrophomonas maltophilia" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1633  rdfs:label  "Lactobacillus vaginalis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_489483  rdfs:label  "HBV genotype D" ;
+        rdfs:subClassOf  obo:NCBITaxon_10407 .
+
+obo:NCBITaxon_945  rdfs:label  "Ehrlichia chaffeensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5535  rdfs:label  "Rhodotorula glutinis" ;
+        rdfs:subClassOf  obo:NCBITaxon_5533 .
+
+obo:NCBITaxon_388795  rdfs:label  "HIV-1 group M" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_387139  rdfs:label  "Influenza A virus (A/Aichi/2/1968(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_2208  rdfs:label  "Methanosarcina barkeri" ;
+        rdfs:subClassOf  bae:BAE_0000065 .
+
+obo:NCBITaxon_200917  rdfs:label  "Acanthoscelides obtectus" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_41281  rdfs:label  "Aspergillus niveus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_29917  rdfs:label  "Cladosporium cladosporioides" ;
+        rdfs:subClassOf  obo:NCBITaxon_5498 .
+
+obo:NCBITaxon_54005  rdfs:label  "Peptoniphilus harei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11176  rdfs:label  "Avian avulavirus 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_211880  rdfs:label  "Leptospira interrogans serovar Canicola" ;
+        rdfs:subClassOf  obo:NCBITaxon_173 .
+
+obo:NCBITaxon_875053  rdfs:label  "Staphylococcus aureus VRS3" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_28171  rdfs:label  "Vibrio aestuarianus" ;
+        rdfs:subClassOf  obo:NCBITaxon_662 .
+
+obo:NCBITaxon_216597  rdfs:label  "Salmonella enterica subsp. enterica serovar Typhimurium str. SL1344" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Salmonella enterica subsp. enterica serovar Typhimurium SL1344" , "Salmonella enterica subsp. enterica serovar Typhimurium strain SL1344" .
+
+obo:NCBITaxon_301447  rdfs:label  "Streptococcus pyogenes serotype M1" ;
+        rdfs:subClassOf  obo:NCBITaxon_1314 .
+
+obo:NCBITaxon_6198  rdfs:label  "Opisthorchis viverrini" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "Southeast Asian liver fluke" .
+
+obo:NCBITaxon_1659  rdfs:label  "Actinomyces israelii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1654 .
+
+obo:NCBITaxon_294381  rdfs:label  "Entamoeba histolytica HM-1:IMSS" ;
+        rdfs:subClassOf  obo:NCBITaxon_5759 .
+
+obo:NCBITaxon_1406  rdfs:label  "Paenibacillus polymyxa" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_216816  rdfs:label  "Bifidobacterium longum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1678 .
+
+obo:NCBITaxon_28184  rdfs:label  "Leptospira weilii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5855  rdfs:label  "Plasmodium vivax" ;
+        rdfs:subClassOf  bao:BAO_0000662 ;
+        bae:altLabel     "malaria parasite P. vivax" .
+
+obo:NCBITaxon_206160  rdfs:label  "Sandfly fever Naples virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_47886  rdfs:label  "Pseudomonas luteola" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_32603  rdfs:label  "Human betaherpesvirus 6A" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_37326  rdfs:label  "Nocardia brasiliensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Nocardia brasilensis" .
+
+obo:NCBITaxon_41067  rdfs:label  "Aspergillus candidus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_83334  rdfs:label  "Escherichia coli O157:H7" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_48296  rdfs:label  "Acinetobacter pittii" ;
+        rdfs:subClassOf  obo:NCBITaxon_909768 .
+
+obo:NCBITaxon_2123  rdfs:label  "Mycoplasma putrefaciens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1561  rdfs:label  "Clostridium baratii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_146827  rdfs:label  "Corynebacterium simulans" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_483216  rdfs:label  "Bacteroides eggerthii DSM 20697" ;
+        rdfs:subClassOf  obo:NCBITaxon_28111 ;
+        bae:altLabel     "Bacteroides eggerthii str. DSM 20697" , "Bacteroides eggerthii strain DSM 20697" .
+
+obo:NCBITaxon_3704  rdfs:label  "Armoracia rusticana" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "horseradish" .
+
+obo:NCBITaxon_620  rdfs:label  "Shigella" ;
+        rdfs:subClassOf  obo:NCBITaxon_543 .
+
+obo:NCBITaxon_28264  rdfs:label  "Arcanobacterium haemolyticum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Arcanibacterium haemolyticum" .
+
+obo:NCBITaxon_13706  rdfs:label  "Syncephalastrum racemosum" ;
+        rdfs:subClassOf  obo:NCBITaxon_13705 .
+
+obo:NCBITaxon_41846  rdfs:label  "Echovirus E30" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_186540  rdfs:label  "Sudan ebolavirus" ;
+        rdfs:subClassOf  obo:NCBITaxon_186536 .
+
+obo:NCBITaxon_418127  rdfs:label  "Staphylococcus aureus subsp. aureus Mu3" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 ;
+        bae:altLabel     "Staphylococcus aureus subsp. aureus str. Mu3" , "Staphylococcus aureus subsp. aureus strain Mu3" .
+
+obo:NCBITaxon_12138  rdfs:label  "Maize chlorotic mottle virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_33039  rdfs:label  "[Ruminococcus] torques" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Ruminococcus torques" .
+
+obo:NCBITaxon_382835  rdfs:label  "Influenza A virus (A/WSN/1933(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_4839  rdfs:label  "Rhizomucor miehei" ;
+        rdfs:subClassOf  obo:NCBITaxon_4838 .
+
+obo:NCBITaxon_652616  rdfs:label  "Mycobacterium tuberculosis str. Erdman = ATCC 35801" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Mycobacterium tuberculosis ATCC 35801 = str. Erdman" .
+
+obo:NCBITaxon_167323  rdfs:label  "Human rhinovirus strain Hanks" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1334  rdfs:label  "Streptococcus dysgalactiae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_52275  rdfs:label  "Human adenovirus D37" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_646  rdfs:label  "Aeromonas sobria" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_535025  rdfs:label  "Bacillus subtilis subsp. subtilis str. JH642" ;
+        rdfs:subClassOf  obo:NCBITaxon_135461 .
+
+obo:NCBITaxon_28037  rdfs:label  "Streptococcus mitis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_365124  rdfs:label  "Influenza A virus (A/chicken/Yogjakarta/BBVet-IX/2004(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_9685  rdfs:label  "Felis catus" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "cat" , "domestic cat" , "cats" .
+
+obo:NCBITaxon_1641  rdfs:label  "Listeria grayi" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Listeria grayi grayi" .
+
+obo:NCBITaxon_953  rdfs:label  "Wolbachia" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5543  rdfs:label  "Trichoderma" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_216592  rdfs:label  "Escherichia coli 042" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Escherichia coli str. 042" , "Escherichia coli strain 042" .
+
+obo:NCBITaxon_1654  rdfs:label  "Actinomyces" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_362651  rdfs:label  "Human immunodeficiency virus type 1 (isolate YU2)" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_36911  rdfs:label  "Clavispora lusitaniae" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_29466  rdfs:label  "Veillonella parvula" ;
+        rdfs:subClassOf  obo:NCBITaxon_29465 .
+
+obo:NCBITaxon_5850  rdfs:label  "Plasmodium knowlesi" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_7787  rdfs:label  "Tetronarce californica" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "Pacific electric ray" .
+
+obo:NCBITaxon_726  rdfs:label  "Haemophilus haemolyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_724 .
+
+obo:NCBITaxon_4754  rdfs:label  "Pneumocystis carinii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_90268  rdfs:label  "Apophysomyces" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_561  rdfs:label  "Escherichia" ;
+        rdfs:subClassOf  obo:NCBITaxon_543 .
+
+obo:NCBITaxon_1427  rdfs:label  "Bacillus thermoproteolyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1386 .
+
+obo:NCBITaxon_12066  rdfs:label  "Coxsackievirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_739  rdfs:label  "Aggregatibacter segnis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_202751  rdfs:label  "Listeria ivanovii subsp. ivanovii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1638 .
+
+obo:NCBITaxon_1262  rdfs:label  "Peptostreptococcus sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11723  rdfs:label  "Simian immunodeficiency virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_321  rdfs:label  "Pseudomonas syringae pv. syringae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_43765  rdfs:label  "Corynebacterium amycolatum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_243922  rdfs:label  "Acinetobacter rhizosphaerae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_587  rdfs:label  "Providencia rettgeri" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_881  rdfs:label  "Desulfovibrio vulgaris" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1747  rdfs:label  "Cutibacterium acnes" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Propionicibacterium acnes" .
+
+obo:NCBITaxon_8976  rdfs:label  "Galliformes" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "fowls" .
+
+obo:NCBITaxon_11277  rdfs:label  "Vesicular stomatitis Indiana virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1288  rdfs:label  "Staphylococcus xylosus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_127906  rdfs:label  "Vibrio cholerae O1" ;
+        rdfs:subClassOf  obo:NCBITaxon_666 .
+
+obo:NCBITaxon_33034  rdfs:label  "Anaerococcus prevotii" ;
+        rdfs:subClassOf  obo:NCBITaxon_165779 .
+
+obo:NCBITaxon_1582  rdfs:label  "Lactobacillus casei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_652611  rdfs:label  "Pseudomonas aeruginosa PA14" ;
+        rdfs:subClassOf  obo:NCBITaxon_287 ;
+        bae:altLabel     "Pseudomonas aeruginosa str. PA14" , "Pseudomonas aeruginosa strain PA14" .
+
+obo:NCBITaxon_61646  rdfs:label  "Lelliottia amnigena" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_28285  rdfs:label  "Human adenovirus 5" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_33047  rdfs:label  "Bartonella vinsonii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_644788  rdfs:label  "Influenza A virus (A/Vietnam/1194/2004(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_4847  rdfs:label  "Rhizopus microsporus var. oligosporus" ;
+        rdfs:subClassOf  obo:NCBITaxon_58291 .
+
+obo:NCBITaxon_654  rdfs:label  "Aeromonas veronii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_197614  rdfs:label  "Streptococcus pasteurianus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_266827  rdfs:label  "Influenza A virus (A/Thailand/1(KAN-1)/2004(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_195  rdfs:label  "Campylobacter coli" ;
+        rdfs:subClassOf  obo:NCBITaxon_194 .
+
+obo:NCBITaxon_271848  rdfs:label  "Burkholderia thailandensis E264" ;
+        rdfs:subClassOf  obo:NCBITaxon_57975 ;
+        bae:altLabel     "Burkholderia thailandensis strain E264" , "Burkholderia thailandensis str. E264" .
+
+obo:NCBITaxon_29879  rdfs:label  "Neurospora discreta" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_411479  rdfs:label  "Bacteroides uniformis ATCC 8492" ;
+        rdfs:subClassOf  obo:NCBITaxon_820 .
+
+obo:NCBITaxon_6660  rdfs:label  "Artemia" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "brine shrimps" , "sea monkeys" .
+
+obo:NCBITaxon_538120  rdfs:label  "Mammalian orthoreovirus 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5551  rdfs:label  "Trichophyton rubrum" ;
+        rdfs:subClassOf  obo:NCBITaxon_5550 .
+
+obo:NCBITaxon_185937  rdfs:label  "Human rhinovirus A85" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_29461  rdfs:label  "Brucella suis" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Brucella melitensis bv. Suis" .
+
+obo:NCBITaxon_224326  rdfs:label  "Borreliella burgdorferi B31" ;
+        rdfs:subClassOf  obo:NCBITaxon_139 .
+
+obo:NCBITaxon_37734  rdfs:label  "Enterococcus casseliflavus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1350 .
+
+obo:NCBITaxon_523103  rdfs:label  "Trichophyton mentagrophytes" ;
+        rdfs:subClassOf  obo:NCBITaxon_5550 .
+
+obo:NCBITaxon_343983  rdfs:label  "Influenza B virus (B/Perth/211/2001)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11520 .
+
+obo:NCBITaxon_9925  rdfs:label  "Capra hircus" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "domestic goat" , "goats" , "goat" .
+
+obo:NCBITaxon_7070  rdfs:label  "Tribolium castaneum" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "red flour beetle" , "rust-red flour beetle" .
+
+obo:NCBITaxon_4927  rdfs:label  "Wickerhamomyces anomalus" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_5871  rdfs:label  "Babesia caballi" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_40126  rdfs:label  "Neurospora sitophila" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_28125  rdfs:label  "Prevotella bivia" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_93062  rdfs:label  "Staphylococcus aureus subsp. aureus COL" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 .
+
+obo:NCBITaxon_149391  rdfs:label  "Salmonella enterica subsp. enterica serovar Braenderup" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_76351  rdfs:label  "Ceratobasidium cereale" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_12074  rdfs:label  "Coxsackievirus B5" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_747  rdfs:label  "Pasteurella multocida" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1270  rdfs:label  "Micrococcus luteus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1269 .
+
+obo:NCBITaxon_356390  rdfs:label  "Hepatitis C virus SA13" ;
+        rdfs:subClassOf  obo:NCBITaxon_31654 .
+
+obo:NCBITaxon_70791  rdfs:label  "[Nectria] haematococca mpVI" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Nectria haematococca subsp. mating population VI" , "Nectria haematococca mpVI" .
+
+obo:NCBITaxon_582  rdfs:label  "Morganella morganii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_440390  rdfs:label  "Influenza A virus (A/Turkey/651242/2006(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_2098  rdfs:label  "Mycoplasma hominis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_403340  rdfs:label  "Influenza B virus (B/Michigan/20/2005)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11520 .
+
+obo:NCBITaxon_11909  rdfs:label  "Human T-lymphotropic virus 2" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_191435  rdfs:label  "Stereum sanguinolentum" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "red heart rot" .
+
+obo:NCBITaxon_1283  rdfs:label  "Staphylococcus haemolyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_333284  rdfs:label  "Hepatitis C virus (isolate Con1)" ;
+        rdfs:subClassOf  obo:NCBITaxon_31647 .
+
+obo:NCBITaxon_6500  rdfs:label  "Aplysia californica" ;
+        rdfs:subClassOf  obo:NCBITaxon_6499 ;
+        bae:altLabel     "California sea hare" .
+
+obo:NCBITaxon_595  rdfs:label  "Salmonella enterica subsp. enterica serovar Infantis" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_165779  rdfs:label  "Anaerococcus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_592022  rdfs:label  "Bacillus megaterium DSM 319" ;
+        rdfs:subClassOf  obo:NCBITaxon_1404 ;
+        bae:altLabel     "Bacillus megaterium str. DSM 319" , "Bacillus megaterium strain DSM 319" .
+
+obo:NCBITaxon_367928  rdfs:label  "Bifidobacterium adolescentis ATCC 15703" ;
+        rdfs:subClassOf  obo:NCBITaxon_1680 ;
+        bae:altLabel     "Bifidobacterium adolescentis str. ATCC 15703" , "Bifidobacterium adolescentis strain ATCC 15703" .
+
+obo:NCBITaxon_1502  rdfs:label  "Clostridium perfringens" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_28280  rdfs:label  "Human adenovirus E4" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1296  rdfs:label  "Staphylococcus sciuri" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_42677  rdfs:label  "Fusarium subglutinans" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_41315  rdfs:label  "Yersinia sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1590  rdfs:label  "Lactobacillus plantarum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 ;
+        bae:altLabel     "Lactobacillus arizonae" .
+
+obo:NCBITaxon_29314  rdfs:label  "Mycolicibacter hiberniae" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Mycobacterium hiberniense" .
+
+obo:NCBITaxon_11757  rdfs:label  "Mouse mammary tumor virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_91930  rdfs:label  "Coniochaeta hoffmannii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_4842  rdfs:label  "Rhizopus" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1768  rdfs:label  "Mycobacterium kansasii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_48544  rdfs:label  "Fort Morgan virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_374031  rdfs:label  "Physalis ixocarpa" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "tomatillo" .
+
+obo:NCBITaxon_827  rdfs:label  "Campylobacter ureolyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_194 .
+
+obo:NCBITaxon_40041  rdfs:label  "Streptococcus equi subsp. zooepidemicus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1336 ;
+        bae:altLabel     "Streptococcus equi zooepidemicus" .
+
+obo:NCBITaxon_6526  rdfs:label  "Biomphalaria glabrata" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "bloodfluke planorb" .
+
+obo:NCBITaxon_51641  rdfs:label  "Willaertia magna" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_67780  rdfs:label  "Edwardsiella ictaluri" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_91943  rdfs:label  "Hortaea werneckii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1350  rdfs:label  "Enterococcus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_7176  rdfs:label  "Culex quinquefasciatus" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "southern house mosquito" .
+
+obo:NCBITaxon_662  rdfs:label  "Vibrio" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_352034  rdfs:label  "Influenza A virus (A/duck/Potsdam/1402-6/1986(H5N2))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_235443  rdfs:label  "Cryptococcus neoformans var. grubii H99" ;
+        rdfs:subClassOf  obo:NCBITaxon_178876 ;
+        bae:altLabel     "Cryptococcus neoformans H99" .
+
+obo:NCBITaxon_464623  rdfs:label  "Influenza A virus (A/Solomon Islands/3/2006(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_10243  rdfs:label  "Cowpox virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_12639  rdfs:label  "Duck hepatitis B virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_39400  rdfs:label  "Curvularia brachyspora" ;
+        rdfs:subClassOf  obo:NCBITaxon_5502 .
+
+obo:NCBITaxon_367830  rdfs:label  "Staphylococcus aureus subsp. aureus USA300" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 ;
+        bae:altLabel     "Staphylococcus aureus subsp. aureus str. USA300" , "Staphylococcus aureus subsp. aureus strain USA300" .
+
+obo:NCBITaxon_132249  rdfs:label  "Nocardia veterana" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_67081  rdfs:label  "Mycolicibacterium alvei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_176275  rdfs:label  "Beauveria bassiana" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_135589  rdfs:label  "Coniferiporia weirii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_4922  rdfs:label  "Komagataella pastoris" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_272560  rdfs:label  "Burkholderia pseudomallei K96243" ;
+        rdfs:subClassOf  obo:NCBITaxon_28450 ;
+        bae:altLabel     "Burkholderia pseudomallei str. K96243" , "Burkholderia pseudomallei strain K96243" .
+
+obo:NCBITaxon_44010  rdfs:label  "Mycobacterium conspicuum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_294748  rdfs:label  "Candida albicans WO-1" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_384602  rdfs:label  "Micrococcus flavus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1269 .
+
+obo:NCBITaxon_478864  rdfs:label  "Plasmodium falciparum VS/1" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_10310  rdfs:label  "Human alphaherpesvirus 2" ;
+        rdfs:subClassOf  obo:NCBITaxon_10294 ;
+        bae:altLabel     "Herpes simplex virus type 2 (HSV-2)" .
+
+obo:NCBITaxon_44276  rdfs:label  "Leptospira interrogans serovar Pomona" ;
+        rdfs:subClassOf  obo:NCBITaxon_173 .
+
+obo:NCBITaxon_37296  rdfs:label  "Human gammaherpesvirus 8" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1902  rdfs:label  "Streptomyces coelicolor" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_28133  rdfs:label  "Prevotella nigrescens" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_12082  rdfs:label  "Human poliovirus 1 strain Sabin" ;
+        rdfs:subClassOf  obo:NCBITaxon_12080 .
+
+obo:NCBITaxon_4236  rdfs:label  "Lactuca sativa" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "cultivated lettuce" , "garden lettuce" .
+
+obo:NCBITaxon_4530  rdfs:label  "Oryza sativa" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "red rice" , "rice" .
+
+obo:NCBITaxon_590  rdfs:label  "Salmonella" ;
+        rdfs:subClassOf  obo:NCBITaxon_543 .
+
+obo:NCBITaxon_1750  rdfs:label  "Pseudopropionibacterium propionicum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Propionicibacterium propionicus" , "Propionicibacterium propionicum" .
+
+obo:NCBITaxon_5180  rdfs:label  "Sclerotinia sclerotiorum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_393133  rdfs:label  "Listeria monocytogenes 10403S" ;
+        rdfs:subClassOf  obo:NCBITaxon_1639 ;
+        bae:altLabel     "Listeria monocytogenes str. 10403S" , "Listeria monocytogenes strain 10403S" .
+
+obo:NCBITaxon_226186  rdfs:label  "Bacteroides thetaiotaomicron VPI-5482" ;
+        rdfs:subClassOf  obo:NCBITaxon_818 ;
+        bae:altLabel     "Bacteroides thetaiotaomicron str. VPI-5482" , "Bacteroides thetaiotaomicron strain VPI-5482" .
+
+obo:NCBITaxon_498742  rdfs:label  "Borreliella spielmanii A14S" ;
+        rdfs:subClassOf  obo:NCBITaxon_88916 .
+
+obo:NCBITaxon_4556  rdfs:label  "Setaria viridis" ;
+        rdfs:subClassOf  bao:BAO_0000605 .
+
+obo:NCBITaxon_27357  rdfs:label  "Colletotrichum acutatum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_40214  rdfs:label  "Acinetobacter johnsonii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_54388  rdfs:label  "Salmonella enterica subsp. enterica serovar Paratyphi A" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_11053  rdfs:label  "Dengue virus 1" ;
+        rdfs:subClassOf  obo:NCBITaxon_12637 .
+
+obo:NCBITaxon_33959  rdfs:label  "Lactobacillus johnsonii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_33706  rdfs:label  "Caviid betaherpesvirus 2" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_376619  rdfs:label  "Francisella tularensis subsp. holarctica LVS" ;
+        rdfs:subClassOf  obo:NCBITaxon_119857 ;
+        bae:altLabel     "Francisella tularensis subsp. holarctica str. LVS" , "Francisella tularensis subsp. holarctica strain LVS" .
+
+obo:NCBITaxon_1789  rdfs:label  "Mycobacterium xenopi" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_716544  rdfs:label  "Waddlia chondrophila WSU 86-1044" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Waddlia chondrophila str. WSU 86-1044" , "Waddlia chondrophila strain WSU 86-1044" .
+
+obo:NCBITaxon_34356  rdfs:label  "Kodamaea ohmeri" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_670  rdfs:label  "Vibrio parahaemolyticus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_10710  rdfs:label  "Escherichia virus Lambda" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_44129  rdfs:label  "Human rhinovirus A29" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_29170  rdfs:label  "Ancylostoma caninum" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "dog hookworm" .
+
+obo:NCBITaxon_42458  rdfs:label  "Lichtheimia corymbifera" ;
+        rdfs:subClassOf  obo:NCBITaxon_688353 .
+
+obo:NCBITaxon_10251  rdfs:label  "Vaccinia virus IHD-J" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_29348  rdfs:label  "[Clostridium] spiroforme" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium spiroforme" .
+
+obo:NCBITaxon_1549  rdfs:label  "[Clostridium] sporosphaeroides" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium sporosphaeroides" .
+
+obo:NCBITaxon_282458  rdfs:label  "Staphylococcus aureus subsp. aureus MRSA252" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 ;
+        bae:altLabel     "Staphylococcus aureus subsp. aureus str. MRSA252" , "Staphylococcus aureus subsp. aureus strain MRSA252" .
+
+obo:NCBITaxon_47763  rdfs:label  "Streptomyces lydicus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_648213  rdfs:label  "Influenza A virus (A/duck/Laos/25/2006(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_746128  rdfs:label  "Aspergillus fumigatus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_1309  rdfs:label  "Streptococcus mutans" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_44271  rdfs:label  "Leishmania chagasi" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_124763  rdfs:label  "Amaranthus retroflexus" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "common amaranth" , "redroot amaranth" , "rough pigweed" .
+
+obo:NCBITaxon_5580  rdfs:label  "Aureobasidium pullulans" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_12242  rdfs:label  "Tobacco mosaic virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_40382  rdfs:label  "Aspergillus ustus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_30069  rdfs:label  "Anopheles stephensi" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "Asian malaria mosquito" .
+
+obo:NCBITaxon_4943  rdfs:label  "Saccharomycopsis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_99822  rdfs:label  "Streptococcus dysgalactiae subsp. dysgalactiae" ;
+        rdfs:subClassOf  obo:NCBITaxon_1334 .
+
+obo:NCBITaxon_84586  rdfs:label  "Pseudomonas borealis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_464417  rdfs:label  "Influenza B virus (B/Malaysia/2506/2004)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11520 .
+
+obo:NCBITaxon_279010  rdfs:label  "Bacillus licheniformis DSM 13 = ATCC 14580" ;
+        rdfs:subClassOf  obo:NCBITaxon_1402 ;
+        bae:altLabel     "Bacillus licheniformis ATCC 14580 = DSM 13" .
+
+obo:NCBITaxon_5518  rdfs:label  "Fusarium graminearum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_4956  rdfs:label  "Zygosaccharomyces rouxii" ;
+        rdfs:subClassOf  obo:NCBITaxon_4953 .
+
+obo:NCBITaxon_3847  rdfs:label  "Glycine max" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "soybean" , "soybeans" .
+
+obo:NCBITaxon_12090  rdfs:label  "Human enterovirus 70" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_35305  rdfs:label  "California encephalitis virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5059  rdfs:label  "Aspergillus flavus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_31704  rdfs:label  "Coxsackievirus A16" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_114517  rdfs:label  "Aeromonas veronii bv. sobria" ;
+        rdfs:subClassOf  obo:NCBITaxon_654 ;
+        bae:altLabel     "Aeromonas veronii biovar sobria" .
+
+obo:NCBITaxon_10891  rdfs:label  "Reovirus sp." ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5825  rdfs:label  "Plasmodium chabaudi" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_642261  rdfs:label  "Influenza A virus (A/California/08/2009(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_694007  rdfs:label  "Tylonycteris bat coronavirus HKU4" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_147674  rdfs:label  "Human rhinovirus A18" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5660  rdfs:label  "Leishmania braziliensis" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_121769  rdfs:label  "Digitaria sanguinalis" ;
+        rdfs:subClassOf  bao:BAO_0000605 .
+
+obo:NCBITaxon_2039  rdfs:label  "Tropheryma whipplei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5838  rdfs:label  "Plasmodium falciparum FCR-3/Gambia" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_11760  rdfs:label  "Mouse mammary tumor virus (STRAIN GR)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11757 .
+
+obo:NCBITaxon_42858  rdfs:label  "Staphylococcus lentus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_1771  rdfs:label  "Mycolicibacterium phlei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_182082  rdfs:label  "Chlamydia pneumoniae TW-183" ;
+        rdfs:subClassOf  obo:NCBITaxon_83558 .
+
+obo:NCBITaxon_536  rdfs:label  "Chromobacterium violaceum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_529038  rdfs:label  "Influenza A virus (A/Idaho/01/2008(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_83557  rdfs:label  "Chlamydia caviae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1784  rdfs:label  "Mycobacterium simiae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11520  rdfs:label  "Influenza B virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1531  rdfs:label  "[Clostridium] clostridioforme" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium clostridioforme" .
+
+obo:NCBITaxon_185894  rdfs:label  "Human rhinovirus A15" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_4577  rdfs:label  "Zea mays" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "maize" .
+
+obo:NCBITaxon_11786  rdfs:label  "Murine leukemia virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_384  rdfs:label  "Rhizobium leguminosarum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1797  rdfs:label  "Mycolicibacterium thermoresistibile" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_169292  rdfs:label  "Corynebacterium aurimucosum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_186763  rdfs:label  "Plasmodium falciparum FcB1/Columbia" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_356411  rdfs:label  "Hepatitis C virus JFH-1" ;
+        rdfs:subClassOf  obo:NCBITaxon_31649 .
+
+obo:NCBITaxon_856  rdfs:label  "Fusobacterium varium" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Fusibacterium pseudonecrophorum" , "Fusibacterium varium" .
+
+obo:NCBITaxon_44137  rdfs:label  "Human rhinovirus B72" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5699  rdfs:label  "Trypanosoma vivax" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_105487  rdfs:label  "Valsa mali" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1304  rdfs:label  "Streptococcus salivarius" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_616  rdfs:label  "Serratia sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_164513  rdfs:label  "Mycobacterium tuberculosis 210" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_95162  rdfs:label  "Nocardia beijingensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Nocardia amycolata" .
+
+obo:NCBITaxon_64495  rdfs:label  "Rhizopus oryzae" ;
+        rdfs:subClassOf  obo:NCBITaxon_4842 .
+
+obo:NCBITaxon_285006  rdfs:label  "Saccharomyces cerevisiae RM11-1a" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_37936  rdfs:label  "Rhinocladiella aquaspersa" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_186536  rdfs:label  "Ebolavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_464  rdfs:label  "Fluoribacter gormanii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1624  rdfs:label  "Lactobacillus salivarius" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_31952  rdfs:label  "Streptomyces sp. R61" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_119947  rdfs:label  "Ulocladium" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_171101  rdfs:label  "Streptococcus pneumoniae R6" ;
+        rdfs:subClassOf  obo:NCBITaxon_1313 .
+
+obo:NCBITaxon_33895  rdfs:label  "Mycobacterium interjectum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_29908  rdfs:label  "Sporothrix schenckii" ;
+        rdfs:subClassOf  obo:NCBITaxon_29907 .
+
+obo:NCBITaxon_2287  rdfs:label  "Sulfolobus solfataricus" ;
+        rdfs:subClassOf  bae:BAE_0000065 .
+
+obo:NCBITaxon_114525  rdfs:label  "Saccharomyces mikatae" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_388799  rdfs:label  "HIV-1 group O" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_375446  rdfs:label  "Streptomyces sp. A012304" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_784  rdfs:label  "Orientia tsutsugamushi" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_67827  rdfs:label  "Citrobacter werkmanii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_76860  rdfs:label  "Streptococcus constellatus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_83552  rdfs:label  "Parachlamydia acanthamoebae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_73239  rdfs:label  "Plasmodium yoelii yoelii" ;
+        rdfs:subClassOf  obo:NCBITaxon_5861 .
+
+obo:NCBITaxon_1485  rdfs:label  "Clostridium" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_483687  rdfs:label  "Salmonella enterica subsp. enterica serovar Concord" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_544  rdfs:label  "Citrobacter" ;
+        rdfs:subClassOf  obo:NCBITaxon_543 .
+
+obo:NCBITaxon_703612  rdfs:label  "Bacillus subtilis subsp. spizizenii ATCC 6633" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Bacillus subtilis subsp. spizizenii str. ATCC 6633" , "Bacillus subtilis subsp. spizizenii strain ATCC 6633" .
+
+obo:NCBITaxon_11234  rdfs:label  "Measles morbillivirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_11706  rdfs:label  "HIV-1 M:B_HXB2R" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_851  rdfs:label  "Fusobacterium nucleatum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Fusibacterium nucleatum" .
+
+obo:NCBITaxon_1717  rdfs:label  "Corynebacterium diphtheriae" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_1258  rdfs:label  "Peptoniphilus asaccharolyticus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_329182  rdfs:label  "Influenza A virus (A/duck/Minnesota/1525/1981(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_79685  rdfs:label  "Avian erythroblastosis virus (strain ES4)" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_611  rdfs:label  "Salmonella enterica subsp. enterica serovar Heidelberg" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_147468  rdfs:label  "Staphylococcus sciuri subsp. carnaticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1296 .
+
+obo:NCBITaxon_12663  rdfs:label  "Feline coronavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1018  rdfs:label  "Capnocytophaga ochracea" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_97006  rdfs:label  "Trifolium alexandrinum" ;
+        rdfs:subClassOf  bao:BAO_0000605 .
+
+obo:NCBITaxon_37637  rdfs:label  "Corynebacterium pseudodiphtheriticum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_760787  rdfs:label  "Streptococcus pneumoniae GA17457" ;
+        rdfs:subClassOf  obo:NCBITaxon_1313 .
+
+obo:NCBITaxon_3708  rdfs:label  "Brassica napus" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "oilseed rape" , "rape" , "rapeseeds" .
+
+obo:NCBITaxon_9103  rdfs:label  "Meleagris gallopavo" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "common turkey" , "turkey" , "wild turkey" .
+
+obo:NCBITaxon_624  rdfs:label  "Shigella sonnei" ;
+        rdfs:subClassOf  obo:NCBITaxon_620 .
+
+obo:NCBITaxon_28090  rdfs:label  "Acinetobacter lwoffii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_290576  rdfs:label  "Colletotrichum lindemuthianum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1578  rdfs:label  "Lactobacillus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_31653  rdfs:label  "Hepatitis C virus subtype 4a" ;
+        rdfs:subClassOf  obo:NCBITaxon_33745 .
+
+obo:NCBITaxon_45574  rdfs:label  "[Candida] palmioleophila" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Candida palmioleophila" .
+
+obo:NCBITaxon_1352354
+        rdfs:label       "Pseudomonas aeruginosa PAO581" ;
+        rdfs:subClassOf  obo:NCBITaxon_287 .
+
+obo:NCBITaxon_307492  rdfs:label  "Aphis craccivora" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "cowpea aphid" .
+
+obo:NCBITaxon_645462  rdfs:label  "Clostridioides difficile CD196" ;
+        rdfs:subClassOf  obo:NCBITaxon_1496 ;
+        bae:altLabel     "Clostridium difficile str. CD196" , "Clostridium difficile strain CD196" .
+
+obo:NCBITaxon_185907  rdfs:label  "Human rhinovirus A39" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_12730  rdfs:label  "Human respirovirus 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_472  rdfs:label  "Acinetobacter sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1338  rdfs:label  "Streptococcus intermedius" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_873533  rdfs:label  "Prevotella oralis ATCC 33269" ;
+        rdfs:subClassOf  obo:NCBITaxon_28134 ;
+        bae:altLabel     "Prevotella oralis str. ATCC 33269" , "Prevotella oralis strain ATCC 33269" .
+
+obo:NCBITaxon_5062  rdfs:label  "Aspergillus oryzae" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_944  rdfs:label  "Ehrlichia canis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_485  rdfs:label  "Neisseria gonorrhoeae" ;
+        rdfs:subClassOf  obo:NCBITaxon_482 .
+
+obo:NCBITaxon_317025  rdfs:label  "Hydrogenovibrio crunogenus XCL-2" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_31973  rdfs:label  "Eggerthia catenaformis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_29916  rdfs:label  "Fusarium sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_5506 .
+
+obo:NCBITaxon_53442  rdfs:label  "Eubacterium callanderi" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_875052  rdfs:label  "Staphylococcus aureus VRS2" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_557599  rdfs:label  "Mycobacterium kansasii ATCC 12478" ;
+        rdfs:subClassOf  obo:NCBITaxon_1768 ;
+        bae:altLabel     "Mycobacterium kansasii str. ATCC 12478" , "Mycobacterium kansasii strain ATCC 12478" .
+
+obo:NCBITaxon_10360  rdfs:label  "Human herpesvirus 5 strain AD169" ;
+        rdfs:subClassOf  obo:NCBITaxon_10359 .
+
+obo:NCBITaxon_358743  rdfs:label  "[Clostridium] citroniae" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium citroniae" .
+
+obo:NCBITaxon_83560  rdfs:label  "Chlamydia muridarum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "agent of mouse pneumonitis" .
+
+obo:NCBITaxon_149539  rdfs:label  "Salmonella enterica subsp. enterica serovar Enteritidis" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_31274  rdfs:label  "Plasmodium yoelii nigeriensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_5861 .
+
+obo:NCBITaxon_388567  rdfs:label  "Cyperus iria" ;
+        rdfs:subClassOf  bao:BAO_0000605 .
+
+obo:NCBITaxon_90259  rdfs:label  "Rhizopus microsporus var. rhizopodiformis" ;
+        rdfs:subClassOf  obo:NCBITaxon_58291 .
+
+obo:NCBITaxon_9031  rdfs:label  "Gallus gallus" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "chicken" , "chickens" , "bantam" .
+
+obo:NCBITaxon_552  rdfs:label  "Erwinia amylovora" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_84135  rdfs:label  "Gemella sanguinis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1378 .
+
+obo:NCBITaxon_102862  rdfs:label  "Proteus penneri" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1253  rdfs:label  "Pediococcus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_3649  rdfs:label  "Carica papaya" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "mamon" , "papaya" .
+
+obo:NCBITaxon_29524  rdfs:label  "Porphyromonas circumdentaria" ;
+        rdfs:subClassOf  obo:NCBITaxon_836 .
+
+obo:NCBITaxon_565  rdfs:label  "Atlantibacter hermannii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1725  rdfs:label  "Corynebacterium xerosis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_83333  rdfs:label  "Escherichia coli K-12" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Escherichia coli K12" .
+
+obo:NCBITaxon_280498  rdfs:label  "Leptospira interrogans serovar Grippotyphosa" ;
+        rdfs:subClassOf  obo:NCBITaxon_173 .
+
+obo:NCBITaxon_117187  rdfs:label  "Fusarium verticillioides" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_6277  rdfs:label  "Acanthocheilonema viteae" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_11090  rdfs:label  "Yellow fever virus 17D" ;
+        rdfs:subClassOf  obo:NCBITaxon_11089 .
+
+obo:NCBITaxon_10912  rdfs:label  "Rotavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1279  rdfs:label  "Staphylococcus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_34393  rdfs:label  "Microsporum audouinii" ;
+        rdfs:subClassOf  obo:NCBITaxon_34392 .
+
+obo:NCBITaxon_160  rdfs:label  "Treponema pallidum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_419947  rdfs:label  "Mycobacterium tuberculosis H37Ra" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Mycobacterium tuberculosis str. H37Ra" , "Mycobacterium tuberculosis strain H37Ra" .
+
+obo:NCBITaxon_13705  rdfs:label  "Syncephalastrum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1320  rdfs:label  "Streptococcus sp. 'group G'" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_885  rdfs:label  "Desulfovibrio sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1201292
+        rdfs:label       "Enterococcus faecalis ATCC 29212" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_632  rdfs:label  "Yersinia pestis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5475  rdfs:label  "Candida <Saccharomycetales>" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Candida" .
+
+obo:NCBITaxon_29385  rdfs:label  "Staphylococcus saprophyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_33038  rdfs:label  "[Ruminococcus] gnavus" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Ruminococcus gnavus" .
+
+obo:NCBITaxon_8090  rdfs:label  "Oryzias latipes" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "medaka" , "Japanese rice fish" , "Japanese medaka" .
+
+obo:NCBITaxon_4113  rdfs:label  "Solanum tuberosum" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "potato" , "potatoes" .
+
+obo:NCBITaxon_173  rdfs:label  "Leptospira interrogans" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_10760  rdfs:label  "Enterobacteria phage T7" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_4838  rdfs:label  "Rhizomucor" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_7159  rdfs:label  "Aedes aegypti" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "yellow fever mosquito" .
+
+obo:NCBITaxon_8015  rdfs:label  "Salmonidae" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "salmonids" .
+
+obo:NCBITaxon_679895  rdfs:label  "Escherichia coli BW25113" ;
+        rdfs:subClassOf  obo:NCBITaxon_83333 ;
+        bae:altLabel     "Escherichia coli str. BW25113" , "Escherichia coli strain BW25113" .
+
+obo:NCBITaxon_11588  rdfs:label  "Rift Valley fever virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1599  rdfs:label  "Lactobacillus sakei" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_439334  rdfs:label  "Mycobacterium avium subsp. hominissuis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1764 .
+
+obo:NCBITaxon_480  rdfs:label  "Moraxella catarrhalis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1640  rdfs:label  "Listeria seeligeri" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_260799  rdfs:label  "Bacillus anthracis str. Sterne" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Bacillus anthracis (strain Sterne)" , "Bacillus anthracis Sterne" .
+
+obo:NCBITaxon_216591  rdfs:label  "Burkholderia cenocepacia J2315" ;
+        rdfs:subClassOf  obo:NCBITaxon_95486 ;
+        bae:altLabel     "Burkholderia cenocepacia str. J2315" .
+
+obo:NCBITaxon_41200  rdfs:label  "Bifidobacterium sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_1678 .
+
+obo:NCBITaxon_545651  rdfs:label  "Sporothrix globosa" ;
+        rdfs:subClassOf  obo:NCBITaxon_29907 .
+
+obo:NCBITaxon_29465  rdfs:label  "Veillonella" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_745376  rdfs:label  "Bacillus sp. BS-01" ;
+        rdfs:subClassOf  obo:NCBITaxon_1386 .
+
+obo:NCBITaxon_253  rdfs:label  "Chryseobacterium indologenes" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_3631  rdfs:label  "Abutilon theophrasti" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "velvetleaf" , "China jute" , "butterprint" , "Indian mallow" .
+
+obo:NCBITaxon_100886  rdfs:label  "Catenibacterium mitsuokai" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_7786  rdfs:label  "Torpedo" ;
+        rdfs:subClassOf  bao:BAO_0000518 .
+
+obo:NCBITaxon_135461  rdfs:label  "Bacillus subtilis subsp. subtilis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1423 .
+
+obo:NCBITaxon_1679  rdfs:label  "Bifidobacterium longum subsp. longum" ;
+        rdfs:subClassOf  obo:NCBITaxon_216816 .
+
+obo:NCBITaxon_28116  rdfs:label  "Bacteroides ovatus" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 .
+
+obo:NCBITaxon_10306  rdfs:label  "Human alphaherpesvirus 1 strain KOS" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1720  rdfs:label  "Corynebacterium sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_738  rdfs:label  "Glaesserella parasuis" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "[Haemophilus] parasuis" .
+
+obo:NCBITaxon_286784  rdfs:label  "Salmonella enterica subsp. enterica serovar Emek" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_42895  rdfs:label  "Enterobacter sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_547 .
+
+obo:NCBITaxon_1261  rdfs:label  "Peptostreptococcus anaerobius" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_37333  rdfs:label  "Nocardia transvalensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Nocardia transvaalensis" .
+
+obo:NCBITaxon_33903  rdfs:label  "Streptomyces avermitilis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_28129  rdfs:label  "Prevotella denticola" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_765953  rdfs:label  "Waddlia chondrophila 2032/99" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Waddlia chondrophila str. 2032/99" , "Waddlia chondrophila strain 2032/99" .
+
+obo:NCBITaxon_12078  rdfs:label  "Echovirus E11" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_2130  rdfs:label  "Ureaplasma urealyticum" ;
+        rdfs:subClassOf  obo:NCBITaxon_2129 .
+
+obo:NCBITaxon_135487  rdfs:label  "Nocardia cyriacigeorgica" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_410289  rdfs:label  "Mycobacterium bovis BCG str. Pasteur 1173P2" ;
+        rdfs:subClassOf  obo:NCBITaxon_33892 ;
+        bae:altLabel     "Mycobacterium bovis BCG Pasteur 1173P2" , "Mycobacterium bovis BCG strain Pasteur 1173P2" .
+
+obo:NCBITaxon_75553  rdfs:label  "Aspergillus viridinutans" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_11276  rdfs:label  "Vesicular stomatitis virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_33033  rdfs:label  "Parvimonas micra" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_12132  rdfs:label  "Human rhinovirus A89" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_8722  rdfs:label  "Bothrops asper" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "terciopelo" .
+
+obo:NCBITaxon_178876  rdfs:label  "Cryptococcus neoformans var. grubii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_254056  rdfs:label  "Fonsecaea monophora" ;
+        rdfs:subClassOf  obo:NCBITaxon_40354 .
+
+obo:NCBITaxon_599  rdfs:label  "Salmonella sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_590 .
+
+obo:NCBITaxon_1506  rdfs:label  "Clostridium sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_742689  rdfs:label  "Influenza A virus (A/Bethesda/956/2006(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_818  rdfs:label  "Bacteroides thetaiotaomicron" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 .
+
+obo:NCBITaxon_29318  rdfs:label  "Actinomyces neuii subsp. anitratus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_4846  rdfs:label  "Rhizopus stolonifer" ;
+        rdfs:subClassOf  obo:NCBITaxon_4842 .
+
+obo:NCBITaxon_5702  rdfs:label  "Trypanosoma brucei brucei" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_641501  rdfs:label  "Influenza A virus (A/California/04/2009(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_194  rdfs:label  "Campylobacter" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_223997  rdfs:label  "Murine norovirus 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_311339  rdfs:label  "Human herpesvirus 5 strain Toledo" ;
+        rdfs:subClassOf  obo:NCBITaxon_10359 .
+
+obo:NCBITaxon_1354  rdfs:label  "Enterococcus hirae" ;
+        rdfs:subClassOf  obo:NCBITaxon_1350 .
+
+obo:NCBITaxon_666  rdfs:label  "Vibrio cholerae" ;
+        rdfs:subClassOf  obo:NCBITaxon_662 .
+
+obo:NCBITaxon_5550  rdfs:label  "Trichophyton" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_680789  rdfs:label  "Influenza A virus (A/environment/Viet Nam/1203/2004(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_281920  rdfs:label  "Porphyromonas uenonis" ;
+        rdfs:subClassOf  obo:NCBITaxon_836 .
+
+obo:NCBITaxon_87883  rdfs:label  "Burkholderia multivorans" ;
+        rdfs:subClassOf  obo:NCBITaxon_87882 .
+
+obo:NCBITaxon_46472  rdfs:label  "Aspergillus versicolor" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_11191  rdfs:label  "Murine respirovirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5269  rdfs:label  "Ustilago" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_81051  rdfs:label  "Poria <basidiomycete fungus>" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Poria" .
+
+obo:NCBITaxon_176279  rdfs:label  "Staphylococcus epidermidis RP62A" ;
+        rdfs:subClassOf  obo:NCBITaxon_1282 ;
+        bae:altLabel     "Staphylococcus epidermidis strain RP62A" , "Staphylococcus epidermidis str. RP62A" .
+
+obo:NCBITaxon_5016  rdfs:label  "Bipolaris maydis" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "southern corn leaf blight pathogen" .
+
+obo:NCBITaxon_55601  rdfs:label  "Vibrio anguillarum" ;
+        rdfs:subClassOf  obo:NCBITaxon_662 .
+
+obo:NCBITaxon_114727  rdfs:label  "H1N1 subtype" ;
+        rdfs:subClassOf  obo:NCBITaxon_11320 .
+
+obo:NCBITaxon_28111  rdfs:label  "Bacteroides eggerthii" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 .
+
+obo:NCBITaxon_1421  rdfs:label  "Lysinibacillus sphaericus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_40837  rdfs:label  "Mycoplana ramosa" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_265872  rdfs:label  "Cowpox virus (Brighton Red)" ;
+        rdfs:subClassOf  obo:NCBITaxon_10243 .
+
+obo:NCBITaxon_12060  rdfs:label  "Echovirus E9" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1322345
+        rdfs:label       "Escherichia coli ATCC 25922" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_504904  rdfs:label  "Influenza A virus (A/Brisbane/59/2007(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_29486  rdfs:label  "Yersinia ruckeri" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_93061  rdfs:label  "Staphylococcus aureus subsp. aureus NCTC 8325" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 ;
+        bae:altLabel     "Staphylococcus aureus subsp. aureus str. NCTC 8325" , "Staphylococcus aureus subsp. aureus strain NCTC 8325" .
+
+obo:NCBITaxon_10314  rdfs:label  "Human herpesvirus 2 strain G" ;
+        rdfs:subClassOf  obo:NCBITaxon_10310 .
+
+obo:NCBITaxon_149390  rdfs:label  "Salmonella enterica subsp. enterica serovar London" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_12073  rdfs:label  "Coxsackievirus B4" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_246196  rdfs:label  "Mycolicibacterium smegmatis MC2 155" ;
+        rdfs:subClassOf  obo:NCBITaxon_1772 ;
+        bae:altLabel     "Mycobacterium smegmatis 'MC2 155'" .
+
+obo:NCBITaxon_162425  rdfs:label  "Aspergillus nidulans" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_664713  rdfs:label  "Influenza A virus (A/reassortant/NIBRG-14(Viet Nam/1194/2004 x Puerto Rico/8/1934)(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_287  rdfs:label  "Pseudomonas aeruginosa" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_28137  rdfs:label  "Prevotella veroralis" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_11983  rdfs:label  "Norwalk virus" ;
+        rdfs:subClassOf  obo:NCBITaxon_142786 .
+
+obo:NCBITaxon_4521  rdfs:label  "Lolium multiflorum" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "Italian ryegrass" .
+
+obo:NCBITaxon_170527  rdfs:label  "Measles virus genotype D6" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_12086  rdfs:label  "Human poliovirus 3" ;
+        rdfs:subClassOf  obo:NCBITaxon_138950 .
+
+obo:NCBITaxon_6280  rdfs:label  "Brugia pahangi" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_59823  rdfs:label  "Prevotella sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_759  rdfs:label  "Pasteurella sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_2097  rdfs:label  "Mycoplasma genitalium" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11908  rdfs:label  "Human T-cell leukemia virus type I" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_28903  rdfs:label  "Mycoplasma bovis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_113226  rdfs:label  "Pseudocercospora musae" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_4787  rdfs:label  "Phytophthora infestans" ;
+        rdfs:subClassOf  bao:BAO_0000662 ;
+        bae:altLabel     "potato late blight agent" , "potato late blight fungus" .
+
+obo:NCBITaxon_1282  rdfs:label  "Staphylococcus epidermidis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_32644  rdfs:label  "unidentified" ;
+        rdfs:subClassOf  bao:BAO_0000551 .
+
+obo:NCBITaxon_46018  rdfs:label  "Echovirus E7" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_356621  rdfs:label  "Salmonella enterica subsp. enterica serovar Westhampton" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_36080  rdfs:label  "Mucor circinelloides" ;
+        rdfs:subClassOf  obo:NCBITaxon_4830 .
+
+obo:NCBITaxon_813  rdfs:label  "Chlamydia trachomatis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_404933  rdfs:label  "Astrosporangium hypotensionis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5656  rdfs:label  "Crithidia fasciculata" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_29313  rdfs:label  "Mycobacterium shimoidei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_231958  rdfs:label  "Pythium debaryanum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_4841  rdfs:label  "Mucor racemosus" ;
+        rdfs:subClassOf  obo:NCBITaxon_4830 .
+
+obo:NCBITaxon_1767  rdfs:label  "Mycobacterium intracellulare" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_451516  rdfs:label  "Staphylococcus aureus subsp. aureus USA300_TCH1516" ;
+        rdfs:subClassOf  obo:NCBITaxon_367830 ;
+        bae:altLabel     "Staphylococcus aureus subsp. aureus str. USA300_TCH1516" , "Staphylococcus aureus subsp. aureus strain USA300_TCH1516" .
+
+obo:NCBITaxon_10407  rdfs:label  "Hepatitis B virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_105751  rdfs:label  "Aeromonas bestiarum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1527  rdfs:label  "Anaerocolumna aminovalerica" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1821  rdfs:label  "Nocardia sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_3505  rdfs:label  "Betula pendula" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "European white birch" , "white birch" .
+
+obo:NCBITaxon_229037  rdfs:label  "Proteus sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_99287  rdfs:label  "Salmonella enterica subsp. enterica serovar Typhimurium str. LT2" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Salmonella enterica subsp. enterica serovar Typhimurium strain LT2" , "Salmonella enterica subsp. enterica serovar Typhimurium strain LT2-LTL2" , "Salmonella enterica subsp. enterica serovar Typhimurium LT2" .
+
+obo:NCBITaxon_10255  rdfs:label  "Variola virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 ;
+        bae:altLabel     "smallpox" , "smallpox virus" , "small pox virus" .
+
+obo:NCBITaxon_186800  rdfs:label  "Fusarium reticulatum" ;
+        rdfs:subClassOf  obo:NCBITaxon_5506 .
+
+obo:NCBITaxon_1375  rdfs:label  "Aerococcus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_553174  rdfs:label  "Prevotella melaninogenica ATCC 25845" ;
+        rdfs:subClassOf  obo:NCBITaxon_28132 ;
+        bae:altLabel     "Prevotella melaninogenica strain ATCC 25845" , "Prevotella melaninogenica str. ATCC 25845" .
+
+obo:NCBITaxon_4921  rdfs:label  "Pichia norvegensis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1847  rdfs:label  "Pseudonocardia" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_722438  rdfs:label  "Mycoplasma pneumoniae FH" ;
+        rdfs:subClassOf  obo:NCBITaxon_2104 ;
+        bae:altLabel     "Mycoplasma pneumoniae str. FH" , "Mycoplasma pneumoniae strain FH" .
+
+obo:NCBITaxon_37919  rdfs:label  "Rhodococcus opacus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_42769  rdfs:label  "Coxsackievirus A10" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1682  rdfs:label  "Bifidobacterium longum subsp. infantis" ;
+        rdfs:subClassOf  obo:NCBITaxon_216816 .
+
+obo:NCBITaxon_5037  rdfs:label  "Histoplasma capsulatum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_5584  rdfs:label  "Exophiala jeanselmei" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_11137  rdfs:label  "Human coronavirus 229E" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_192956  rdfs:label  "Salmonella enterica subsp. enterica serovar Haifa" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_28132  rdfs:label  "Prevotella melaninogenica" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_283166  rdfs:label  "Bartonella henselae str. Houston-1" ;
+        rdfs:subClassOf  obo:NCBITaxon_38323 ;
+        bae:altLabel     "Bartonella henselae strain Houston-1" .
+
+obo:NCBITaxon_644888  rdfs:label  "Influenza A virus (A/Mexico/4604/2009(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_12081  rdfs:label  "Human poliovirus 1 Mahoney" ;
+        rdfs:subClassOf  obo:NCBITaxon_12080 .
+
+obo:NCBITaxon_5597  rdfs:label  "Scedosporium boydii" ;
+        rdfs:subClassOf  obo:NCBITaxon_41687 .
+
+obo:NCBITaxon_296738  rdfs:label  "Pneumonia virus of mice 15" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_103920  rdfs:label  "Guinea pig cytomegalovirus (strain 22122 / ATCC VR682) (GPCMV)" ;
+        rdfs:subClassOf  obo:NCBITaxon_33706 ;
+        bae:altLabel     "Guinea pig cytomegalovirus (strain 22122 / ATCC VR682)" .
+
+obo:NCBITaxon_505575  rdfs:label  "Influenza A virus (A/Texas/12/2007(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_10335  rdfs:label  "Human alphaherpesvirus 3" ;
+        rdfs:subClassOf  bao:BAO_0000232 ;
+        bae:altLabel     "Varicella-zoster virus" .
+
+obo:NCBITaxon_48409  rdfs:label  "Salmonella enterica subsp. enterica serovar Virchow" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_1290  rdfs:label  "Staphylococcus hominis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_312309  rdfs:label  "Aliivibrio fischeri ES114" ;
+        rdfs:subClassOf  obo:NCBITaxon_668 ;
+        bae:altLabel     "Vibrio fischeri str. ES114" , "Vibrio fischeri strain ES114" .
+
+obo:NCBITaxon_7588  rdfs:label  "Asteroidea" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "starfish" , "sea stars" , "starfishes" .
+
+obo:NCBITaxon_45464  rdfs:label  "Teladorsagia circumcincta" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_226185  rdfs:label  "Enterococcus faecalis V583" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Enterococcus faecalis str. V583" , "Enterococcus faecalis strain V583" .
+
+obo:NCBITaxon_13688  rdfs:label  "Novosphingobium capsulatum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_821  rdfs:label  "Bacteroides vulgatus" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 .
+
+obo:NCBITaxon_33945  rdfs:label  "Enterococcus avium" ;
+        rdfs:subClassOf  obo:NCBITaxon_1350 .
+
+obo:NCBITaxon_401614  rdfs:label  "Francisella tularensis subsp. novicida U112" ;
+        rdfs:subClassOf  obo:NCBITaxon_264 .
+
+obo:NCBITaxon_383379  rdfs:label  "Toxoplasma gondii RH" ;
+        rdfs:subClassOf  obo:NCBITaxon_5811 .
+
+obo:NCBITaxon_575584  rdfs:label  "Acinetobacter baumannii ATCC 19606 = CIP 70.34 = JCM 6841" ;
+        rdfs:subClassOf  obo:NCBITaxon_470 .
+
+obo:NCBITaxon_60552  rdfs:label  "Burkholderia vietnamiensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_87882 .
+
+obo:NCBITaxon_1522  rdfs:label  "[Clostridium] innocuum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium innocuum" .
+
+obo:NCBITaxon_86635  rdfs:label  "Rhizopus microsporus var. microsporus" ;
+        rdfs:subClassOf  obo:NCBITaxon_58291 .
+
+obo:NCBITaxon_24  rdfs:label  "Shewanella putrefaciens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_375  rdfs:label  "Bradyrhizobium japonicum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1788  rdfs:label  "Mycolicibacter terrae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_225855  rdfs:label  "Acinetobacter sp. An9" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1535  rdfs:label  "[Clostridium] leptum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium leptum" .
+
+obo:NCBITaxon_40520  rdfs:label  "Blautia obeum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_70803  rdfs:label  "Salmonella enterica subsp. enterica serovar Minnesota" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_309120  rdfs:label  "Dialister micraerophilus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_7108  rdfs:label  "Spodoptera frugiperda" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "fall armyworm" .
+
+obo:NCBITaxon_29347  rdfs:label  "[Clostridium] scindens" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium scindens" .
+
+obo:NCBITaxon_356415  rdfs:label  "Hepatitis C virus (isolate NZL1)" ;
+        rdfs:subClassOf  obo:NCBITaxon_356426 .
+
+obo:NCBITaxon_5272  rdfs:label  "Microbotryum violaceum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_7668  rdfs:label  "Strongylocentrotus purpuratus" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "purple sea urchin" , "purple urchin" .
+
+obo:NCBITaxon_53345  rdfs:label  "Enterococcus durans" ;
+        rdfs:subClassOf  obo:NCBITaxon_1350 .
+
+obo:NCBITaxon_57706  rdfs:label  "Citrobacter braakii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_901  rdfs:label  "Desulfovibrio piger" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_82519  rdfs:label  "Apiotrichum loubieri" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_119912  rdfs:label  "Salmonella enterica subsp. enterica serovar Choleraesuis" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_243277  rdfs:label  "Vibrio cholerae O1 biovar El Tor str. N16961" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Vibrio cholerae serotype O1 biotype ElTor strain N16961" , "Vibrio cholerae serotype O1 biotype El Tor strain N16961" , "Vibrio cholerae El Tor N16961" .
+
+obo:NCBITaxon_9940  rdfs:label  "Ovis aries" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "domestic sheep" , "sheep" , "wild sheep" , "lambs" .
+
+obo:NCBITaxon_1396  rdfs:label  "Bacillus cereus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5757  rdfs:label  "Acanthamoeba polyphaga" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_44742  rdfs:label  "Desulfovibrio fairfieldensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_40559  rdfs:label  "Botrytis cinerea" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_106654  rdfs:label  "Acinetobacter nosocomialis" ;
+        rdfs:subClassOf  obo:NCBITaxon_909768 .
+
+obo:NCBITaxon_425941  rdfs:label  "Prevotella nanceiensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_162387  rdfs:label  "Metapneumovirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_31649  rdfs:label  "Hepatitis C virus subtype 2a" ;
+        rdfs:subClassOf  obo:NCBITaxon_40271 .
+
+obo:NCBITaxon_5045  rdfs:label  "Acremonium sp. (in: Ascomycota)" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Acremonium sp. (Ascomycota)" .
+
+obo:NCBITaxon_10036  rdfs:label  "Mesocricetus auratus" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "Syrian golden hamster" , "golden hamster" , "Syrian hamster" , "Syrian golden hamsters" .
+
+obo:NCBITaxon_508528  rdfs:label  "Leptospira interrogans serovar Portlandvere" ;
+        rdfs:subClassOf  obo:NCBITaxon_173 .
+
+obo:NCBITaxon_45611  rdfs:label  "Psychrobacter frigidicola" ;
+        rdfs:subClassOf  obo:NCBITaxon_497 .
+
+obo:NCBITaxon_5811  rdfs:label  "Toxoplasma gondii" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_64300  rdfs:label  "Modoc virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1922  rdfs:label  "Streptomyces plicatus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_11158  rdfs:label  "Paramyxoviridae" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_95486  rdfs:label  "Burkholderia cenocepacia" ;
+        rdfs:subClassOf  obo:NCBITaxon_87882 .
+
+obo:NCBITaxon_563041  rdfs:label  "Helicobacter pylori G27" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Helicobacter pylori str. G27" , "Helicobacter pylori strain G27" .
+
+obo:NCBITaxon_566546  rdfs:label  "Escherichia coli W" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "E. coli W" , "Escherichia coli str. W" , "Escherichia coli strain W" .
+
+obo:NCBITaxon_1770  rdfs:label  "Mycobacterium avium subsp. paratuberculosis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1764 ;
+        bae:altLabel     "Mycobacterium avium paratuberculosis" .
+
+obo:NCBITaxon_39054  rdfs:label  "Enterovirus A71" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_229992  rdfs:label  "SARS coronavirus Frankfurt 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_33953  rdfs:label  "Clostridium aminobutyricum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_13443  rdfs:label  "Coffea arabica" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "arabica coffee" , "coffee" .
+
+obo:NCBITaxon_46506  rdfs:label  "Bacteroides stercoris" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 .
+
+obo:NCBITaxon_10369  rdfs:label  "Human herpesvirus 6 (strain GS)" ;
+        rdfs:subClassOf  obo:NCBITaxon_32603 .
+
+obo:NCBITaxon_74940  rdfs:label  "Oncorhynchus tshawytscha" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "king salmon" , "Chinook salmon" .
+
+obo:NCBITaxon_1783  rdfs:label  "Mycobacterium scrofulaceum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_548  rdfs:label  "Klebsiella aerogenes" ;
+        rdfs:subClassOf  obo:NCBITaxon_570 ;
+        bae:altLabel     "[Enterobacter] aerogenes" .
+
+obo:NCBITaxon_64633  rdfs:label  "Mycotypha microspora" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_11060  rdfs:label  "Dengue virus 2" ;
+        rdfs:subClassOf  obo:NCBITaxon_12637 .
+
+obo:NCBITaxon_868129  rdfs:label  "Prevotella bivia DSM 20514" ;
+        rdfs:subClassOf  obo:NCBITaxon_28125 ;
+        bae:altLabel     "Prevotella bivia strain DSM 20514" , "Prevotella bivia str. DSM 20514" .
+
+obo:NCBITaxon_184072  rdfs:label  "Cosenzaea myxofaciens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_150372  rdfs:label  "Escovopsis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_72570  rdfs:label  "Actinomadura sp. R39" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_90397  rdfs:label  "Echinochloa crus-galli" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "cockspur grass" , "barnyard grass" .
+
+obo:NCBITaxon_82514  rdfs:label  "Apiotrichum domesticum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_320286  rdfs:label  "Ascia monuste" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_1303  rdfs:label  "Streptococcus oralis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_334413  rdfs:label  "Finegoldia magna ATCC 29328" ;
+        rdfs:subClassOf  obo:NCBITaxon_1260 ;
+        bae:altLabel     "Finegoldia magna str. ATCC 29328" , "Finegoldia magna strain ATCC 29328" .
+
+obo:NCBITaxon_1332246
+        rdfs:label       "Houston virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_31631  rdfs:label  "Human coronavirus OC43" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_47770  rdfs:label  "Lactobacillus crispatus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_909768  rdfs:label  "Acinetobacter calcoaceticus/baumannii complex" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_615  rdfs:label  "Serratia marcescens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_241526  rdfs:label  "Candida africana" ;
+        rdfs:subClassOf  obo:NCBITaxon_5475 .
+
+obo:NCBITaxon_37463  rdfs:label  "Phoma" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_11099  rdfs:label  "Bovine viral diarrhea virus 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_244319  rdfs:label  "Escherichia coli O26:H11" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_337041  rdfs:label  "Alphapapillomavirus 9" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_74561  rdfs:label  "Coxsackievirus B6" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_4950  rdfs:label  "Torulaspora delbrueckii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_12721  rdfs:label  "Human immunodeficiency virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_509173  rdfs:label  "Acinetobacter baumannii AYE" ;
+        rdfs:subClassOf  obo:NCBITaxon_470 ;
+        bae:altLabel     "Acinetobacter baumannii str. AYE" , "Acinetobacter baumannii strain AYE" .
+
+obo:NCBITaxon_12262  rdfs:label  "Red clover mottle virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5778  rdfs:label  "Vermamoeba vermiformis" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_38345  rdfs:label  "Leptospira kirschneri serovar Grippotyphosa" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_208479  rdfs:label  "[Clostridium] bolteae" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium bolteae" .
+
+obo:NCBITaxon_28873  rdfs:label  "Camelpox virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5066  rdfs:label  "Aspergillus wentii" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_163011  rdfs:label  "Pseudomonas lini" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_555400  rdfs:label  "Influenza B virus (B/New York/22/2008)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11520 .
+
+obo:NCBITaxon_29907  rdfs:label  "Sporothrix" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1177  rdfs:label  "Nostoc" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_59300  rdfs:label  "Getah virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_10529  rdfs:label  "Human adenovirus 31" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_188539  rdfs:label  "Amphotropic murine leukemia virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_75750  rdfs:label  "Aspergillus sydowii" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_6954  rdfs:label  "Dermatophagoides farinae" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "American house dust mite" .
+
+obo:NCBITaxon_641809  rdfs:label  "Influenza A virus (A/California/07/2009(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_257758  rdfs:label  "Streptococcus pseudopneumoniae" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_526977  rdfs:label  "Bacillus cereus ATCC 4342" ;
+        rdfs:subClassOf  obo:NCBITaxon_1396 .
+
+obo:NCBITaxon_93036  rdfs:label  "Poa annua" ;
+        rdfs:subClassOf  bao:BAO_0000605 .
+
+obo:NCBITaxon_543  rdfs:label  "Enterobacteriaceae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1409  rdfs:label  "Bacillus sp. (in: Bacteria)" ;
+        rdfs:subClassOf  obo:NCBITaxon_1386 ;
+        bae:altLabel     "Bacillus sp." .
+
+obo:NCBITaxon_91365  rdfs:label  "Curvularia australiensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_5502 .
+
+obo:NCBITaxon_8932  rdfs:label  "Columba livia" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "rock dove" , "carrier pigeon" , "Columba domestica" , "domestic pigeon" , "rock pigeon" .
+
+obo:NCBITaxon_43987  rdfs:label  "Geotrichum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_5858  rdfs:label  "Plasmodium malariae" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_1791  rdfs:label  "Mycolicibacterium aurum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_12814  rdfs:label  "Respiratory syncytial virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_303  rdfs:label  "Pseudomonas putida" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_529058  rdfs:label  "Influenza A virus (A/Uruguay/716/2007(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_850  rdfs:label  "Fusobacterium mortiferum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "[Clostridium] rectum" , "Fusibacterium mortiferum" .
+
+obo:NCBITaxon_1716  rdfs:label  "Corynebacterium" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_106590  rdfs:label  "Cupriavidus necator" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11246  rdfs:label  "Bovine orthopneumovirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_4331  rdfs:label  "Protea" ;
+        rdfs:subClassOf  bao:BAO_0000605 .
+
+obo:NCBITaxon_37329  rdfs:label  "Nocardia farcinica" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_4509  rdfs:label  "Dactylis glomerata" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "cocksfoot" , "orchard grass" .
+
+obo:NCBITaxon_569  rdfs:label  "Hafnia alvei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_35658  rdfs:label  "Mastomys coucha" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "southern multimammate mouse" .
+
+obo:NCBITaxon_316  rdfs:label  "Pseudomonas stutzeri" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_79684  rdfs:label  "Microtus ochrogaster" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "prairie vole" , "prairie voles" .
+
+obo:NCBITaxon_147467  rdfs:label  "Staphylococcus sciuri subsp. sciuri" ;
+        rdfs:subClassOf  obo:NCBITaxon_1296 .
+
+obo:NCBITaxon_38020  rdfs:label  "marmosets" ;
+        rdfs:subClassOf  bao:BAO_0000362 .
+
+obo:NCBITaxon_29363  rdfs:label  "Clostridium paraputrificum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_82522  rdfs:label  "Cutaneotrichosporon mucoides" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_329  rdfs:label  "Ralstonia pickettii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1046577
+        rdfs:label       "Staphylococcus aureus C1" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Staphylococcus aureus str. C1" , "Staphylococcus aureus strain C1" .
+
+obo:NCBITaxon_37930  rdfs:label  "Glutamicibacter protophormiae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_876  rdfs:label  "Desulfovibrio desulfuricans" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1093900
+        rdfs:label       "Phialemoniopsis curvata" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1311  rdfs:label  "Streptococcus agalactiae" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_57975  rdfs:label  "Burkholderia thailandensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_3707  rdfs:label  "Brassica juncea" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "Indian mustard" , "brown mustard" .
+
+obo:NCBITaxon_623  rdfs:label  "Shigella flexneri" ;
+        rdfs:subClassOf  obo:NCBITaxon_620 ;
+        bae:altLabel     "Escherichia/Shigella flexneri" .
+
+obo:NCBITaxon_420174  rdfs:label  "Hepatitis C virus isolate HC-J4" ;
+        rdfs:subClassOf  obo:NCBITaxon_31647 .
+
+obo:NCBITaxon_508771  rdfs:label  "Toxoplasma gondii ME49" ;
+        rdfs:subClassOf  obo:NCBITaxon_5811 .
+
+obo:NCBITaxon_76405  rdfs:label  "Cunninghamella echinulata" ;
+        rdfs:subClassOf  obo:NCBITaxon_4852 .
+
+obo:NCBITaxon_290028  rdfs:label  "Human coronavirus HKU1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_7609  rdfs:label  "Marthasterias glacialis" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "spiny starfish" .
+
+obo:NCBITaxon_11313  rdfs:label  "Fowl plague virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_48100  rdfs:label  "Alternaria solani" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_636  rdfs:label  "Edwardsiella tarda" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_35725  rdfs:label  "Macrophomina phaseolina" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "charcoal rot" .
+
+obo:NCBITaxon_132504  rdfs:label  "Influenza A virus (A/X-31(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_5520  rdfs:label  "Microdochium nivale" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_29430  rdfs:label  "Acinetobacter haemolyticus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_471  rdfs:label  "Acinetobacter calcoaceticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_909768 .
+
+obo:NCBITaxon_5061  rdfs:label  "Aspergillus niger" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_948311  rdfs:label  "Fusarium proliferatum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1809  rdfs:label  "Mycobacterium ulcerans" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11161  rdfs:label  "Mumps virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5533  rdfs:label  "Rhodotorula" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_11886  rdfs:label  "Rous sarcoma virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_160404  rdfs:label  "Anaerotignum lactatifermentans" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "[Clostridium] lactatifermentans" .
+
+obo:NCBITaxon_80637  rdfs:label  "Coniophora puteana" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_10524  rdfs:label  "Human adenovirus 41" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_224308  rdfs:label  "Bacillus subtilis subsp. subtilis str. 168" ;
+        rdfs:subClassOf  obo:NCBITaxon_135461 .
+
+obo:NCBITaxon_198094  rdfs:label  "Bacillus anthracis str. Ames" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Bacillus anthracis (strain Ames)" , "Bacillus anthracis Ames" , "Bacillus anthracis strain Ames" .
+
+obo:NCBITaxon_43675  rdfs:label  "Rothia mucilaginosa" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_875051  rdfs:label  "Staphylococcus aureus VRS1" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_703  rdfs:label  "Plesiomonas shigelloides" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_497  rdfs:label  "Psychrobacter" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_358742  rdfs:label  "[Clostridium] aldenense" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium aldenense" .
+
+obo:NCBITaxon_7052  rdfs:label  "Aquatica lateralis" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "Japanese firefly" .
+
+obo:NCBITaxon_1404  rdfs:label  "Bacillus megaterium" ;
+        rdfs:subClassOf  obo:NCBITaxon_1386 .
+
+obo:NCBITaxon_9995  rdfs:label  "Marmota monax" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "groundhog" , "woodchucks" , "woodchuck" .
+
+obo:NCBITaxon_4909  rdfs:label  "Pichia kudriavzevii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1492  rdfs:label  "Clostridium butyricum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_440524  rdfs:label  "Salmonella enterica subsp. enterica serovar 4,[5],12:i:-" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_3888  rdfs:label  "Pisum sativum" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "garden pea" , "pea" , "peas" .
+
+obo:NCBITaxon_90258  rdfs:label  "Saksenaea vasiformis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_435591  rdfs:label  "Parabacteroides distasonis ATCC 8503" ;
+        rdfs:subClassOf  obo:NCBITaxon_823 ;
+        bae:altLabel     "Parabacteroides distasonis str. ATCC 8503" , "Parabacteroides distasonis strain ATCC 8503" .
+
+obo:NCBITaxon_342616  rdfs:label  "Streptococcus agalactiae COH1" ;
+        rdfs:subClassOf  obo:NCBITaxon_1311 ;
+        bae:altLabel     "Streptococcus agalactiae str. COH1" , "Streptococcus agalactiae strain COH1" .
+
+obo:NCBITaxon_28107  rdfs:label  "Pseudoalteromonas espejiana" ;
+        rdfs:subClassOf  obo:NCBITaxon_53246 .
+
+obo:NCBITaxon_46228  rdfs:label  "Ruminococcus lactaris" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5141  rdfs:label  "Neurospora crassa" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_729  rdfs:label  "Haemophilus parainfluenzae" ;
+        rdfs:subClassOf  obo:NCBITaxon_724 .
+
+obo:NCBITaxon_342451  rdfs:label  "Staphylococcus saprophyticus subsp. saprophyticus ATCC 15305" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Staphylococcus saprophyticus subsp. saprophyticus strain ATCC 15305" , "Staphylococcus saprophyticus subsp. saprophyticus str. ATCC 15305" .
+
+obo:NCBITaxon_31286  rdfs:label  "Trypanosoma brucei rhodesiense" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_29523  rdfs:label  "Bacteroides sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_816 .
+
+obo:NCBITaxon_9515  rdfs:label  "Sapajus apella" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "Tufted capuchin" , "brown-capped capuchin" , "black-capped capuchin" , "brown capuchin" .
+
+obo:NCBITaxon_83332  rdfs:label  "Mycobacterium tuberculosis H37Rv" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Mycobacterium tuberculosis str. H37Rv" , "Mycobacterium tuberculosis strain H37Rv" .
+
+obo:NCBITaxon_36050  rdfs:label  "Fusarium poae" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1265  rdfs:label  "Ruminococcus flavefaciens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_33011  rdfs:label  "Cutibacterium granulosum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11726  rdfs:label  "Simian immunodeficiency virus - agm" ;
+        rdfs:subClassOf  obo:NCBITaxon_11723 .
+
+obo:NCBITaxon_4058  rdfs:label  "Catharanthus roseus" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "old-maid" , "chula" , "rosy periwinkle" , "Madagascar periwinkle" , "chatas" .
+
+obo:NCBITaxon_1439707
+        rdfs:label       "Respiratory syncytial virus type A" ;
+        rdfs:subClassOf  obo:NCBITaxon_12814 .
+
+obo:NCBITaxon_34392  rdfs:label  "Microsporum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_431947  rdfs:label  "Porphyromonas gingivalis ATCC 33277" ;
+        rdfs:subClassOf  obo:NCBITaxon_837 ;
+        bae:altLabel     "Porphyromonas gingivalis str. ATCC 33277" , "Porphyromonas gingivalis strain ATCC 33277" .
+
+obo:NCBITaxon_469008  rdfs:label  "Escherichia coli BL21(DE3)" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Escherichia coli str. BL21(DE3)" , "Escherichia coli strain BL21(DE3)" .
+
+obo:NCBITaxon_35720  rdfs:label  "Thielavia terrestris" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_33037  rdfs:label  "Anaerococcus vaginalis" ;
+        rdfs:subClassOf  obo:NCBITaxon_165779 .
+
+obo:NCBITaxon_369723  rdfs:label  "Salinispora tropica CNB-440" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Salinispora tropica str. CNB-440" , "Salinispora tropica strain CNB-440" .
+
+obo:NCBITaxon_41857  rdfs:label  "Influenza A virus H3N2" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_145393  rdfs:label  "Staphylococcus hominis subsp. novobiosepticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1290 .
+
+obo:NCBITaxon_644  rdfs:label  "Aeromonas hydrophila" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_379755  rdfs:label  "Influenza A virus (A/Yamagata/32/1989(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_11587  rdfs:label  "Punta Toro virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1598  rdfs:label  "Lactobacillus reuteri" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_28035  rdfs:label  "Staphylococcus lugdunensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_593905  rdfs:label  "Salmonella enterica subsp. enterica serovar Corvallis" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_272947  rdfs:label  "Rickettsia prowazekii str. Madrid E" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Rickettsia prowazekii 'Madrid E'" , "Rickettsia prowazekii strain Madrid E" .
+
+obo:NCBITaxon_45594  rdfs:label  "[Candida] stellata" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Candida stellata" .
+
+obo:NCBITaxon_187420  rdfs:label  "Methanothermobacter thermautotrophicus str. Delta H" ;
+        rdfs:subClassOf  obo:NCBITaxon_145262 ;
+        bae:altLabel     "Methanobacterium thermoautotrophicum str. Delta H" , "Methanothermobacter thermautotrophicus str. deltaH" .
+
+obo:NCBITaxon_33528  rdfs:label  "Gambusia affinis" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "western mosquitofish" .
+
+obo:NCBITaxon_1358  rdfs:label  "Lactococcus lactis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1652  rdfs:label  "Alloiococcus otitis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_91061  rdfs:label  "Bacilli" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_9443  rdfs:label  "Primates" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "primate" .
+
+obo:NCBITaxon_45354  rdfs:label  "[Candida] intermedia" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Candida intermedia" .
+
+obo:NCBITaxon_39483  rdfs:label  "Faecalitalea cylindroides" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_467705  rdfs:label  "Streptococcus gordonii str. Challis substr. CH1" ;
+        rdfs:subClassOf  obo:NCBITaxon_29390 .
+
+obo:NCBITaxon_526980  rdfs:label  "Bacillus cereus ATCC 10876" ;
+        rdfs:subClassOf  obo:NCBITaxon_1396 .
+
+obo:NCBITaxon_54571  rdfs:label  "Streptomyces venezuelae" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 ;
+        bae:altLabel     "Streptomyces venezuelensis" .
+
+obo:NCBITaxon_35519  rdfs:label  "Mogibacterium timidum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_53462  rdfs:label  "Mycolicibacterium mageritense" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_724  rdfs:label  "Haemophilus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_85963  rdfs:label  "Helicobacter pylori J99" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Helicobacter pylori str. J99" , "Helicobacter pylori strain J99" .
+
+obo:NCBITaxon_31281  rdfs:label  "Enterocytozoon bieneusi" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_5861  rdfs:label  "Plasmodium yoelii" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_42881  rdfs:label  "Streptomyces chromofuscus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_28115  rdfs:label  "Porphyromonas macacae" ;
+        rdfs:subClassOf  obo:NCBITaxon_836 .
+
+obo:NCBITaxon_1678  rdfs:label  "Bifidobacterium" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_205488  rdfs:label  "Ebola virus sp." ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_69820  rdfs:label  "Spodoptera litura" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_40410  rdfs:label  "Cryptococcus neoformans var. neoformans" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_502800  rdfs:label  "Yersinia pseudotuberculosis YPIII" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Yersinia pseudotuberculosis str. YPIII" , "Yersinia pseudotuberculosis strain YPIII" .
+
+obo:NCBITaxon_27300  rdfs:label  "Schwanniomyces occidentalis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_89153  rdfs:label  "[Clostridium] hylemonae" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium hylemonae" .
+
+obo:NCBITaxon_103903  rdfs:label  "Coxsackievirus B3 (strain Nancy)" ;
+        rdfs:subClassOf  obo:NCBITaxon_12072 .
+
+obo:NCBITaxon_1260  rdfs:label  "Finegoldia magna" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_28128  rdfs:label  "Prevotella corporis" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_364106  rdfs:label  "Escherichia coli UTI89" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Escherichia coli str. UTI89" , "Escherichia coli strain UTI89" .
+
+obo:NCBITaxon_509207  rdfs:label  "Botryosphaeria berengeriana" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_557433  rdfs:label  "Lactobacillus reuteri JCM 1112" ;
+        rdfs:subClassOf  obo:NCBITaxon_1598 ;
+        bae:altLabel     "Lactobacillus reuteri strain JCM 1112" , "Lactobacillus reuteri str. JCM 1112" .
+
+obo:NCBITaxon_81847  rdfs:label  "Trichophyton quinckeanum" ;
+        rdfs:subClassOf  obo:NCBITaxon_5550 .
+
+obo:NCBITaxon_585  rdfs:label  "Proteus vulgaris" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_27326  rdfs:label  "Metschnikowia pulcherrima" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_283763  rdfs:label  "Planorbella trivolvis" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_33203  rdfs:label  "Purpureocillium lilacinum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_12131  rdfs:label  "Rhinovirus B14" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1286  rdfs:label  "Staphylococcus simulans" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_33032  rdfs:label  "Anaerococcus lactolyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_165779 .
+
+obo:NCBITaxon_81682  rdfs:label  "Methylovorus" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Methylivorus" .
+
+obo:NCBITaxon_40271  rdfs:label  "Hepatitis C virus genotype 2" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1580  rdfs:label  "Lactobacillus brevis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_208348  rdfs:label  "Puccinia triticina" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "wheat leaf rust" .
+
+obo:NCBITaxon_47678  rdfs:label  "Bacteroides caccae" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 .
+
+obo:NCBITaxon_1505  rdfs:label  "Paeniclostridium sordellii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5482  rdfs:label  "Candida tropicalis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_461779  rdfs:label  "Influenza A virus (A/Georgia/17/2006(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_817  rdfs:label  "Bacteroides fragilis" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 .
+
+obo:NCBITaxon_7625  rdfs:label  "Echinoidea" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "sea urchins" .
+
+obo:NCBITaxon_142786  rdfs:label  "Norovirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_358  rdfs:label  "Agrobacterium tumefaciens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_29317  rdfs:label  "Actinomyces sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_1654 .
+
+obo:NCBITaxon_672379  rdfs:label  "Influenza A virus (A/Florida/01/2009(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_411464  rdfs:label  "Desulfovibrio piger ATCC 29098" ;
+        rdfs:subClassOf  obo:NCBITaxon_901 ;
+        bae:altLabel     "Desulfovibrio piger str. ATCC 29098" , "Desulfovibrio piger strain ATCC 29098" .
+
+obo:NCBITaxon_155892  rdfs:label  "Caulobacter vibrioides" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_8022  rdfs:label  "Oncorhynchus mykiss" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "rainbow trout" .
+
+obo:NCBITaxon_28502  rdfs:label  "Amaranthus hypochondriacus" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "grain amaranth" , "prince's feather" .
+
+obo:NCBITaxon_11801  rdfs:label  "Moloney murine leukemia virus" ;
+        rdfs:subClassOf  obo:NCBITaxon_11786 .
+
+obo:NCBITaxon_596781  rdfs:label  "Chlamydia trachomatis J/UW-36" ;
+        rdfs:subClassOf  obo:NCBITaxon_813 ;
+        bae:altLabel     "Chlamydia trachomatis str. J/UW-36" , "Chlamydia trachomatis strain J/UW-36" .
+
+obo:NCBITaxon_1353  rdfs:label  "Enterococcus gallinarum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1350 .
+
+obo:NCBITaxon_119676  rdfs:label  "Nannizzia nana" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_43131  rdfs:label  "Tissierella praeacuta" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_35295  rdfs:label  "Echovirus E4" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_474186  rdfs:label  "Enterococcus faecalis OG1RF" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Enterococcus faecalis str. OG1RF" , "Enterococcus faecalis strain OG1RF" .
+
+obo:NCBITaxon_39950  rdfs:label  "Dialister pneumosintes" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_678  rdfs:label  "Vibrio sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_662 .
+
+obo:NCBITaxon_587884  rdfs:label  "Influenza A virus (A/Sydney/5/1997(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_36329  rdfs:label  "Plasmodium falciparum 3D7" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_1660  rdfs:label  "Actinomyces odontolyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1654 .
+
+obo:NCBITaxon_224324  rdfs:label  "Aquifex aeolicus VF5" ;
+        rdfs:subClassOf  obo:NCBITaxon_63363 .
+
+obo:NCBITaxon_87882  rdfs:label  "Burkholderia cepacia complex" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_39491  rdfs:label  "[Eubacterium] rectale" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Eubacterium rectale" .
+
+obo:NCBITaxon_593939  rdfs:label  "Influenza A virus (A/Florida/21/2008(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_88916  rdfs:label  "Borreliella spielmanii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_37998  rdfs:label  "Parengyodontium album" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_381518  rdfs:label  "Influenza A virus (A/Wilson-Smith/1933(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_28110  rdfs:label  "Francisella philomiragia" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_101202  rdfs:label  "Microsporum distortum" ;
+        rdfs:subClassOf  obo:NCBITaxon_34392 .
+
+obo:NCBITaxon_380703  rdfs:label  "Aeromonas hydrophila subsp. hydrophila ATCC 7966" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Aeromonas hydrophila subsp. hydrophila str. ATCC 7966" , "Aeromonas hydrophila subsp. hydrophila strain ATCC 7966" .
+
+obo:NCBITaxon_272563  rdfs:label  "Clostridioides difficile 630" ;
+        rdfs:subClassOf  obo:NCBITaxon_1496 ;
+        bae:altLabel     "Clostridium difficile 630 (epidemic type X)" , "Clostridium difficile str. 630" , "Clostridium difficile strain 630" .
+
+obo:NCBITaxon_732  rdfs:label  "Aggregatibacter aphrophilus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_192222  rdfs:label  "Campylobacter jejuni subsp. jejuni NCTC 11168 = ATCC 700819" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Campylobacter jejuni subsp. jejuni ATCC 700819 = NCTC 11168" .
+
+obo:NCBITaxon_358771  rdfs:label  "Salmonella enterica subsp. enterica serovar Kedougou" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_505553  rdfs:label  "Influenza A virus (A/New Jersey/15/2007(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_28123  rdfs:label  "Porphyromonas asaccharolytica" ;
+        rdfs:subClassOf  obo:NCBITaxon_836 .
+
+obo:NCBITaxon_10313  rdfs:label  "Human herpesvirus 2 strain 333" ;
+        rdfs:subClassOf  obo:NCBITaxon_10310 .
+
+obo:NCBITaxon_12072  rdfs:label  "Coxsackievirus B3" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_152480  rdfs:label  "Burkholderia ambifaria" ;
+        rdfs:subClassOf  obo:NCBITaxon_87882 .
+
+obo:NCBITaxon_11688  rdfs:label  "Human immunodeficiency virus type 1 (JRCSF ISOLATE)" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_28136  rdfs:label  "Prevotella oulorum" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_10326  rdfs:label  "Equid alphaherpesvirus 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 ;
+        bae:altLabel     "Equine herpesvirus 1" .
+
+obo:NCBITaxon_5807  rdfs:label  "Cryptosporidium parvum" ;
+        rdfs:subClassOf  obo:NCBITaxon_5806 .
+
+obo:NCBITaxon_2096  rdfs:label  "Mycoplasma gallisepticum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11907  rdfs:label  "Bovine leukemia virus (JAPANESE ISOLATE BLV-1)" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_43771  rdfs:label  "Corynebacterium urealyticum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 ;
+        bae:altLabel     "Corynebacterium ureailyticum" .
+
+obo:NCBITaxon_1281  rdfs:label  "Staphylococcus carnosus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_11448  rdfs:label  "Influenza A virus (A/parrot/Ulster/73(H7N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_11742  rdfs:label  "Visna lentivirus (strain 1514)" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_66527  rdfs:label  "Balamuthia mandrillaris" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_89940  rdfs:label  "Cladophialophora bantiana" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_76122  rdfs:label  "Alloprevotella tannerae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_518  rdfs:label  "Bordetella bronchiseptica" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_519082  rdfs:label  "Influenza A virus (A/New York/107/2003(H7N2))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_4840  rdfs:label  "Rhizomucor pusillus" ;
+        rdfs:subClassOf  obo:NCBITaxon_4838 .
+
+obo:NCBITaxon_634468  rdfs:label  "Escherichia coli HB101" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Escherichia coli str. HB101" , "Escherichia coli strain HB101" .
+
+obo:NCBITaxon_1766  rdfs:label  "Mycolicibacterium fortuitum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_9557  rdfs:label  "Papio hamadryas" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "Papio hamadryas subsp." , "western baboon" , "red baboon" , "hamadryas baboon" , "baboon" .
+
+obo:NCBITaxon_393902  rdfs:label  "Influenza A virus (A/Wisconsin/67/2005(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_13274  rdfs:label  "Stellaria media" ;
+        rdfs:subClassOf  bao:BAO_0000605 .
+
+obo:NCBITaxon_9864  rdfs:label  "Cervus canadensis nelsoni" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "American elk" .
+
+obo:NCBITaxon_83681  rdfs:label  "Nonomuraea" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_838  rdfs:label  "Prevotella" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_118562  rdfs:label  "Arthrospira platensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_43304  rdfs:label  "Mycolicibacterium peregrinum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_12637  rdfs:label  "Dengue virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5722  rdfs:label  "Trichomonas vaginalis" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_1539  rdfs:label  "Clostridium malenominatum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_11069  rdfs:label  "Dengue virus 3" ;
+        rdfs:subClassOf  obo:NCBITaxon_12637 .
+
+obo:NCBITaxon_506350  rdfs:label  "Influenza A virus (A/Hong Kong/1/1968(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_10254  rdfs:label  "Vaccinia virus WR" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_387161  rdfs:label  "Influenza A virus (A/Japan/305/1957(H2N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114729 .
+
+obo:NCBITaxon_89014  rdfs:label  "Blautia luti" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_381513  rdfs:label  "Influenza A virus (A/Panama/2007/1999(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_139  rdfs:label  "Borreliella burgdorferi" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Lyme disease spirochete" , "Borrelia burgdorferi sensu stricto" .
+
+obo:NCBITaxon_59750  rdfs:label  "Mycolicibacterium wolinskyi" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_2702  rdfs:label  "Gardnerella vaginalis" ;
+        rdfs:subClassOf  obo:NCBITaxon_2701 .
+
+obo:NCBITaxon_36809  rdfs:label  "Mycobacteroides abscessus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1681  rdfs:label  "Bifidobacterium bifidum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1678 .
+
+obo:NCBITaxon_56689  rdfs:label  "Mycolicibacterium mucogenicum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_446  rdfs:label  "Legionella pneumophila" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_351256  rdfs:label  "Influenza A virus (A/Hong Kong/7/1987(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_740  rdfs:label  "Haemophilus sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_724 .
+
+obo:NCBITaxon_688353  rdfs:label  "Lichtheimia" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_192955  rdfs:label  "Salmonella enterica subsp. enterica serovar Kentucky" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_108329  rdfs:label  "Macrophoma" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_28131  rdfs:label  "Prevotella intermedia" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_1694  rdfs:label  "Bifidobacterium pseudolongum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1678 .
+
+obo:NCBITaxon_322095  rdfs:label  "Porphyromonas somerae" ;
+        rdfs:subClassOf  obo:NCBITaxon_836 .
+
+obo:NCBITaxon_85698  rdfs:label  "Achromobacter xylosoxidans" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Alcaligenes xylosoxydans" , "Achromobacter xylosoxydans" .
+
+obo:NCBITaxon_459  rdfs:label  "Legionella sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5802  rdfs:label  "Eimeria tenella" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_12080  rdfs:label  "Human poliovirus 1" ;
+        rdfs:subClassOf  obo:NCBITaxon_138950 .
+
+obo:NCBITaxon_11149  rdfs:label  "Transmissible gastroenteritis virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_294  rdfs:label  "Pseudomonas fluorescens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_10334  rdfs:label  "Felid alphaherpesvirus 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_4959  rdfs:label  "Debaryomyces hansenii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1290428
+        rdfs:label       "Rickettsia prowazekii str. Breinl" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Rickettsia prowazekii Breinl" .
+
+obo:NCBITaxon_145262  rdfs:label  "Methanothermobacter thermautotrophicus" ;
+        rdfs:subClassOf  bae:BAE_0000065 .
+
+obo:NCBITaxon_138282  rdfs:label  "Aspergillus sclerotiorum" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_33178  rdfs:label  "Aspergillus terreus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_84109  rdfs:label  "Slackia exigua" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_820  rdfs:label  "Bacteroides uniformis" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 .
+
+obo:NCBITaxon_129132  rdfs:label  "Cutaneotrichosporon dermatis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_5663  rdfs:label  "Leishmania enriettii" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_1047171
+        rdfs:label       "Zymoseptoria tritici" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_361  rdfs:label  "Agrobacterium sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11216  rdfs:label  "Human respirovirus 3" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_643680  rdfs:label  "Saccharomyces cerevisiae EC1118" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_68766  rdfs:label  "Fusobacterium sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_2336  rdfs:label  "Thermotoga maritima" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_120957  rdfs:label  "Nocardia abscessus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1774  rdfs:label  "Mycobacteroides chelonae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_195103  rdfs:label  "Clostridium perfringens ATCC 13124" ;
+        rdfs:subClassOf  obo:NCBITaxon_1502 ;
+        bae:altLabel     "Clostridium perfringens str. ATCC 13124" , "Clostridium perfringens strain ATCC 13124" .
+
+obo:NCBITaxon_280500  rdfs:label  "Leptospira interrogans serovar Pyrogenes" ;
+        rdfs:subClassOf  obo:NCBITaxon_173 .
+
+obo:NCBITaxon_150056  rdfs:label  "Staphylococcus fleurettii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_5970  rdfs:label  "Exophiala dermatitidis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1787  rdfs:label  "Mycobacterium szulgai" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_61673  rdfs:label  "Porcine endogenous retrovirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5689  rdfs:label  "Leishmania tarentolae" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_7107  rdfs:label  "Spodoptera exigua" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "beet armyworm" , "pigweed caterpillar" , "small mottled willow caterpillar" .
+
+obo:NCBITaxon_119857  rdfs:label  "Francisella tularensis subsp. holarctica" ;
+        rdfs:subClassOf  obo:NCBITaxon_263 .
+
+obo:NCBITaxon_71452  rdfs:label  "Enterococcus raffinosus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1350 .
+
+obo:NCBITaxon_158879  rdfs:label  "Staphylococcus aureus subsp. aureus N315" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 .
+
+obo:NCBITaxon_1547  rdfs:label  "Erysipelatoclostridium ramosum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_63363  rdfs:label  "Aquifex aeolicus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_859  rdfs:label  "Fusobacterium necrophorum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Fusibacterium necrophorum" .
+
+obo:NCBITaxon_7667  rdfs:label  "Strongylocentrotus intermedius" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_176281  rdfs:label  "Listeria monocytogenes ATCC 19115" ;
+        rdfs:subClassOf  obo:NCBITaxon_1639 .
+
+obo:NCBITaxon_34839  rdfs:label  "Chinchilla lanigera" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "long-tailed chinchilla" .
+
+obo:NCBITaxon_6305  rdfs:label  "Meloidogyne hapla" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_1382  rdfs:label  "Atopobium parvulum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_82518  rdfs:label  "Cutaneotrichosporon jirovecii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_35783  rdfs:label  "Enterococcus sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_1350 .
+
+obo:NCBITaxon_40545  rdfs:label  "Sutterella wadsworthensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1307  rdfs:label  "Streptococcus suis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_84024  rdfs:label  "Clostridium disporicum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_45303  rdfs:label  "Alternaria infectoria" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_40380  rdfs:label  "Aspergillus ochraceus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_38323  rdfs:label  "Bartonella henselae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5503  rdfs:label  "Curvularia lunata" ;
+        rdfs:subClassOf  obo:NCBITaxon_5502 .
+
+obo:NCBITaxon_11309  rdfs:label  "unidentified influenza virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1867  rdfs:label  "Actinoplanes teichomyceticus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_511693  rdfs:label  "Escherichia coli BL21" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Escherichia coli str. BL21" , "Escherichia coli strain BL21" .
+
+obo:NCBITaxon_11691  rdfs:label  "Human immunodeficiency virus type 1 (SF162 ISOLATE)" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_42789  rdfs:label  "Enterovirus D68" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_231640  rdfs:label  "Puccinia asparagi" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_5057  rdfs:label  "Aspergillus clavatus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_66948  rdfs:label  "Meyerozyma caribbica" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_33632  rdfs:label  "Babesia gibsoni" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_67345  rdfs:label  "Streptomyces prasinus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_95485  rdfs:label  "Burkholderia stabilis" ;
+        rdfs:subClassOf  obo:NCBITaxon_87882 .
+
+obo:NCBITaxon_5823  rdfs:label  "Plasmodium berghei ANKA" ;
+        rdfs:subClassOf  obo:NCBITaxon_5821 .
+
+obo:NCBITaxon_748136  rdfs:label  "Influenza A virus (A/Oklahoma/3052/2009(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_694005  rdfs:label  "Murine coronavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_160488  rdfs:label  "Pseudomonas putida KT2440" ;
+        rdfs:subClassOf  obo:NCBITaxon_303 .
+
+obo:NCBITaxon_169388  rdfs:label  "Fusarium solani" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_179879  rdfs:label  "Burkholderia anthina" ;
+        rdfs:subClassOf  obo:NCBITaxon_87882 .
+
+obo:NCBITaxon_879243  rdfs:label  "Porphyromonas asaccharolytica DSM 20707" ;
+        rdfs:subClassOf  obo:NCBITaxon_28123 ;
+        bae:altLabel     "Porphyromonas asaccharolytica strain DSM 20707" , "Porphyromonas asaccharolytica str. DSM 20707" .
+
+obo:NCBITaxon_5671  rdfs:label  "Leishmania infantum" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_29581  rdfs:label  "Janthinobacterium lividum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1488  rdfs:label  "Clostridium acetobutylicum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_666260  rdfs:label  "Influenza A virus (A/North Carolina/02/2009(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_1118959
+        rdfs:label       "Staphylococcus aureus subsp. aureus M013" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 ;
+        bae:altLabel     "Staphylococcus aureus subsp. aureus str. M013" , "Staphylococcus aureus subsp. aureus strain M013" .
+
+obo:NCBITaxon_6499  rdfs:label  "Aplysia" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_547  rdfs:label  "Enterobacter" ;
+        rdfs:subClassOf  obo:NCBITaxon_543 .
+
+obo:NCBITaxon_561307  rdfs:label  "Staphylococcus aureus subsp. aureus RN4220" ;
+        rdfs:subClassOf  obo:NCBITaxon_93061 ;
+        bae:altLabel     "Staphylococcus aureus subsp. aureus str. RN4220" , "Staphylococcus aureus subsp. aureus strain RN4220" .
+
+obo:NCBITaxon_426430  rdfs:label  "Staphylococcus aureus subsp. aureus str. Newman" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 ;
+        bae:altLabel     "Staphylococcus aureus subsp. aureus strain Newman" .
+
+obo:NCBITaxon_2104  rdfs:label  "Mycoplasma pneumoniae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_31870  rdfs:label  "Colletotrichum graminicola" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_29519  rdfs:label  "Borreliella garinii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11709  rdfs:label  "Human immunodeficiency virus 2" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_11072  rdfs:label  "Japanese encephalitis virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_441771  rdfs:label  "Clostridium botulinum A str. Hall" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium botulinum A strain Hall" .
+
+obo:NCBITaxon_5697  rdfs:label  "Trypanosoma evansi" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_102617  rdfs:label  "Helicobacter pylori SS1" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_29354  rdfs:label  "[Clostridium] celerecrescens" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium celerecrescens" , "Clostridium celericrescens" .
+
+obo:NCBITaxon_1302  rdfs:label  "Streptococcus gordonii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_614  rdfs:label  "Serratia liquefaciens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_35703  rdfs:label  "Citrobacter amalonaticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_544 .
+
+obo:NCBITaxon_1390  rdfs:label  "Bacillus amyloliquefaciens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_34388  rdfs:label  "Trichophyton violaceum" ;
+        rdfs:subClassOf  obo:NCBITaxon_5550 .
+
+obo:NCBITaxon_64493  rdfs:label  "Mucor hiemalis" ;
+        rdfs:subClassOf  obo:NCBITaxon_4830 .
+
+obo:NCBITaxon_357544  rdfs:label  "Helicobacter pylori HPAG1" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Helicobacter pylori str. HPAG1" , "Helicobacter pylori strain HPAG1" .
+
+obo:NCBITaxon_63131  rdfs:label  "Aspergillus foetidus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_39693  rdfs:label  "Mycolicibacterium porcinum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_6326  rdfs:label  "Bursaphelenchus xylophilus" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "pinewood nematode" , "pine wood nematode" , "pine wilt nematode" .
+
+obo:NCBITaxon_264951  rdfs:label  "Byssochlamys spectabilis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_290579  rdfs:label  "HIV-1 M:B_Lai" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_57267  rdfs:label  "Plasmodium falciparum Dd2" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_1328  rdfs:label  "Streptococcus anginosus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_154046  rdfs:label  "Hungatella hathewayi" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_593976  rdfs:label  "Influenza A virus (A/Wisconsin/16/2008(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_5052  rdfs:label  "Aspergillus" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_643706  rdfs:label  "Influenza A virus (A/Michigan/09/2007(H1N2))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_27291  rdfs:label  "Saccharomyces paradoxus" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_13548  rdfs:label  "Glomerella <ascomycete fungus>" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Glomerella" .
+
+obo:NCBITaxon_41688  rdfs:label  "Lomentospora prolificans" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1888  rdfs:label  "Streptomyces albus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_913028  rdfs:label  "Yersinia enterocolitica W22703" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Yersinia enterocolitica str. W22703" , "Yersinia enterocolitica strain W22703" .
+
+obo:NCBITaxon_5065  rdfs:label  "Aspergillus sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_196620  rdfs:label  "Staphylococcus aureus subsp. aureus MW2" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 .
+
+obo:NCBITaxon_1211845
+        rdfs:label       "Escherichia coli MC1061" ;
+        rdfs:subClassOf  obo:NCBITaxon_83333 .
+
+obo:NCBITaxon_5537  rdfs:label  "Rhodotorula mucilaginosa" ;
+        rdfs:subClassOf  obo:NCBITaxon_5533 .
+
+obo:NCBITaxon_29447  rdfs:label  "Xanthomonas albilineans" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_563466  rdfs:label  "Scedosporium apiospermum" ;
+        rdfs:subClassOf  obo:NCBITaxon_41687 .
+
+obo:NCBITaxon_235  rdfs:label  "Brucella abortus" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Brucella melitensis bv. Abortus" .
+
+obo:NCBITaxon_9986  rdfs:label  "Oryctolagus cuniculus" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "rabbit" , "rabbits" , "domestic rabbit" , "European rabbit" , "Japanese white rabbit" .
+
+obo:NCBITaxon_54007  rdfs:label  "Anaerococcus octavius" ;
+        rdfs:subClassOf  obo:NCBITaxon_165779 .
+
+obo:NCBITaxon_84112  rdfs:label  "Eggerthella lenta" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_10363  rdfs:label  "Human herpesvirus 5 strain Towne" ;
+        rdfs:subClassOf  obo:NCBITaxon_10359 .
+
+obo:NCBITaxon_177416  rdfs:label  "Francisella tularensis subsp. tularensis SCHU S4" ;
+        rdfs:subClassOf  obo:NCBITaxon_119856 ;
+        bae:altLabel     "Francisella tularensis subsp. tularensis strain SCHU S4" , "Francisella tularensis subsp. tularensis str. SCHU S4" .
+
+obo:NCBITaxon_1408  rdfs:label  "Bacillus pumilus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1386 .
+
+obo:NCBITaxon_579112  rdfs:label  "Vibrio cholerae M66-2" ;
+        rdfs:subClassOf  obo:NCBITaxon_666 ;
+        bae:altLabel     "Vibrio cholerae str. M66-2" , "Vibrio cholerae strain M66-2" .
+
+obo:NCBITaxon_291056  rdfs:label  "Phomopsis obscurans" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_58291  rdfs:label  "Rhizopus microsporus" ;
+        rdfs:subClassOf  obo:NCBITaxon_4842 .
+
+obo:NCBITaxon_69891  rdfs:label  "Trichophyton soudanense" ;
+        rdfs:subClassOf  obo:NCBITaxon_5550 .
+
+obo:NCBITaxon_1496  rdfs:label  "Clostridioides difficile" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "[Clostridium] difficile" .
+
+obo:NCBITaxon_11232  rdfs:label  "Canine morbillivirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1243  rdfs:label  "Leuconostoc" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_476294  rdfs:label  "Influenza A virus (A/Brisbane/10/2007(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_882102  rdfs:label  "Vibrio anguillarum 775" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Vibrio anguillarum str. 775" , "Vibrio anguillarum strain 775" .
+
+obo:NCBITaxon_233412  rdfs:label  "[Haemophilus] ducreyi 35000HP" ;
+        rdfs:subClassOf  obo:NCBITaxon_730 ;
+        bae:altLabel     "Haemophilus ducreyi 35000HP" .
+
+obo:NCBITaxon_37328  rdfs:label  "Nocardia carnea" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1550  rdfs:label  "Clostridium subterminale" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_73098  rdfs:label  "Kluyvera georgiana" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_74426  rdfs:label  "Collinsella aerofaciens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1269  rdfs:label  "Micrococcus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1310  rdfs:label  "Streptococcus sobrinus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_440389  rdfs:label  "Influenza A virus (A/Turkey/15/2006(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_622  rdfs:label  "Shigella dysenteriae" ;
+        rdfs:subClassOf  obo:NCBITaxon_620 ;
+        bae:altLabel     "Escherichia/Shigella dysenteriae" .
+
+obo:NCBITaxon_72590  rdfs:label  "Salmonella sp. 'group B'" ;
+        rdfs:subClassOf  obo:NCBITaxon_590 .
+
+obo:NCBITaxon_33028  rdfs:label  "Staphylococcus saccharolyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_4828  rdfs:label  "Absidia" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_8005  rdfs:label  "Electrophorus electricus" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "electric eel" , "electric knifefish" .
+
+obo:NCBITaxon_5478  rdfs:label  "[Candida] glabrata" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Candida glabrata" .
+
+obo:NCBITaxon_29388  rdfs:label  "Staphylococcus capitis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_47715  rdfs:label  "Lactobacillus rhamnosus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_55810  rdfs:label  "Bulinus truncatus" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_28026  rdfs:label  "Bifidobacterium pseudocatenulatum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1678 .
+
+obo:NCBITaxon_1336  rdfs:label  "Streptococcus equi" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_470  rdfs:label  "Acinetobacter baumannii" ;
+        rdfs:subClassOf  obo:NCBITaxon_909768 .
+
+obo:NCBITaxon_1883  rdfs:label  "Streptomyces" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_56460  rdfs:label  "Xanthomonas vesicatoria" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_648  rdfs:label  "Aeromonas caviae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_474922  rdfs:label  "Colletotrichum gloeosporioides" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_185918  rdfs:label  "Human rhinovirus A59" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_596777  rdfs:label  "Chlamydia trachomatis E/Bour" ;
+        rdfs:subClassOf  obo:NCBITaxon_813 ;
+        bae:altLabel     "Chlamydia trachomatis str. E/Bour" , "Chlamydia trachomatis strain E/Bour" .
+
+obo:NCBITaxon_1349  rdfs:label  "Streptococcus uberis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_61235  rdfs:label  "Fusarium equiseti" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_6182  rdfs:label  "Schistosoma japonicum" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_1643  rdfs:label  "Listeria welshimeri" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5073  rdfs:label  "Penicillium" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_52584  rdfs:label  "Brachyspira pilosicoli" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1656  rdfs:label  "Actinomyces viscosus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1654 .
+
+obo:NCBITaxon_321967  rdfs:label  "Lactobacillus paracasei ATCC 334" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Lactobacillus casei str. ATCC 334" , "Lactobacillus casei strain ATCC 334" , "Lactobacillus casei ATCC 334" .
+
+obo:NCBITaxon_550  rdfs:label  "Enterobacter cloacae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_272559  rdfs:label  "Bacteroides fragilis NCTC 9343" ;
+        rdfs:subClassOf  obo:NCBITaxon_817 ;
+        bae:altLabel     "Bacteroides fragilis str. NCTC 9343" , "Bacteroides fragilis strain NCTC 9343" .
+
+obo:NCBITaxon_31285  rdfs:label  "Trypanosoma brucei gambiense" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_92953  rdfs:label  "Naganishia albidosimilis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_28119  rdfs:label  "Bacteroides zoogleoformans" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 ;
+        bae:altLabel     "[Prevotella] zoogleoformans" .
+
+obo:NCBITaxon_69824  rdfs:label  "[Clostridium] cocleatum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium cocleatum" .
+
+obo:NCBITaxon_10309  rdfs:label  "Human alphaherpesvirus 1 strain SC16" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_149385  rdfs:label  "Salmonella enterica subsp. enterica serovar Hadar" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_403321  rdfs:label  "Influenza B virus (B/Illinois/47/2005)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11520 .
+
+obo:NCBITaxon_83331  rdfs:label  "Mycobacterium tuberculosis CDC1551" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_210007  rdfs:label  "Streptococcus mutans UA159" ;
+        rdfs:subClassOf  obo:NCBITaxon_1309 .
+
+obo:NCBITaxon_130760  rdfs:label  "Influenza A virus (A/Hong Kong/1073/99(H9N2))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1264  rdfs:label  "Ruminococcus albus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_33010  rdfs:label  "Cutibacterium avidum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Propionicibacterium avidum" .
+
+obo:NCBITaxon_357240  rdfs:label  "Franconibacter helveticus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_576  rdfs:label  "Klebsiella sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_570 .
+
+obo:NCBITaxon_192066  rdfs:label  "Neisseria sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_482 .
+
+obo:NCBITaxon_3701  rdfs:label  "Arabidopsis" ;
+        rdfs:subClassOf  bao:BAO_0000605 .
+
+obo:NCBITaxon_1736  rdfs:label  "Eubacterium limosum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_9527  rdfs:label  "Cercopithecidae" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "Old World monkeys" , "monkey" , "monkeys" .
+
+obo:NCBITaxon_29370  rdfs:label  "[Clostridium] sphenoides" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium sphenoides" .
+
+obo:NCBITaxon_43767  rdfs:label  "Rhodococcus hoagii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_34391  rdfs:label  "Epidermophyton floccosum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_589  rdfs:label  "Providencia sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_6035  rdfs:label  "Encephalitozoon cuniculi" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_33036  rdfs:label  "Anaerococcus tetradius" ;
+        rdfs:subClassOf  obo:NCBITaxon_165779 .
+
+obo:NCBITaxon_65071  rdfs:label  "Pythium ultimum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_309806  rdfs:label  "Sulfurihydrogenibium azorense" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11320  rdfs:label  "Influenza A virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_237895  rdfs:label  "Cryptosporidium hominis" ;
+        rdfs:subClassOf  obo:NCBITaxon_5806 .
+
+obo:NCBITaxon_79923  rdfs:label  "Clonorchis sinensis" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "oriental liver fluke" .
+
+obo:NCBITaxon_41856  rdfs:label  "Hepatitis C virus genotype 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_36841  rdfs:label  "Terrisporobacter glycolicus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_277944  rdfs:label  "Human coronavirus NL63" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1509  rdfs:label  "Clostridium sporogenes" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_11039  rdfs:label  "Western equine encephalitis virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_227882  rdfs:label  "Streptomyces avermitilis MA-4680 = NBRC 14893" ;
+        rdfs:subClassOf  obo:NCBITaxon_33903 ;
+        bae:altLabel     "Streptomyces avermitilis NBRC 14893 = MA-4680" .
+
+obo:NCBITaxon_3562  rdfs:label  "Spinacia oleracea" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "spinach" .
+
+obo:NCBITaxon_656  rdfs:label  "Aeromonas allosaccharophila" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_63632  rdfs:label  "Agrostis stolonifera" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "creeping bent grass" .
+
+obo:NCBITaxon_197  rdfs:label  "Campylobacter jejuni" ;
+        rdfs:subClassOf  obo:NCBITaxon_194 .
+
+obo:NCBITaxon_185926  rdfs:label  "Human rhinovirus B70" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_10784  rdfs:label  "Bovine parvovirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5081  rdfs:label  "Penicillium sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_5073 ;
+        bae:altLabel     "Eupenicillium sp." .
+
+obo:NCBITaxon_211044  rdfs:label  "Influenza A virus (A/Puerto Rico/8/1934(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_4903  rdfs:label  "Cyberlindnera jadinii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_39482  rdfs:label  "Faecalicatena contorta" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "[Eubacterium] contortum" .
+
+obo:NCBITaxon_69218  rdfs:label  "Enterobacter cancerogenus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_40355  rdfs:label  "Fonsecaea pedrosoi" ;
+        rdfs:subClassOf  obo:NCBITaxon_40354 .
+
+obo:NCBITaxon_100884  rdfs:label  "Coprobacillus cateniformis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_330879  rdfs:label  "Aspergillus fumigatus Af293" ;
+        rdfs:subClassOf  obo:NCBITaxon_746128 .
+
+obo:NCBITaxon_292805  rdfs:label  "Wolbachia endosymbiont strain TRS of Brugia malayi" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_667723  rdfs:label  "Influenza A virus (A/Washington/29/2009(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_63405  rdfs:label  "Microsporum canis" ;
+        rdfs:subClassOf  obo:NCBITaxon_34392 .
+
+obo:NCBITaxon_85962  rdfs:label  "Helicobacter pylori 26695" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Helicobacter pylori (strain 26695)" , "Helicobacter pylori str. 26695" , "Helicobacter pylori strain 26695" .
+
+obo:NCBITaxon_316407  rdfs:label  "Escherichia coli str. K-12 substr. W3110" ;
+        rdfs:subClassOf  obo:NCBITaxon_83333 ;
+        bae:altLabel     "Escherichia coli str. K12 substr. W3110" , "Escherichia coli str. W3110" , "Escherichia coli strain W3110" .
+
+obo:NCBITaxon_109790  rdfs:label  "Lactobacillus jensenii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_121791  rdfs:label  "Nipah henipavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_659634  rdfs:label  "Influenza A virus (A/New Hampshire/01/2009(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_5860  rdfs:label  "Plasmodium vinckei" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_264  rdfs:label  "Francisella tularensis subsp. novicida" ;
+        rdfs:subClassOf  obo:NCBITaxon_263 .
+
+obo:NCBITaxon_28114  rdfs:label  "Porphyromonas levii" ;
+        rdfs:subClassOf  obo:NCBITaxon_836 .
+
+obo:NCBITaxon_10304  rdfs:label  "Human alphaherpesvirus 1 strain F" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_4929  rdfs:label  "Meyerozyma guilliermondii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_736  rdfs:label  "Haemophilus paraphrohaemolyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_724 .
+
+obo:NCBITaxon_29489  rdfs:label  "Aeromonas enteropelogenes" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_108619  rdfs:label  "Salmonella enterica subsp. enterica serovar Newport" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_571  rdfs:label  "Klebsiella oxytoca" ;
+        rdfs:subClassOf  obo:NCBITaxon_570 .
+
+obo:NCBITaxon_11720  rdfs:label  "Human immunodeficiency virus type 2 (ISOLATE ROD)" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_59813  rdfs:label  "Mycolicibacterium novocastrense" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_304736  rdfs:label  "Sulfurihydrogenibium yellowstonense" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_100951  rdfs:label  "Naganishia albida" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_115981  rdfs:label  "Salmonella enterica subsp. enterica serovar Montevideo" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_400727  rdfs:label  "Pomacea canaliculata" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_584  rdfs:label  "Proteus mirabilis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_12089  rdfs:label  "Coxsackievirus A24" ;
+        rdfs:subClassOf  obo:NCBITaxon_138950 .
+
+obo:NCBITaxon_1285  rdfs:label  "Staphylococcus intermedius" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_11021  rdfs:label  "Eastern equine encephalitis virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_33031  rdfs:label  "Peptoniphilus lacrimalis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_803  rdfs:label  "Bartonella quintana" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_12130  rdfs:label  "Human rhinovirus A2" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_272634  rdfs:label  "Mycoplasma pneumoniae M129" ;
+        rdfs:subClassOf  obo:NCBITaxon_2104 ;
+        bae:altLabel     "Mycoplasma pneumoniae str. M129" , "Mycoplasma pneumoniae strain M129" .
+
+obo:NCBITaxon_61171  rdfs:label  "Holdemania filiformis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_53719  rdfs:label  "Eclipta prostrata" ;
+        rdfs:subClassOf  bao:BAO_0000605 .
+
+obo:NCBITaxon_228604  rdfs:label  "Prevotella salivae" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_158836  rdfs:label  "Enterobacter hormaechei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1504  rdfs:label  "Clostridium septicum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_5481  rdfs:label  "Diutina rugosa" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_29391  rdfs:label  "Gemella morbillorum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1378 .
+
+obo:NCBITaxon_816  rdfs:label  "Bacteroides" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11034  rdfs:label  "Sindbis virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5659  rdfs:label  "Leishmania amazonensis" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_3988  rdfs:label  "Ricinus communis" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "castor bean" .
+
+obo:NCBITaxon_7165  rdfs:label  "Anopheles gambiae" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "African malaria mosquito" , "Anopheles gambiae sensu stricto" .
+
+obo:NCBITaxon_90105  rdfs:label  "Salmonella enterica subsp. enterica serovar Saintpaul" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_69159  rdfs:label  "Human coxsackievirus A16 (strain G-10)" ;
+        rdfs:subClassOf  obo:NCBITaxon_31704 .
+
+obo:NCBITaxon_45219  rdfs:label  "Guanarito mammarenavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_223995  rdfs:label  "Lipaphis erysimi" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "mustard aphid" .
+
+obo:NCBITaxon_185921  rdfs:label  "Human rhinovirus A63" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1352  rdfs:label  "Enterococcus faecium" ;
+        rdfs:subClassOf  obo:NCBITaxon_1350 .
+
+obo:NCBITaxon_411476  rdfs:label  "Bacteroides ovatus ATCC 8483" ;
+        rdfs:subClassOf  obo:NCBITaxon_28116 .
+
+obo:NCBITaxon_1824  rdfs:label  "Nocardia asteroides" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_137071  rdfs:label  "Plasmodium falciparum HB3" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_292800  rdfs:label  "Flavonifractor plautii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_4911  rdfs:label  "Kluyveromyces marxianus" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_402873  rdfs:label  "Sporothrix albicans" ;
+        rdfs:subClassOf  obo:NCBITaxon_29907 .
+
+obo:NCBITaxon_10258  rdfs:label  "Orf virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_29471  rdfs:label  "Pectobacterium atrosepticum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1378  rdfs:label  "Gemella" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_367120  rdfs:label  "Influenza A virus (A/Fort Monmouth/1/1947(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_381517  rdfs:label  "Influenza A virus (A/Udorn/307/1972(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_36470  rdfs:label  "Streptococcus sp. 'group A'" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_1685  rdfs:label  "Bifidobacterium breve" ;
+        rdfs:subClassOf  obo:NCBITaxon_1678 .
+
+obo:NCBITaxon_10312  rdfs:label  "Human herpesvirus 2 strain 186" ;
+        rdfs:subClassOf  obo:NCBITaxon_10310 .
+
+obo:NCBITaxon_28847  rdfs:label  "Leishmania sp." ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_12071  rdfs:label  "Coxsackievirus B1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_35833  rdfs:label  "Bilophila wadsworthia" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_29497  rdfs:label  "Vibrio splendidus" ;
+        rdfs:subClassOf  obo:NCBITaxon_662 .
+
+obo:NCBITaxon_28135  rdfs:label  "Prevotella oris" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_10325  rdfs:label  "Macacine alphaherpesvirus 1" ;
+        rdfs:subClassOf  obo:NCBITaxon_10294 ;
+        bae:altLabel     "monkey B virus" .
+
+obo:NCBITaxon_5806  rdfs:label  "Cryptosporidium" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_2095  rdfs:label  "Mycoplasma capricolum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_28901  rdfs:label  "Salmonella enterica" ;
+        rdfs:subClassOf  obo:NCBITaxon_590 .
+
+obo:NCBITaxon_43770  rdfs:label  "Corynebacterium striatum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_645582  rdfs:label  "Influenza A virus (A/England/195/2009(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_10632  rdfs:label  "JC polyomavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_167741  rdfs:label  "Alternaria mali" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_418086  rdfs:label  "[Candida] nivariensis" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Candida nivariensis" .
+
+obo:NCBITaxon_233155  rdfs:label  "Culex pipiens molestus" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_63746  rdfs:label  "Hepatitis C virus (isolate H77)" ;
+        rdfs:subClassOf  obo:NCBITaxon_31646 .
+
+obo:NCBITaxon_1765  rdfs:label  "Mycobacterium bovis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1512  rdfs:label  "[Clostridium] symbiosum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Clostridium symbiosum" .
+
+obo:NCBITaxon_131111  rdfs:label  "Actinomyces turicensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1654 .
+
+obo:NCBITaxon_824  rdfs:label  "Campylobacter gracilis" ;
+        rdfs:subClassOf  obo:NCBITaxon_194 .
+
+obo:NCBITaxon_315946  rdfs:label  "Scedosporium aurantiacum" ;
+        rdfs:subClassOf  obo:NCBITaxon_41687 .
+
+obo:NCBITaxon_6523  rdfs:label  "Lymnaea stagnalis" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "great pond snail" .
+
+obo:NCBITaxon_42434  rdfs:label  "Culex pipiens pallens" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_1778  rdfs:label  "Mycobacterium gordonae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_4852  rdfs:label  "Cunninghamella" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_40216  rdfs:label  "Acinetobacter radioresistens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_588858  rdfs:label  "Salmonella enterica subsp. enterica serovar Typhimurium str. 14028S" ;
+        rdfs:subClassOf  obo:NCBITaxon_99287 .
+
+obo:NCBITaxon_837  rdfs:label  "Porphyromonas gingivalis" ;
+        rdfs:subClassOf  obo:NCBITaxon_836 .
+
+obo:NCBITaxon_47917  rdfs:label  "Serratia fonticola" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_291645  rdfs:label  "Bacteroides nordii" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 .
+
+obo:NCBITaxon_34358  rdfs:label  "Kazachstania exigua" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_672  rdfs:label  "Vibrio vulnificus" ;
+        rdfs:subClassOf  obo:NCBITaxon_662 .
+
+obo:NCBITaxon_353153  rdfs:label  "Trypanosoma cruzi strain CL Brener" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_328812  rdfs:label  "Parabacteroides goldsteinii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_505493  rdfs:label  "Influenza A virus (A/California/27/2007(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_52773  rdfs:label  "Actinomyces meyeri" ;
+        rdfs:subClassOf  obo:NCBITaxon_1654 .
+
+obo:NCBITaxon_381512  rdfs:label  "Influenza A virus (A/New Caledonia/20/1999(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_58346  rdfs:label  "Streptomyces platensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_38301  rdfs:label  "Corynebacterium minutissimum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_138  rdfs:label  "Borrelia" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_273372  rdfs:label  "Candida metapsilosis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_559292  rdfs:label  "Saccharomyces cerevisiae S288C" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_2701  rdfs:label  "Gardnerella" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_388919  rdfs:label  "Streptococcus sanguinis SK36" ;
+        rdfs:subClassOf  obo:NCBITaxon_1305 ;
+        bae:altLabel     "Streptococcus sanguinis str. SK36" , "Streptococcus sanguinis strain SK36" .
+
+obo:NCBITaxon_1386  rdfs:label  "Bacillus <bacterium>" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Bacillus" .
+
+obo:NCBITaxon_1680  rdfs:label  "Bifidobacterium adolescentis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1678 .
+
+obo:NCBITaxon_478861  rdfs:label  "Plasmodium falciparum D10" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_147802  rdfs:label  "Lactobacillus iners" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_305719  rdfs:label  "Prevotella baroniae" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_53655  rdfs:label  "Pichia fermentans" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_192954  rdfs:label  "Salmonella enterica subsp. enterica serovar Mbandaka" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_10026  rdfs:label  "Cricetinae" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "hamsters" .
+
+obo:NCBITaxon_28130  rdfs:label  "Prevotella disiens" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_5507  rdfs:label  "Fusarium oxysporum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_82829  rdfs:label  "Epstein-barr virus strain p3hr-1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_205  rdfs:label  "Campylobacter sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_194 .
+
+obo:NCBITaxon_42068  rdfs:label  "Pneumocystis jirovecii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1912  rdfs:label  "Streptomyces hygroscopicus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_10586  rdfs:label  "Human papillomavirus type 33" ;
+        rdfs:subClassOf  obo:NCBITaxon_337041 .
+
+obo:NCBITaxon_1116234
+        rdfs:label       "Acinetobacter baumannii AB5075" ;
+        rdfs:subClassOf  obo:NCBITaxon_470 ;
+        bae:altLabel     "Acinetobacter baumannii strain AB5075" , "Acinetobacter baumannii str. AB5075" .
+
+obo:NCBITaxon_41978  rdfs:label  "Ruminococcus sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_133448  rdfs:label  "Citrobacter youngae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_411577  rdfs:label  "Anaerococcus murdochii" ;
+        rdfs:subClassOf  obo:NCBITaxon_165779 .
+
+obo:NCBITaxon_79880  rdfs:label  "Bacillus clausii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1386 .
+
+obo:NCBITaxon_6211  rdfs:label  "Echinococcus multilocularis" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_284593  rdfs:label  "[Candida] glabrata CBS 138" ;
+        rdfs:subClassOf  obo:NCBITaxon_5478 ;
+        bae:altLabel     "Candida glabrata ATCC 2001" , "Candida glabrata ATCC2001" , "Candida glabrata CBS 138" , "Candida glabrata CBS138" .
+
+obo:NCBITaxon_28450  rdfs:label  "Burkholderia pseudomallei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5827  rdfs:label  "Plasmodium cynomolgi" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_333761  rdfs:label  "Human papillomavirus type 18" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_4081  rdfs:label  "Solanum lycopersicum" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "tomato" .
+
+obo:NCBITaxon_1206108
+        rdfs:label       "Escherichia coli J96" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_284812  rdfs:label  "Schizosaccharomyces pombe 972h-" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_147676  rdfs:label  "Human rhinovirus A45" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_10359  rdfs:label  "Human betaherpesvirus 5" ;
+        rdfs:subClassOf  obo:NCBITaxon_10358 ;
+        bae:altLabel     "Human cytomegalovirus" .
+
+obo:NCBITaxon_60550  rdfs:label  "Burkholderia pyrrocinia" ;
+        rdfs:subClassOf  obo:NCBITaxon_87882 .
+
+obo:NCBITaxon_1520  rdfs:label  "Clostridium beijerinckii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_420089  rdfs:label  "Henosepilachna vigintioctopunctata" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_83559  rdfs:label  "Chlamydia suis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_72000  rdfs:label  "Kocuria rhizophila" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_716541  rdfs:label  "Enterobacter cloacae subsp. cloacae ATCC 13047" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Enterobacter cloacae subsp. cloacae str. ATCC 13047" , "Enterobacter cloacae subsp. cloacae strain ATCC 13047" .
+
+obo:NCBITaxon_1533  rdfs:label  "Clostridium fallax" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_481805  rdfs:label  "Escherichia coli ATCC 8739" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Escherichia coli str. ATCC 8739" , "Escherichia coli strain ATCC 8739" .
+
+obo:NCBITaxon_7653  rdfs:label  "Lytechinus pictus" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "painted sea urchin" , "painted urchin" .
+
+obo:NCBITaxon_119856  rdfs:label  "Francisella tularensis subsp. tularensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_263 .
+
+obo:NCBITaxon_36331  rdfs:label  "Pythium irregulare" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_757418  rdfs:label  "Mycobacterium tuberculosis H37RvMA" ;
+        rdfs:subClassOf  obo:NCBITaxon_83332 .
+
+obo:NCBITaxon_158878  rdfs:label  "Staphylococcus aureus subsp. aureus Mu50" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 .
+
+obo:NCBITaxon_858  rdfs:label  "Fusobacterium necrogenes" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11076  rdfs:label  "Japanese encephalitis virus strain Nakayama" ;
+        rdfs:subClassOf  obo:NCBITaxon_11072 .
+
+obo:NCBITaxon_176280  rdfs:label  "Staphylococcus epidermidis ATCC 12228" ;
+        rdfs:subClassOf  obo:NCBITaxon_1282 .
+
+obo:NCBITaxon_1263871
+        rdfs:label       "Klebsiella pneumoniae ATCC BAA-2146" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_436295  rdfs:label  "Salmonella enterica subsp. enterica serovar Poona" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_1381  rdfs:label  "Atopobium minutum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_381520  rdfs:label  "Influenza B virus (B/Hong Kong/05/1972)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11520 .
+
+obo:NCBITaxon_82517  rdfs:label  "Trichosporon inkin" ;
+        rdfs:subClassOf  obo:NCBITaxon_5552 .
+
+obo:NCBITaxon_1559  rdfs:label  "Clostridium tertium" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_1306  rdfs:label  "Streptococcus sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_356426  rdfs:label  "Hepatitis C virus subtype 3a" ;
+        rdfs:subClassOf  obo:NCBITaxon_356114 .
+
+obo:NCBITaxon_11089  rdfs:label  "Yellow fever virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_52247  rdfs:label  "[Candida] inconspicua" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Candida inconspicua" .
+
+obo:NCBITaxon_331636  rdfs:label  "Chlamydia psittaci 6BC" ;
+        rdfs:subClassOf  obo:NCBITaxon_83554 ;
+        bae:altLabel     "Chlamydophila psittaci str. 6BC" , "Chlamydophila psittaci strain 6BC" .
+
+obo:NCBITaxon_5755  rdfs:label  "Acanthamoeba castellanii" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_5502  rdfs:label  "Curvularia" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_11855  rdfs:label  "Mason-Pfizer monkey virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_41413  rdfs:label  "Aspergillus glaucus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_1319  rdfs:label  "Streptococcus sp. 'group B'" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_31647  rdfs:label  "Hepatitis C virus subtype 1b" ;
+        rdfs:subClassOf  obo:NCBITaxon_41856 .
+
+obo:NCBITaxon_186538  rdfs:label  "Zaire ebolavirus" ;
+        rdfs:subClassOf  obo:NCBITaxon_186536 .
+
+obo:NCBITaxon_1613  rdfs:label  "Lactobacillus fermentum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_343462  rdfs:label  "Human adenovirus 11p" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_511145  rdfs:label  "Escherichia coli str. K-12 substr. MG1655" ;
+        rdfs:subClassOf  obo:NCBITaxon_83333 ;
+        bae:altLabel     "Escherichia coli str. K12 substr. MG1655" , "Escherichia coli str. MG1655" , "Escherichia coli strain MG1655" .
+
+obo:NCBITaxon_71237  rdfs:label  "Staphylococcus vitulinus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_4953  rdfs:label  "Zygosaccharomyces" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_300852  rdfs:label  "Thermus thermophilus HB8" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Thermus thermophilus str. HB8" , "Thermus thermophilus strain HB8" .
+
+obo:NCBITaxon_65660  rdfs:label  "Acanthamoeba hatchetti" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_10506  rdfs:label  "Paramecium bursaria Chlorella virus 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_162145  rdfs:label  "Human metapneumovirus" ;
+        rdfs:subClassOf  obo:NCBITaxon_162387 .
+
+obo:NCBITaxon_10047  rdfs:label  "Meriones unguiculatus" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "Mongolian gerbil" , "Mongolian jird" .
+
+obo:NCBITaxon_120644  rdfs:label  "Fusarium thapsinum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_2748  rdfs:label  "Carnobacterium divergens" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Carnibacterium divergens" .
+
+obo:NCBITaxon_11628  rdfs:label  "Machupo mammarenavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_412694  rdfs:label  "Bacillus thuringiensis str. Al Hakam" ;
+        rdfs:subClassOf  obo:NCBITaxon_1428 ;
+        bae:altLabel     "Bacillus thuringiensis 'Al Hakam'" , "Bacillus thuringiensis strain Al Hakam" .
+
+obo:NCBITaxon_1639  rdfs:label  "Listeria monocytogenes" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_643545  rdfs:label  "Influenza A virus (A/New York/18/2009(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_520  rdfs:label  "Bordetella pertussis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1474  rdfs:label  "Sporosarcina pasteurii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_90062  rdfs:label  "Leptospira interrogans serovar Icterohaemorrhagiae" ;
+        rdfs:subClassOf  obo:NCBITaxon_173 .
+
+obo:NCBITaxon_119072  rdfs:label  "Caldanaerobacter subterraneus subsp. tengcongensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_239  rdfs:label  "Flavobacterium sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Flavibacterium sp." .
+
+obo:NCBITaxon_7047  rdfs:label  "Sitophilus zeamais" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "maize weevil" .
+
+obo:NCBITaxon_83554  rdfs:label  "Chlamydia psittaci" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5670  rdfs:label  "Leishmania guyanensis" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_39777  rdfs:label  "Veillonella atypica" ;
+        rdfs:subClassOf  obo:NCBITaxon_29465 .
+
+obo:NCBITaxon_10367  rdfs:label  "Murine cytomegalovirus (strain Smith)" ;
+        rdfs:subClassOf  obo:NCBITaxon_10366 .
+
+obo:NCBITaxon_1781  rdfs:label  "Mycobacterium marinum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_546  rdfs:label  "Citrobacter freundii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_185891  rdfs:label  "Human rhinovirus A9" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1232598
+        rdfs:label       "Alternaria kikuchiana" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_840  rdfs:label  "Prevotella loescheii" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_1299114
+        rdfs:label       "Salmonella enterica subsp. enterica serovar Typhimurium str. ATCC 14028" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_41047  rdfs:label  "Aspergillus thermomutatus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_152500  rdfs:label  "Burkholderia dolosa" ;
+        rdfs:subClassOf  obo:NCBITaxon_87882 .
+
+obo:NCBITaxon_29518  rdfs:label  "Borreliella afzelii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_356114  rdfs:label  "Hepatitis C virus genotype 3" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_306  rdfs:label  "Pseudomonas sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_64644  rdfs:label  "Actinomucor" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_9598  rdfs:label  "Pan troglodytes" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "chimpanzee" .
+
+obo:NCBITaxon_1209523
+        rdfs:label       "Toxoplasma gondii type II" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_1301  rdfs:label  "Streptococcus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11084  rdfs:label  "Tick-borne encephalitis virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_34387  rdfs:label  "Trichophyton tonsurans" ;
+        rdfs:subClassOf  obo:NCBITaxon_5550 .
+
+obo:NCBITaxon_2129  rdfs:label  "Ureaplasma" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_316385  rdfs:label  "Escherichia coli str. K-12 substr. DH10B" ;
+        rdfs:subClassOf  obo:NCBITaxon_83333 ;
+        bae:altLabel     "Escherichia coli DH10B" , "Escherichia coli str. K12 substr. DH10B" , "Escherichia coli strain K12 substrain DH10B" .
+
+obo:NCBITaxon_1314  rdfs:label  "Streptococcus pyogenes" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_1432137
+        rdfs:label       "Cryptococcus neoformans var. grubii H99S" ;
+        rdfs:subClassOf  obo:NCBITaxon_178876 ;
+        bae:altLabel     "Cryptococcus neoformans var. grubii Stud" .
+
+obo:NCBITaxon_38289  rdfs:label  "Corynebacterium jeikeium" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_29379  rdfs:label  "Staphylococcus auricularis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_5763  rdfs:label  "Naegleria fowleri" ;
+        rdfs:subClassOf  bao:BAO_0000662 ;
+        bae:altLabel     "brain-eating amoeba" .
+
+obo:NCBITaxon_57266  rdfs:label  "Plasmodium falciparum 7G8" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_866789  rdfs:label  "Escherichia coli DSM 30083 = JCM 1649 = ATCC 11775" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_31655  rdfs:label  "Hepatitis C virus subtype 6a" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_593975  rdfs:label  "Influenza A virus (A/Washington/10/2008(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_71704  rdfs:label  "Coprinellus domesticus" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_41687  rdfs:label  "Scedosporium" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_35269  rdfs:label  "Woodchuck hepatitis virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5523  rdfs:label  "Fusarium lateritium" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_185909  rdfs:label  "Human rhinovirus A41" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_510516  rdfs:label  "Aspergillus oryzae RIB40" ;
+        rdfs:subClassOf  obo:NCBITaxon_5062 .
+
+obo:NCBITaxon_286432  rdfs:label  "Aspergillus fumisynnematus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_33892  rdfs:label  "Mycobacterium bovis BCG" ;
+        rdfs:subClassOf  obo:NCBITaxon_1765 .
+
+obo:NCBITaxon_487  rdfs:label  "Neisseria meningitidis" ;
+        rdfs:subClassOf  obo:NCBITaxon_482 .
+
+obo:NCBITaxon_688394  rdfs:label  "Lichtheimia ramosa" ;
+        rdfs:subClassOf  obo:NCBITaxon_688353 .
+
+obo:NCBITaxon_448086  rdfs:label  "Lake Victoria marburgvirus - Ci67" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_338187  rdfs:label  "Vibrio campbellii ATCC BAA-1116" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_92931  rdfs:label  "Rat sialodacryoadenitis coronavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_641807  rdfs:label  "Influenza A virus (A/California/05/2009(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_5843  rdfs:label  "Plasmodium falciparum NF54" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_561007  rdfs:label  "Mycobacteroides abscessus ATCC 19977" ;
+        rdfs:subClassOf  obo:NCBITaxon_36809 ;
+        bae:altLabel     "Mycobacterium abscessus str. ATCC 19977" , "Mycobacterium abscessus strain ATCC 19977" .
+
+obo:NCBITaxon_668369  rdfs:label  "Escherichia coli DH5[alpha]" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Escherichia coli str. DH5[alpha]" , "Escherichia coli strain DH5[alpha]" .
+
+obo:NCBITaxon_32604  rdfs:label  "Human betaherpesvirus 6B" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_554  rdfs:label  "Pectobacterium carotovorum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_12059  rdfs:label  "Enterovirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_289380  rdfs:label  "Clostridium perfringens SM101" ;
+        rdfs:subClassOf  obo:NCBITaxon_1502 ;
+        bae:altLabel     "Clostridium perfringens str. SM101" , "Clostridium perfringens strain SM101" .
+
+obo:NCBITaxon_256701  rdfs:label  "Glutamicibacter arilaitensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_6253  rdfs:label  "Ascaris suum" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "pig roundworm" .
+
+obo:NCBITaxon_33972  rdfs:label  "Streptococcus sp. 'group C'" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_40199  rdfs:label  "Fusarium avenaceum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_6978  rdfs:label  "Periplaneta americana" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "American cockroach" .
+
+obo:NCBITaxon_115711  rdfs:label  "Chlamydia pneumoniae AR39" ;
+        rdfs:subClassOf  obo:NCBITaxon_83558 .
+
+obo:NCBITaxon_113287  rdfs:label  "Pseudoramibacter alactolyticus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_37162  rdfs:label  "Mycobacterium avium complex sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_204722  rdfs:label  "Brucella suis 1330" ;
+        rdfs:subClassOf  obo:NCBITaxon_29461 ;
+        bae:altLabel     "Brucella suis str. 1330" .
+
+obo:NCBITaxon_29361  rdfs:label  "Tyzzerella nexilis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_29833  rdfs:label  "Hanseniaspora uvarum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_6279  rdfs:label  "Brugia malayi" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "agent of lymphatic filariasis" .
+
+obo:NCBITaxon_38284  rdfs:label  "Corynebacterium accolens" ;
+        rdfs:subClassOf  obo:NCBITaxon_1716 .
+
+obo:NCBITaxon_1169286
+        rdfs:label       "Enterococcus faecalis ATCC 19433" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_621  rdfs:label  "Shigella boydii" ;
+        rdfs:subClassOf  obo:NCBITaxon_620 .
+
+obo:NCBITaxon_33745  rdfs:label  "Hepatitis C virus genotype 4" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_278025  rdfs:label  "Kazachstania pintolopesii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_456999  rdfs:label  "Rhizoctonia solani" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_191090  rdfs:label  "Influenza A virus (A/Weiss/1943(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_13707  rdfs:label  "Tagetes" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "marigolds" .
+
+obo:NCBITaxon_31650  rdfs:label  "Hepatitis C virus subtype 2b" ;
+        rdfs:subClassOf  obo:NCBITaxon_40271 .
+
+obo:NCBITaxon_33758  rdfs:label  "Echovirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_29387  rdfs:label  "Staphylococcus sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_11577  rdfs:label  "La Crosse virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_28025  rdfs:label  "Bifidobacterium animalis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1678 .
+
+obo:NCBITaxon_91928  rdfs:label  "Exophiala spinifera" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1335  rdfs:label  "Streptococcus equinus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_467210  rdfs:label  "Lachnoanaerobaculum saburreum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_647  rdfs:label  "Aeromonas sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_535026  rdfs:label  "Bacillus subtilis subsp. subtilis str. NCIB 3610" ;
+        rdfs:subClassOf  obo:NCBITaxon_135461 .
+
+obo:NCBITaxon_482  rdfs:label  "Neisseria" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11631  rdfs:label  "Tacaribe mammarenavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1642  rdfs:label  "Listeria innocua" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_160490  rdfs:label  "Streptococcus pyogenes M1 GAS" ;
+        rdfs:subClassOf  obo:NCBITaxon_301447 ;
+        bae:altLabel     "Streptococcus pyogenes (serotype 1 / M1 GAS)" .
+
+obo:NCBITaxon_73484  rdfs:label  "Human immunodeficiency virus type 2 (isolate KR)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11709 .
+
+obo:NCBITaxon_7215  rdfs:label  "Drosophila <fruit fly, genus>" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "fruit fly" , "Drosophila" , "fruit flies" .
+
+obo:NCBITaxon_45816  rdfs:label  "Lindra thalassiae" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_10535  rdfs:label  "unidentified adenovirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1655  rdfs:label  "Actinomyces naeslundii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1654 .
+
+obo:NCBITaxon_37727  rdfs:label  "Talaromyces marneffei" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1402  rdfs:label  "Bacillus licheniformis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_45357  rdfs:label  "[Candida] haemulonis" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Candida haemulonis" .
+
+obo:NCBITaxon_714  rdfs:label  "Aggregatibacter actinomycetemcomitans" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1490  rdfs:label  "Paraclostridium bifermentans" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_31271  rdfs:label  "Plasmodium chabaudi chabaudi" ;
+        rdfs:subClassOf  obo:NCBITaxon_5825 .
+
+obo:NCBITaxon_11657  rdfs:label  "Bovine immunodeficiency virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_134047  rdfs:label  "Salmonella enterica subsp. enterica serovar Bredeney" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_1406863
+        rdfs:label       "Staphylococcus aureus subsp. aureus Z172" ;
+        rdfs:subClassOf  obo:NCBITaxon_46170 .
+
+obo:NCBITaxon_727  rdfs:label  "Haemophilus influenzae" ;
+        rdfs:subClassOf  obo:NCBITaxon_724 .
+
+obo:NCBITaxon_6973  rdfs:label  "Blattella germanica" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "German cockroach" .
+
+obo:NCBITaxon_3899  rdfs:label  "Trifolium repens" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "creeping white clover" , "white clover" .
+
+obo:NCBITaxon_82639  rdfs:label  "Coxsackievirus B2" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_90269  rdfs:label  "Apophysomyces elegans" ;
+        rdfs:subClassOf  obo:NCBITaxon_90268 .
+
+obo:NCBITaxon_28118  rdfs:label  "Odoribacter splanchnicus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_237561  rdfs:label  "Candida albicans SC5314" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1428  rdfs:label  "Bacillus thuringiensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_11711  rdfs:label  "Simian immunodeficiency virus - mac" ;
+        rdfs:subClassOf  obo:NCBITaxon_11723 .
+
+obo:NCBITaxon_12067  rdfs:label  "Coxsackievirus A9" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_202752  rdfs:label  "Listeria ivanovii subsp. londoniensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1638 .
+
+obo:NCBITaxon_33905  rdfs:label  "Bifidobacterium thermophilum" ;
+        rdfs:subClassOf  obo:NCBITaxon_1678 .
+
+obo:NCBITaxon_36773  rdfs:label  "Burkholderia sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1735  rdfs:label  "Holdemanella biformis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_7130  rdfs:label  "Manduca sexta" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "tobacco hornworm" , "hornblower" , "tobacco hawkmoth" , "Carolina sphinx" , "tomato hornworm" .
+
+obo:NCBITaxon_5637  rdfs:label  "Polyporus" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_588  rdfs:label  "Providencia stuartii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_28985  rdfs:label  "Kluyveromyces lactis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_29382  rdfs:label  "Staphylococcus cohnii" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_807  rdfs:label  "Bartonella elizabethae" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Rochalimaea saintelizabethsina" , "Bartonella saintelizabethsina" .
+
+obo:NCBITaxon_33035  rdfs:label  "Blautia producta" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_65070  rdfs:label  "Pythium aphanidermatum" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_378809  rdfs:label  "Ravn virus - Ravn, Kenya, 1987" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1214573
+        rdfs:label       "Diaporthe ampelina" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_61647  rdfs:label  "Pluralibacter gergoviae" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Enterobacter gergoviensis" .
+
+obo:NCBITaxon_57741  rdfs:label  "Salmonella enterica subsp. enterica serovar Blockley" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_58097  rdfs:label  "Salmonella enterica subsp. enterica serovar Bovismorbificans" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_140099  rdfs:label  "Salmonella enterica subsp. enterica serovar Virginia" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_518987  rdfs:label  "Influenza B virus (B/Lee/1940)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11520 .
+
+obo:NCBITaxon_341980  rdfs:label  "Human herpesvirus 3 strain Oka vaccine" ;
+        rdfs:subClassOf  obo:NCBITaxon_10335 .
+
+obo:NCBITaxon_1890  rdfs:label  "Streptomyces antibioticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_1343  rdfs:label  "Streptococcus vestibularis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_5498  rdfs:label  "Cladosporium" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_196  rdfs:label  "Campylobacter fetus" ;
+        rdfs:subClassOf  obo:NCBITaxon_194 .
+
+obo:NCBITaxon_1356  rdfs:label  "Enterococcus sulfureus" ;
+        rdfs:subClassOf  obo:NCBITaxon_1350 .
+
+obo:NCBITaxon_10530  rdfs:label  "Murine adenovirus 1" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_668  rdfs:label  "Aliivibrio fischeri" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5005  rdfs:label  "Sporidiobolus salmonicolor" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_5552  rdfs:label  "Trichosporon" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_185938  rdfs:label  "Human rhinovirus B86" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_10249  rdfs:label  "Vaccinia virus Copenhagen" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_40354  rdfs:label  "Fonsecaea" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_11105  rdfs:label  "Hepatitis C virus (isolate BK)" ;
+        rdfs:subClassOf  obo:NCBITaxon_31647 .
+
+obo:NCBITaxon_90251  rdfs:label  "Cunninghamella bertholletiae" ;
+        rdfs:subClassOf  obo:NCBITaxon_4852 .
+
+obo:NCBITaxon_138950  rdfs:label  "Enterovirus C" ;
+        rdfs:subClassOf  obo:NCBITaxon_12059 .
+
+obo:NCBITaxon_145471  rdfs:label  "Brassica rapa subsp. oleifera" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "biennial turnip rape" .
+
+obo:NCBITaxon_12227  rdfs:label  "Tobacco etch virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_114729  rdfs:label  "H2N2 subtype" ;
+        rdfs:subClassOf  obo:NCBITaxon_11320 .
+
+obo:NCBITaxon_32019  rdfs:label  "Campylobacter fetus subsp. fetus" ;
+        rdfs:subClassOf  obo:NCBITaxon_196 ;
+        bae:altLabel     "Campylobacter fetus fetus" .
+
+obo:NCBITaxon_263  rdfs:label  "Francisella tularensis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_28113  rdfs:label  "Bacteroides heparinolyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_816 ;
+        bae:altLabel     "[Prevotella] heparinolytica" .
+
+obo:NCBITaxon_1423  rdfs:label  "Bacillus subtilis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_265874  rdfs:label  "Ectromelia virus Moscow" ;
+        rdfs:subClassOf  obo:NCBITaxon_12643 .
+
+obo:NCBITaxon_12062  rdfs:label  "Echovirus E6" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_735  rdfs:label  "Haemophilus parahaemolyticus" ;
+        rdfs:subClassOf  obo:NCBITaxon_724 .
+
+obo:NCBITaxon_134821  rdfs:label  "Ureaplasma parvum" ;
+        rdfs:subClassOf  obo:NCBITaxon_2129 .
+
+obo:NCBITaxon_29488  rdfs:label  "Photorhabdus luminescens" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5325  rdfs:label  "Trametes versicolor" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_11678  rdfs:label  "Human immunodeficiency virus type 1 BH10" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1689  rdfs:label  "Bifidobacterium dentium" ;
+        rdfs:subClassOf  obo:NCBITaxon_1678 .
+
+obo:NCBITaxon_37330  rdfs:label  "Nocardia nova" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_28126  rdfs:label  "Prevotella buccae" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_293939  rdfs:label  "Aspergillus lentulus" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_570  rdfs:label  "Klebsiella" ;
+        rdfs:subClassOf  obo:NCBITaxon_543 .
+
+obo:NCBITaxon_62690  rdfs:label  "Blumeria graminis f. sp. tritici" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1908  rdfs:label  "Streptomyces globisporus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_271217  rdfs:label  "Mythimna separata" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "northern armyworm" , "ear-cutting caterpillar" , "Oriental armyworm" , "rice ear-cutting caterpillar" .
+
+obo:NCBITaxon_262307  rdfs:label  "Measles virus genotype A" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_170529  rdfs:label  "Measles virus genotype D7" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_6282  rdfs:label  "Onchocerca volvulus" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_10623  rdfs:label  "Kappapapillomavirus 2" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1743  rdfs:label  "Propionibacterium" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Propionicibacterium" .
+
+obo:NCBITaxon_53246  rdfs:label  "Pseudoalteromonas" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_9534  rdfs:label  "Chlorocebus aethiops" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "African green monkey" , "savanah monkey" , "grivet" , "African green monkeys" .
+
+obo:NCBITaxon_33030  rdfs:label  "Peptoniphilus indolicus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_169963  rdfs:label  "Listeria monocytogenes EGD-e" ;
+        rdfs:subClassOf  obo:NCBITaxon_1639 ;
+        bae:altLabel     "Listeria monocytogenes EGDe" , "Listeria monocytogenes strain EGD-e" , "Listeria monocytogenes str. EGD-e" .
+
+obo:NCBITaxon_27337  rdfs:label  "Verticillium dahliae" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_4830  rdfs:label  "Mucor" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_261299  rdfs:label  "Intestinibacter bartlettii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5480  rdfs:label  "Candida parapsilosis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_29390  rdfs:label  "Streptococcus gordonii str. Challis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1302 ;
+        bae:altLabel     "Streptococcus gordonii Challis" .
+
+obo:NCBITaxon_1591  rdfs:label  "Lactobacillus sp." ;
+        rdfs:subClassOf  obo:NCBITaxon_1578 .
+
+obo:NCBITaxon_71421  rdfs:label  "Haemophilus influenzae Rd KW20" ;
+        rdfs:subClassOf  obo:NCBITaxon_727 ;
+        bae:altLabel     "Haemophilus influenzae KW20" , "Haemophilus influenzae Rd" .
+
+obo:NCBITaxon_1769  rdfs:label  "Mycobacterium leprae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5493  rdfs:label  "[Candida] zeylanoides" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Candida zeylanoides" .
+
+obo:NCBITaxon_1810  rdfs:label  "Mycolicibacterium vaccae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_341694  rdfs:label  "Peptostreptococcus stomatis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5418  rdfs:label  "Papiliotrema laurentii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_663  rdfs:label  "Vibrio alginolyticus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1276653
+        rdfs:label       "Klebsiella pneumoniae 700603" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1529  rdfs:label  "Clostridium cadaveris" ;
+        rdfs:subClassOf  obo:NCBITaxon_1485 .
+
+obo:NCBITaxon_1823  rdfs:label  "Nocardia otitidiscaviarum" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_53326  rdfs:label  "Ancylostoma ceylanicum" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_51655  rdfs:label  "Plutella xylostella" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "cabbage moth" , "diamondback moth" .
+
+obo:NCBITaxon_39107  rdfs:label  "Murinae" ;
+        rdfs:subClassOf  bao:BAO_0000362 .
+
+obo:NCBITaxon_10244  rdfs:label  "Monkeypox virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_11100  rdfs:label  "Bovine viral diarrhea virus 1-NADL" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_676  rdfs:label  "Vibrio fluvialis" ;
+        rdfs:subClassOf  obo:NCBITaxon_662 .
+
+obo:NCBITaxon_29176  rdfs:label  "Neospora caninum" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_316401  rdfs:label  "Escherichia coli ETEC H10407" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Escherichia coli ETEC str. H10407" , "Escherichia coli ETEC strain H10407" .
+
+obo:NCBITaxon_1377  rdfs:label  "Aerococcus viridans" ;
+        rdfs:subClassOf  obo:NCBITaxon_1375 .
+
+obo:NCBITaxon_8353  rdfs:label  "Xenopus <genus>" ;
+        rdfs:subClassOf  bao:BAO_0000518 ;
+        bae:altLabel     "Xenopus" .
+
+obo:NCBITaxon_273123  rdfs:label  "Yersinia pseudotuberculosis IP 32953" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Yersinia pseudotuberculosis IP32953" , "Yersinia pseudotuberculosis str. IP 32953" , "Yersinia pseudotuberculosis strain IP 32953" .
+
+obo:NCBITaxon_867914  rdfs:label  "Staphylococcus aureus LAC" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_730  rdfs:label  "[Haemophilus] ducreyi" ;
+        rdfs:subClassOf  obo:NCBITaxon_724 ;
+        bae:altLabel     "Haemophilus ducreyi" .
+
+obo:NCBITaxon_100816  rdfs:label  "Madurella mycetomatis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_242750  rdfs:label  "Prevotella bergensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_400667  rdfs:label  "Acinetobacter baumannii ATCC 17978" ;
+        rdfs:subClassOf  obo:NCBITaxon_470 ;
+        bae:altLabel     "Acinetobacter baumannii str. ATCC 17978" , "Acinetobacter baumannii strain ATCC 17978" .
+
+obo:NCBITaxon_271  rdfs:label  "Thermus aquaticus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1335626
+        rdfs:label       "Middle East respiratory syndrome-related coronavirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_12070  rdfs:label  "Human coxsackievirus A21 Coe" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5039  rdfs:label  "Blastomyces dermatitidis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_11686  rdfs:label  "Human immunodeficiency virus type 1 (BRU ISOLATE)" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_12542  rdfs:label  "Omsk hemorrhagic fever virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_28134  rdfs:label  "Prevotella oralis" ;
+        rdfs:subClassOf  obo:NCBITaxon_838 .
+
+obo:NCBITaxon_12083  rdfs:label  "Human poliovirus 2" ;
+        rdfs:subClassOf  obo:NCBITaxon_138950 .
+
+obo:NCBITaxon_209  rdfs:label  "Helicobacter" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5599  rdfs:label  "Alternaria alternata" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1916  rdfs:label  "Streptomyces lividans" ;
+        rdfs:subClassOf  obo:NCBITaxon_1883 .
+
+obo:NCBITaxon_218538  rdfs:label  "Dialister invisus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_10884  rdfs:label  "Mammalian orthoreovirus 1 Lang" ;
+        rdfs:subClassOf  obo:NCBITaxon_538120 .
+
+obo:NCBITaxon_556330  rdfs:label  "Acinetobacter sp. N2" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1292  rdfs:label  "Staphylococcus warneri" ;
+        rdfs:subClassOf  obo:NCBITaxon_1279 .
+
+obo:NCBITaxon_5106  rdfs:label  "Verticillium <Hypocreales>" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Verticillium" .
+
+obo:NCBITaxon_1764  rdfs:label  "Mycobacterium avium" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_31545  rdfs:label  "Human adenovirus D8" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_9555  rdfs:label  "Papio anubis" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "Doguera baboon" , "Kenya baboon" , "olive baboon" , "baboon" .
+
+obo:NCBITaxon_447094  rdfs:label  "Histoplasma capsulatum G217B" ;
+        rdfs:subClassOf  obo:NCBITaxon_5037 .
+
+obo:NCBITaxon_138298  rdfs:label  "Plasmodium vinckei petteri" ;
+        rdfs:subClassOf  obo:NCBITaxon_5860 .
+
+obo:NCBITaxon_69153  rdfs:label  "Human enterovirus 71 (strain BRCR)" ;
+        rdfs:subClassOf  obo:NCBITaxon_39054 .
+
+obo:NCBITaxon_823  rdfs:label  "Parabacteroides distasonis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5666  rdfs:label  "Leishmania tropica" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_78535  rdfs:label  "Streptococcus viridans" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_385599  rdfs:label  "Influenza A virus (A/udorn/1972(H3N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_119210 .
+
+obo:NCBITaxon_40215  rdfs:label  "Acinetobacter junii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_547911  rdfs:label  "Influenza B virus (B/Illinois/03/2008)" ;
+        rdfs:subClassOf  obo:NCBITaxon_11520 .
+
+obo:NCBITaxon_552467  rdfs:label  "Cryptococcus gattii VGIII" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_907340  rdfs:label  "Cyberlindnera saturnus" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Pichia sp. GG4S01" , "Lindnera sp. GG4S01" .
+
+obo:NCBITaxon_836  rdfs:label  "Porphyromonas" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_3755  rdfs:label  "Prunus dulcis" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "sweet almond" , "almond" .
+
+obo:NCBITaxon_46170  rdfs:label  "Staphylococcus aureus subsp. aureus" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Staphylococcus aureus aureus" .
+
+obo:NCBITaxon_1831  rdfs:label  "Rhodococcus sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_214092  rdfs:label  "Yersinia pestis CO92" ;
+        rdfs:subClassOf  obo:NCBITaxon_632 ;
+        bae:altLabel     "Yersinia pestis str. CO92" , "Yersinia pestis strain CO92" .
+
+obo:NCBITaxon_82508  rdfs:label  "Trichosporon asahii" ;
+        rdfs:subClassOf  obo:NCBITaxon_5552 .
+
+obo:NCBITaxon_59201  rdfs:label  "Salmonella enterica subsp. enterica" ;
+        rdfs:subClassOf  obo:NCBITaxon_28901 .
+
+obo:NCBITaxon_273371  rdfs:label  "Candida orthopsilosis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_399587  rdfs:label  "Salmonella enterica subsp. enterica serovar Rissen" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_478860  rdfs:label  "Plasmodium falciparum D6" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_38313  rdfs:label  "Shewanella algae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_4931  rdfs:label  "Saccharomyces bayanus" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_247475  rdfs:label  "Psychrobacter sp. DY9-2" ;
+        rdfs:subClassOf  obo:NCBITaxon_497 .
+
+obo:NCBITaxon_5759  rdfs:label  "Entamoeba histolytica" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_1398  rdfs:label  "Bacillus coagulans" ;
+        rdfs:subClassOf  obo:NCBITaxon_1386 .
+
+obo:NCBITaxon_192953  rdfs:label  "Salmonella enterica subsp. enterica serovar Stanley" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_89585  rdfs:label  "Lemna paucicostata" ;
+        rdfs:subClassOf  bao:BAO_0000605 .
+
+obo:NCBITaxon_5506  rdfs:label  "Fusarium" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1911  rdfs:label  "Streptomyces griseus" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5341  rdfs:label  "Agaricus bisporus" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "cultivated mushroom" , "button mushroom" , "common mushroom" .
+
+obo:NCBITaxon_292  rdfs:label  "Burkholderia cepacia" ;
+        rdfs:subClassOf  obo:NCBITaxon_87882 ;
+        bae:altLabel     "Burkholderia cepacia genomovar I" .
+
+obo:NCBITaxon_32595  rdfs:label  "Babesia divergens" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_117544  rdfs:label  "Cytospora" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_1452  rdfs:label  "Bacillus atrophaeus" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Bacillus atriphaeus" .
+
+obo:NCBITaxon_511  rdfs:label  "Alcaligenes faecalis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_42374  rdfs:label  "Candida dubliniensis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_6210  rdfs:label  "Echinococcus granulosus" ;
+        rdfs:subClassOf  bao:BAO_0000511 .
+
+obo:NCBITaxon_4792  rdfs:label  "Phytophthora parasitica" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_10598  rdfs:label  "Human papillomavirus type 58" ;
+        rdfs:subClassOf  obo:NCBITaxon_337041 .
+
+obo:NCBITaxon_486994  rdfs:label  "Salmonella enterica subsp. enterica serovar Hvittingfoss" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_370551  rdfs:label  "Streptococcus pyogenes MGAS9429" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Streptococcus pyogenes str. MGAS9429" , "Streptococcus pyogenes strain MGAS9429" .
+
+obo:NCBITaxon_107832  rdfs:label  "Thanatephorus cucumeris" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "black scurf of potato" .
+
+obo:NCBITaxon_777  rdfs:label  "Coxiella burnetii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_333760  rdfs:label  "Human papillomavirus type 16" ;
+        rdfs:subClassOf  obo:NCBITaxon_337041 .
+
+obo:NCBITaxon_694008  rdfs:label  "Pipistrellus bat coronavirus HKU5" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5661  rdfs:label  "Leishmania donovani" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_12870  rdfs:label  "Variola major virus" ;
+        rdfs:subClassOf  obo:NCBITaxon_10255 .
+
+obo:NCBITaxon_10358  rdfs:label  "Cytomegalovirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_746044  rdfs:label  "Influenza A virus (A/whooper swan/Mongolia/1/2009(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_5839  rdfs:label  "Plasmodium falciparum K1" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_1772  rdfs:label  "Mycolicibacterium smegmatis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_9310  rdfs:label  "Potorous tridactylus" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "potoroo" , "long-nosed potoroo" , "long-nosed rat kangaroo" .
+
+obo:NCBITaxon_86632  rdfs:label  "Rhizopus homothallicus" ;
+        rdfs:subClassOf  obo:NCBITaxon_4842 .
+
+obo:NCBITaxon_83558  rdfs:label  "Chlamydia pneumoniae" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_5127  rdfs:label  "Fusarium fujikuroi" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_4565  rdfs:label  "Triticum aestivum" ;
+        rdfs:subClassOf  bao:BAO_0000605 ;
+        bae:altLabel     "common wheat" , "bread wheat" , "Canadian hard winter wheat" , "wheat" .
+
+obo:NCBITaxon_10665  rdfs:label  "Escherichia virus T4" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_384498  rdfs:label  "Influenza A virus (A/Ann Arbor/6/1960(H2N2))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114729 .
+
+obo:NCBITaxon_12643  rdfs:label  "Ectromelia virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_119602  rdfs:label  "Streptococcus dysgalactiae subsp. equisimilis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1334 .
+
+obo:NCBITaxon_2107  rdfs:label  "Mycoplasma pulmonis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_36330  rdfs:label  "Plasmodium ovale" ;
+        rdfs:subClassOf  bao:BAO_0000662 ;
+        bae:altLabel     "malaria parasite P. ovale" .
+
+obo:NCBITaxon_102148  rdfs:label  "Solobacterium moorei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_85549  rdfs:label  "Artemia salina" ;
+        rdfs:subClassOf  obo:NCBITaxon_6660 .
+
+obo:NCBITaxon_399582  rdfs:label  "Salmonella enterica subsp. enterica serovar Binza" ;
+        rdfs:subClassOf  obo:NCBITaxon_59201 .
+
+obo:NCBITaxon_62977  rdfs:label  "Acinetobacter sp. ADP1" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Acinetobacter baylyi str. ADP1" , "Acinetobacter baylyi strain ADP1" .
+
+obo:NCBITaxon_5741  rdfs:label  "Giardia intestinalis" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_243274  rdfs:label  "Thermotoga maritima MSB8" ;
+        rdfs:subClassOf  obo:NCBITaxon_2336 ;
+        bae:altLabel     "Thermotoga maritima str. MSB8" , "Thermotoga maritima strain MSB8" .
+
+obo:NCBITaxon_1305  rdfs:label  "Streptococcus sanguinis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_142586  rdfs:label  "Eubacterium sp." ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_1393  rdfs:label  "Brevibacillus brevis" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_98668  rdfs:label  "Mycolicibacterium septicum" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Mycobacterium genomospecies 3" , "Mycobacterium concordense" .
+
+obo:NCBITaxon_5501  rdfs:label  "Coccidioides immitis" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_69966  rdfs:label  "Macrococcus caseolyticus" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Staphylococcus caseilyticus" .
+
+obo:NCBITaxon_382819  rdfs:label  "Influenza A virus (A/NWS/1933(H1N1))" ;
+        rdfs:subClassOf  obo:NCBITaxon_114727 .
+
+obo:NCBITaxon_31646  rdfs:label  "Hepatitis C virus subtype 1a" ;
+        rdfs:subClassOf  obo:NCBITaxon_41856 .
+
+obo:NCBITaxon_1318  rdfs:label  "Streptococcus parasanguinis" ;
+        rdfs:subClassOf  obo:NCBITaxon_1301 .
+
+obo:NCBITaxon_186537  rdfs:label  "Marburgvirus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_873513  rdfs:label  "Prevotella buccae ATCC 33574" ;
+        rdfs:subClassOf  obo:NCBITaxon_28126 ;
+        bae:altLabel     "Prevotella buccae str. ATCC 33574" , "Prevotella buccae strain ATCC 33574" .
+
+obo:NCBITaxon_169066  rdfs:label  "Human rhinovirus sp." ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_33870  rdfs:label  "Coriobacterium" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_45567  rdfs:label  "[Candida] membranifaciens" ;
+        rdfs:subClassOf  bao:BAO_0000418 ;
+        bae:altLabel     "Candida membranifaciens" .
+
+obo:NCBITaxon_119210  rdfs:label  "H3N2 subtype" ;
+        rdfs:subClassOf  obo:NCBITaxon_11320 .
+
+obo:NCBITaxon_1080348
+        rdfs:label       "Toxoplasma gondii PRU" ;
+        rdfs:subClassOf  obo:NCBITaxon_5811 .
+
+obo:NCBITaxon_10580  rdfs:label  "Human papillomavirus type 11" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_133901  rdfs:label  "Frankliniella occidentalis" ;
+        rdfs:subClassOf  bao:BAO_0000511 ;
+        bae:altLabel     "western flower thrips" .
+
+obo:NCBITaxon_4952  rdfs:label  "Yarrowia lipolytica" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_179392  rdfs:label  "Paradendryphiella salina" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_9669  rdfs:label  "Mustela putorius furo" ;
+        rdfs:subClassOf  bao:BAO_0000362 ;
+        bae:altLabel     "domestic ferret" , "black ferret" , "ferret" .
+
+obo:NCBITaxon_13373  rdfs:label  "Burkholderia mallei" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_438045  rdfs:label  "Xenotropic MuLV-related virus" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_546273  rdfs:label  "Veillonella dispar ATCC 17748" ;
+        rdfs:subClassOf  bao:BAO_0000364 ;
+        bae:altLabel     "Veillonella dispar str. ATCC 17748" , "Veillonella dispar strain ATCC 17748" .
+
+obo:NCBITaxon_5821  rdfs:label  "Plasmodium berghei" ;
+        rdfs:subClassOf  bao:BAO_0000662 .
+
+obo:NCBITaxon_5068  rdfs:label  "Aspergillus tubingensis" ;
+        rdfs:subClassOf  obo:NCBITaxon_5052 .
+
+obo:NCBITaxon_284218  rdfs:label  "Influenza A virus (A/Viet Nam/1203/2004(H5N1))" ;
+        rdfs:subClassOf  bao:BAO_0000232 .
+
+obo:NCBITaxon_1638  rdfs:label  "Listeria ivanovii" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_39291  rdfs:label  "Athelia rolfsii" ;
+        rdfs:subClassOf  bao:BAO_0000418 .
+
+obo:NCBITaxon_373045  rdfs:label  "Escherichia coli O111:NM" ;
+        rdfs:subClassOf  bao:BAO_0000364 .
+
+obo:NCBITaxon_306902  rdfs:label  "Clavispora lusitaniae ATCC 42720" ;
+        rdfs:subClassOf  obo:NCBITaxon_36911 .

--- a/data/ontology/provisional_values.ttl
+++ b/data/ontology/provisional_values.ttl
@@ -338,4 +338,23 @@ bae:BAE_0000063
   obo:IAO_0000115 "" ;
   .
 
+# rearrangements to the "organism" hierarchy, to insert prokaryotes as a branch
+
+bae:BAE_0000064
+  rdfs:label "prokaryote" ;
+  rdfs:subClassOf bao:BAO_0000658 ;
+  obo:IAO_0000115 "Prokaryotes are single-celled organisms that lack nuclei." ;
+  .
+
+bao:BAO_0000364  
+  bat:notSubClass bao:BAO_0000658 ;
+  rdfs:subClassOf bae:BAE_0000064 ;
+  .
+
+bae:BAE_0000065
+  rdfs:label "archaea" ;
+  rdfs:subClassOf bae:BAE_0000064 ;
+  obo:IAO_0000115 "Archaea are an ancient branch of prokaryotes, exemplified by deep ocean extremophiles." ;
+  .
+
 

--- a/src/com/cdd/bao/template/Vocabulary.java
+++ b/src/com/cdd/bao/template/Vocabulary.java
@@ -453,7 +453,7 @@ public class Vocabulary
 
 			String subjURI = remapIfAny(subject.getURI());
 			String objURI = remapIfAny(object.getURI());
-			classBreakers.add(subjURI + "::" + objURI);
+			classBreakers.add(subjURI + SEP + objURI);
 		}
 		for (StmtIterator iter = model.listStatements(null, rdfType, resEliminated); iter.hasNext();)
 		{
@@ -638,8 +638,6 @@ public class Vocabulary
 
 				String labelChild = uriToLabel.get(uriChild), labelParent = uriToLabel.get(uriParent);
 				if (labelChild == null || labelParent == null) continue;
-				
-				//Util.writeln("{"+uriParent+":"+getLabel(uriParent)+"} -> {"+uriChild+":"+getLabel(uriChild)+"}");
 				
 				Branch child = hier.uriToBranch.get(uriChild), parent = hier.uriToBranch.get(uriParent);
 				


### PR DESCRIPTION
There's now a new ontology file, `extra_organisms.ttl`, which has a number of NCBI taxonomy organisms to supplement what BAO originally cherry-picked from the complete set. The entire taxonomy is way too large to include, but the total set should now be a fairly inclusive selection for drug discovery purposes.

The imported terms are reparented to use the condensed and simplified branching that BAO introduced:

![image](https://user-images.githubusercontent.com/6205603/55158948-771d3f00-5136-11e9-8eb0-1e7d318aab01.png)

The BAO hierarchy has also been modified so that bacteria is currently a sub-branch of prokaryote, and archaea have been included... in case anybody wants to target extremophiles.