### PR TITLE
Added 'mandatory' field

### DIFF
--- a/data/template/schema.json
+++ b/data/template/schema.json
@@ -12,6 +12,7 @@
                 "descr": "A short summary description of the assay.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002853",
                 "suggestions": "string",
+                "mandatory": false,
                 "values": []
             }, 
             {
@@ -19,6 +20,7 @@
                 "descr": "Categorization of bioassays based on the property or process that the assay is interrogating, e.g. ADMET, functional, etc.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002854",
                 "suggestions": "full",
+                "mandatory": true,
                 "values": 
                 [
                     {
@@ -52,6 +54,7 @@
                 "descr": "Categorization of the general class of bioassay (enyzme activity, gene expression...)",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002855",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -115,6 +118,7 @@
                 "descr": "Assay format is a conceptualization of assays based on the biological and / or chemical features of the experimental system. For example assay formats include biochemical assays - referring to assays with purified protein, cell-based - referring to assays in whole cells, or organism-based - referring to assays performed in an organism.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0000205",
                 "suggestions": "full",
+                "mandatory": true,
                 "values": 
                 [
                     {
@@ -148,6 +152,7 @@
                 "descr": "The assay design method describes how a biological or physical process screened / investigated in the model system is translated into a detectable signal. This relates to the technology / technologies used to make the assay system work, i.e. enable that the screened process can be detected.  It typically involves some manipulation of the (biological) model system to detect the process of interest.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0095009",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -187,6 +192,7 @@
                 "descr": "Assay supporting methods describe the methods to prepare, generate or post-process the assay system or assay screening process. Such methods include the sample preparation, labeling, data processing, etc., which are required to performing the assay, but do not constitute the actual assay (design method).",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0095010",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -226,6 +232,7 @@
                 "descr": "An assay cell line refers to the source of the cells or cell line used in the assay. This may be from primary cells (as annotated) or, more frequently, from an immortal cell line. Due to the continued passaging of immortal cell lines, users must be aware that spontaneous mutations can, and often do, arise in sub-populations, such that the actual cells used in the individual assay may differ from the original source.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002800",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -265,6 +272,7 @@
                 "descr": "The organism related to the target / meta-target of the bioassay. It includes both bacterium and eukaryote.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002921",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -298,6 +306,7 @@
                 "descr": "Any process specifically pertinent to the functioning of integrated living units: cells, tissues, organs, and organisms. A process is a collection of molecular events with a defined beginning and end (from GO). For annotated BioAssays, Biological Process is the process that is being (or is presumed to be) affected by an entity with a perturbagen role in the assay.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002009",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -343,6 +352,7 @@
                 "descr": "The molecular entity (e.g., protein, carbohydrate, nucleic acid, or other) that is the presumed subject of the assay and whose activity is being effected by an entity with a perturbagen role in the assay. Can encompass the TYPE of biological macromolecule (e.g., enzyme, chaperone, GPCR, etc.) as well as the specific molecular target (e.g., gene name or geneid). An assay can have zero (e.g., if unknown as in assays for cytotoxic compounds) or multiple targets.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0000211",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -382,6 +392,7 @@
                 "descr": "Disease targets that the assay is designed to affect. This is a more general term than the specific biological target.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002848",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -421,6 +432,7 @@
                 "descr": "Assay mode of action refers both to the mechanism (binding vs. functional) and the effect of the perturbagen on the target - whether it brings about inhibition, activation, cytotoxicity, etc.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0000196",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -454,6 +466,7 @@
                 "descr": "The endpoint is a quantitive or qualitative interpretable standardized representation of a perturbation (a change from a defined reference state of a \"closed\" model system) that is measured by the bioassay.  An endpoint consists of a series of data points, one for each perturbing agent (screened entity) tested the assay.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0000208",
                 "suggestions": "full",
+                "mandatory": true,
                 "values": 
                 [
                     {
@@ -487,6 +500,7 @@
                 "descr": "The assay stage describes the purpose of the assay in an assay campaign.  Assay stage also relates to the order of assays in a screening campaign.  For example the primary assay, which is performed first, identifies hits. The primary hits are then confirmed in a confirmatory assay.  Subsequent secondary assays are run to eliminate compounds that are not of interest or to confirm hits using an alternate design / technology, or to further characterize compounds.\nWhether an assay is run in single concentration or concentration response is defined in the class 'assay measurement throughput quality'.  For example primary assays are typically run in single concentration with single measurements. However, the NCGC runs qHTS primary assays as concentration-response assays.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0000210",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -520,6 +534,7 @@
                 "descr": "This describes the physical format such as plate density in which an assay is performed, which is generally a microplate format, but can also be an array format.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002867",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -553,6 +568,7 @@
                 "descr": "The title of the kit/biologicals used in the assay.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002663",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -586,6 +602,7 @@
                 "descr": "The physical method (technology) used to measure / readout the effect caused by a perturbagen in the assay environment.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0000207",
                 "suggestions": "full",
+                "mandatory": true,
                 "values": 
                 [
                     {
@@ -619,6 +636,7 @@
                 "descr": "The names of equipment used for measurement/readout from an assay, e.g. FLIPR, ViewLux plate reader, PHERAstar, etc.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002865",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -652,6 +670,7 @@
                 "descr": "Compounds or other perturbagens that modulate diverse biological targets.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0000185",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -691,6 +710,7 @@
                 "descr": "Protein identity, from the NCBI reference set.",
                 "propURI": "http://www.bioassayontology.org/bao#BAX_0000012",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -706,6 +726,7 @@
                 "descr": "Gene identity, from the NCBI reference set.",
                 "propURI": "http://www.bioassayontology.org/bao#BAX_0000011",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -721,6 +742,7 @@
                 "descr": "Functions of the target gene, selected from the Gene Ontology hierarchy.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0003107",
                 "suggestions": "disabled",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -772,6 +794,7 @@
                 "descr": "",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0002852",
                 "suggestions": "full",
+                "mandatory": false,
                 "values": 
                 [
                     {
@@ -787,6 +810,7 @@
                 "descr": "Assays belonging to the same project.",
                 "propURI": "http://www.bioassayontology.org/bao#BAO_0000539",
                 "suggestions": "id",
+                "mandatory": false,
                 "values": []
             }
         ],
@@ -804,6 +828,7 @@
                         "descr": "Field name for the column that supplies the activity units.",
                         "propURI": "http://www.bioassayontology.org/bao#BAX_0000015",
                         "suggestions": "field",
+                        "mandatory": false,
                         "values": []
                     }, 
                     {
@@ -811,6 +836,7 @@
                         "descr": "Units for the resulting measurements (e.g. IC50, EC50, etc.)",
                         "propURI": "http://www.bioassayontology.org/bao#BAO_0002874",
                         "suggestions": "full",
+                        "mandatory": false,
                         "values": 
                         [
                             {
@@ -874,6 +900,7 @@
                         "descr": "Defines the cutoff relationship for active/inactive",
                         "propURI": "http://www.bioassayontology.org/bao#BAX_0000016",
                         "suggestions": "full",
+                        "mandatory": false,
                         "values": 
                         [
                             {
@@ -889,6 +916,7 @@
                         "descr": "Defines the value cutoff for active/inactive.",
                         "propURI": "http://www.bioassayontology.org/bao#BAO_0002916",
                         "suggestions": "number",
+                        "mandatory": false,
                         "values": []
                     }
                 ],

--- a/src/com/cdd/bao/axioms/CellLineFix.java
+++ b/src/com/cdd/bao/axioms/CellLineFix.java
@@ -597,7 +597,7 @@ public class CellLineFix
 			d[i][j] = Math.min(Math.min(d[i - 1][j] + 1, d[i][j - 1] + 1), d[i - 1][j - 1] + cost);
 		}
 		return d[sz1][sz2];
-	}	
+	}
 	
 	private void processCurated(File f) throws IOException
 	{

--- a/src/com/cdd/bao/editor/DetailPane.java
+++ b/src/com/cdd/bao/editor/DetailPane.java
@@ -604,6 +604,7 @@ public class DetailPane extends ScrollPane implements URIRowLine.Delegate
 
 		chkMandatory = new CheckBox("Mandatory");
 		chkMandatory.setSelected(assignment.mandatory);
+		Tooltip.install(chkMandatory, new Tooltip("If checked, the assignment should not be left blank."));
 
 		suggestionsLine.getChildren().addAll(suggestionsFull, suggestionsDisabled, suggestionsField, suggestionsURL, suggestionsID, 
 											 suggestionsString, suggestionsNumber, suggestionsInteger, suggestionsDate, chkMandatory);

--- a/src/com/cdd/bao/editor/DetailPane.java
+++ b/src/com/cdd/bao/editor/DetailPane.java
@@ -70,6 +70,7 @@ public class DetailPane extends ScrollPane implements URIRowLine.Delegate
 	private RadioButton suggestionsFull = null, suggestionsDisabled = null, suggestionsField = null;
 	private RadioButton suggestionsURL = null, suggestionsID = null, suggestionsString = null;
 	private RadioButton suggestionsNumber = null, suggestionsInteger = null, suggestionsDate = null; 
+	private CheckBox chkMandatory = null;
 	
 	private final class ValueWidgets
 	{
@@ -217,6 +218,8 @@ public class DetailPane extends ScrollPane implements URIRowLine.Delegate
 		else if (suggestionsNumber.isSelected()) mod.suggestions = Schema.Suggestions.NUMBER;
 		else if (suggestionsInteger.isSelected()) mod.suggestions = Schema.Suggestions.INTEGER;
 		else if (suggestionsDate.isSelected()) mod.suggestions = Schema.Suggestions.DATE;
+		
+		mod.mandatory = chkMandatory.isSelected();
 		
 		if (isSummaryView)
 		{
@@ -598,8 +601,13 @@ public class DetailPane extends ScrollPane implements URIRowLine.Delegate
 		suggestionsNumber.setSelected(assignment.suggestions == Schema.Suggestions.NUMBER);
 		suggestionsInteger.setSelected(assignment.suggestions == Schema.Suggestions.INTEGER);
 		suggestionsDate.setSelected(assignment.suggestions == Schema.Suggestions.DATE);
+
+		chkMandatory = new CheckBox("Mandatory");
+		chkMandatory.setSelected(assignment.mandatory);
+
 		suggestionsLine.getChildren().addAll(suggestionsFull, suggestionsDisabled, suggestionsField, suggestionsURL, suggestionsID, 
-											 suggestionsString, suggestionsNumber, suggestionsInteger, suggestionsDate);
+											 suggestionsString, suggestionsNumber, suggestionsInteger, suggestionsDate, chkMandatory);
+
 		line.add(suggestionsLine, "Suggestions:", 1, 0);
 
 		vbox.getChildren().add(line);

--- a/src/com/cdd/bao/template/ClipboardSchema.java
+++ b/src/com/cdd/bao/template/ClipboardSchema.java
@@ -172,6 +172,7 @@ public class ClipboardSchema
 		json.put("descr", assn.descr);
 		json.put("propURI", assn.propURI);
 		json.put("suggestions", assn.suggestions.toString().toLowerCase());
+		json.put("mandatory", assn.mandatory);
 
 		JSONArray jvalues = new JSONArray();
 		for (Schema.Value val : assn.values)
@@ -284,6 +285,8 @@ public class ClipboardSchema
 			try {assn.suggestions = Schema.Suggestions.valueOf(suggestValue.toUpperCase());}
 			catch (IllegalArgumentException ex) {} // silent fail: leave it as default (see class definition)
 		}
+		
+		assn.mandatory = json.optBoolean("mandatory", false);
 		
 		JSONArray jvalues = json.getJSONArray("values");
 		for (int n = 0; n < jvalues.length(); n++)

--- a/src/com/cdd/bao/template/ModelSchema.java
+++ b/src/com/cdd/bao/template/ModelSchema.java
@@ -86,6 +86,7 @@ public class ModelSchema
 	public static final String IS_WHOLEBRANCH = "isWholeBranch"; // indicates a value refers to an entire branch, not just one term
 	public static final String IS_EXCLUDEBRANCH = "isExcludeBranch"; // indicates a value refers to an entire branch to exclude
 	public static final String IS_CONTAINER = "isContainer"; // indicates a value that is not explicitly selected
+	public static final String IS_MANDATORY = "isMandatory"; // indicates that the assignment should not be blank
 	
 	public static final String SUGGESTIONS_FULL = "suggestionsFull"; // normal state: all suggestion modelling options enabled
 	public static final String SUGGESTIONS_DISABLED = "suggestionsDisabled"; // do not use for suggestion models (neither input nor output)
@@ -108,7 +109,7 @@ public class ModelSchema
 	private Property hasGroupURI, hasProperty, hasValue;
 	private Property mapsTo;
 	private Property hasAnnotation, isAssignment, hasLiteral;
-	private Property isExclude, isWholeBranch, isExcludeBranch, isContainer;
+	private Property isExclude, isWholeBranch, isExcludeBranch, isContainer, isMandatory;
 	private Property suggestionsFull, suggestionsDisabled, suggestionsField;
 	private Property suggestionsURL, suggestionsID, suggestionsString;
 	private Property suggestionsNumber, suggestionsInteger, suggestionsDate;
@@ -306,6 +307,7 @@ public class ModelSchema
 		isWholeBranch = model.createProperty(PFX_BAT + IS_WHOLEBRANCH);
 		isExcludeBranch = model.createProperty(PFX_BAT + IS_EXCLUDEBRANCH);
 		isContainer = model.createProperty(PFX_BAT + IS_CONTAINER);
+		isMandatory = model.createProperty(PFX_BAT + IS_MANDATORY);
 		suggestionsFull = model.createProperty(PFX_BAT + SUGGESTIONS_FULL);
 		suggestionsDisabled = model.createProperty(PFX_BAT + SUGGESTIONS_DISABLED);
 		suggestionsField = model.createProperty(PFX_BAT + SUGGESTIONS_FIELD);
@@ -400,6 +402,8 @@ public class ModelSchema
 			else if (assn.suggestions == Schema.Suggestions.INTEGER) model.add(objAssn, suggestionsInteger, model.createTypedLiteral(true));
 			else if (assn.suggestions == Schema.Suggestions.DATE) model.add(objAssn, suggestionsDate, model.createTypedLiteral(true));
 			
+			model.add(objAssn, isMandatory, model.createTypedLiteral(assn.mandatory));
+			
 			int vorder = 0;
 			for (Value val : assn.values)
 			{
@@ -415,7 +419,7 @@ public class ModelSchema
 				else if (val.spec == Schema.Specify.WHOLEBRANCH) model.add(blank, isWholeBranch, model.createTypedLiteral(true));
 				else if (val.spec == Schema.Specify.EXCLUDEBRANCH) model.add(blank, isExcludeBranch, model.createTypedLiteral(true));
 				else if (val.spec == Schema.Specify.CONTAINER) model.add(blank, isContainer, model.createTypedLiteral(true));
-
+				
 				model.add(blank, inOrder, model.createTypedLiteral(++vorder));
 			}
 			
@@ -530,6 +534,8 @@ public class ModelSchema
 						   findBoolean(objAssn, suggestionsNumber) ? Schema.Suggestions.NUMBER : 
 						   findBoolean(objAssn, suggestionsInteger) ? Schema.Suggestions.INTEGER : 
 						   findBoolean(objAssn, suggestionsDate) ? Schema.Suggestions.DATE : Schema.Suggestions.FULL;
+
+		assn.mandatory = findBoolean(objAssn, isContainer);
 		
 		Map<Object, Integer> order = new HashMap<>();
 

--- a/src/com/cdd/bao/template/Schema.java
+++ b/src/com/cdd/bao/template/Schema.java
@@ -171,6 +171,7 @@ public class Schema
 		public String propURI;
 		public List<Value> values = new ArrayList<>();
 		public Suggestions suggestions = Suggestions.FULL;
+		public boolean mandatory = false;
 		
 		public Assignment(Group parent, String name, String propURI) 
 		{
@@ -185,6 +186,7 @@ public class Schema
 			dup.descr = descr;
 			for (Value val : values) dup.values.add(val.clone());
 			dup.suggestions = suggestions;
+			dup.mandatory = mandatory;
 			return dup;
 		}
 		
@@ -195,13 +197,13 @@ public class Schema
 			if (o == null || getClass() != o.getClass()) return false;
 			Assignment other = (Assignment)o;
 			return Util.equals(name, other.name) && Util.equals(descr, other.descr) && Util.equals(propURI, other.propURI) &&
-				   suggestions == other.suggestions && values.equals(other.values);
+				   suggestions == other.suggestions && mandatory == other.mandatory && values.equals(other.values);
 		}
 
 		@Override
 		public int hashCode()
 		{
-			return Objects.hash(name, descr, propURI, suggestions, values);
+			return Objects.hash(name, descr, propURI, suggestions, mandatory, values);
 		}
 		
 		// returns true if the other assignment has the same branch sequence, i.e. the name is the same, and likewise for the trail of parent groups


### PR DESCRIPTION
The schema (and its JSON/TTL file formats) now have a "mandatory" flag per assignment. It is also present in the editor. The flag is a hint to derived applications that the assignment should not be left blank. Four fields in the CAT have been marked as so (in lieu of more later).