### PR TITLE
addNodes fix: clones properly

### DIFF
--- a/src/com/cdd/bao/template/SchemaTree.java
+++ b/src/com/cdd/bao/template/SchemaTree.java
@@ -58,11 +58,14 @@ public class SchemaTree
 		public Node(Branch source, String descr)
 		{
 			this.source = source;
-			uri = source.uri;
-			label = source.label;
+			if (source != null)
+			{
+				uri = source.uri;
+				label = source.label;
+			}
 			this.descr = descr;
 		}
-
+		
 		public String toString()
 		{
 			StringBuilder sb = new StringBuilder();
@@ -148,42 +151,51 @@ public class SchemaTree
 	// label, description, and uri fields return true if SchemaTree was changed, false otherwise
 	public List<Node> addNodes(List<Pair<String, Node>> nodes)
 	{
-		List<Node> wasAdded = new ArrayList<>();
-		
+		List<Node> wereAdded = new ArrayList<>();
 		List<Pair<String, Node>> candidates = new ArrayList<>(nodes); 
+
 		while (!candidates.isEmpty())
 		{
+			boolean modified = false;
 			int prevSize = candidates.size();
 			for (Iterator<Pair<String, Node>> it = candidates.iterator(); it.hasNext();)
 			{
 				Pair<String, Node> pair = it.next();
 				Node parent = tree.get(pair.getLeft());
-				if (parent != null)
-				{
-					Node node = pair.getRight();
-					node.parent = parent;
-					node.depth = parent.depth + 1;
-					parent.children.add(node);
-					parent.childCount++;
-					node.inSchema = false;
-					node.isExplicit = false;
-					wasAdded.add(node);
+				if (parent == null) continue;
+				
+				Node srcNode = pair.getRight();
+				Node node = new Node(srcNode.source, srcNode.descr);
+				node.uri = srcNode.uri;
+				node.label = srcNode.label;
+				node.altLabels = srcNode.altLabels;
+				node.externalURLs = srcNode.externalURLs;
+				node.pubchemSource = srcNode.pubchemSource;
+				node.pubchemImport = srcNode.pubchemImport;
+				node.parent = parent;
+				node.depth = parent.depth + 1;
+				parent.children.add(node);
+				parent.childCount++;
+				node.inSchema = false;
+				node.isExplicit = false;
+				wereAdded.add(node);
 
-					tree.put(node.uri, node);
-					list.add(node);
-					
-					it.remove();
-				}
+				tree.put(node.uri, node);
+				list.add(node);
+				
+				it.remove();
+				modified = true;
 			}
-			if (prevSize == candidates.size()) break; // exit outer loop if no change
+			if (!modified) break;
 		}
-		if (wasAdded.size() > 0)
+		
+		if (wereAdded.size() > 0)
 		{
 			// both flat & list need to be updated
 			flattenTree();
 			list.sort((v1, v2) -> v1.label.compareToIgnoreCase(v2.label));
 		}
-		return wasAdded;
+		return wereAdded;
 	}
 
 	// tack on value node to this schema tree, leaving the underlying assignment untouched

--- a/src/com/cdd/bao/template/SchemaTree.java
+++ b/src/com/cdd/bao/template/SchemaTree.java
@@ -157,7 +157,6 @@ public class SchemaTree
 		while (!candidates.isEmpty())
 		{
 			boolean modified = false;
-			int prevSize = candidates.size();
 			for (Iterator<Pair<String, Node>> it = candidates.iterator(); it.hasNext();)
 			{
 				Pair<String, Node> pair = it.next();

--- a/src/com/cdd/bao/template/SchemaVocab.java
+++ b/src/com/cdd/bao/template/SchemaVocab.java
@@ -404,7 +404,7 @@ public class SchemaVocab
 	// update internal data structures to reflect addition of named terms and any related remappings
 	public void addTerms(List<StoredTerm> newTerms, Map<String, StoredRemapTo> newTermRemappings)
 	{
-		StoredTerm[] newTermList = (StoredTerm[]) ArrayUtils.addAll(termList, newTerms.toArray(new StoredTerm[0]));
+		StoredTerm[] newTermList = ArrayUtils.addAll(termList, newTerms.toArray(new StoredTerm[0]));
 		for (int k = termList.length; k < newTermList.length; k++)
 		{
 			termLookup.put(newTermList[k].uri, Integer.valueOf(k));


### PR DESCRIPTION
Previously when nodes were being added to the tree from the provisional collection, each fabricated Node instance could be added to any number of branches - and the object was being manipulated directly, which was fine if it only inserted into one position, but broken if it got invoked more than once.

This could be the fix for a [hard to reproduce] bug that I encountered recently.