### PR TITLE
Split the BRENDA list

### DIFF
--- a/data/ontology/brendafix.ttl
+++ b/data/ontology/brendafix.ttl
@@ -23,2985 +23,5964 @@ bae:BrendaTissues
 
 # reparenting cells
 
-obo:BTO_0000003 rdfs:subClassOf bae:BrendaCell . # intestinal cell line
-obo:BTO_0000006 rdfs:subClassOf bae:BrendaCell . # osteoblastoma cell
-obo:BTO_0000028 rdfs:subClassOf bae:BrendaCell . # pancreatic acinar cell
-obo:BTO_0000032 rdfs:subClassOf bae:BrendaCell . # colonic adenocarcinoma cell
-obo:BTO_0000036 rdfs:subClassOf bae:BrendaCell . # gastric adenocarcinoma cell
-obo:BTO_0000037 rdfs:subClassOf bae:BrendaCell . # renal cell carcinoma cell
-obo:BTO_0000067 rdfs:subClassOf bae:BrendaCell . # kidney cell line
-obo:BTO_0000094 rdfs:subClassOf bae:BrendaCell . # ascites tumor cell
-obo:BTO_0000100 rdfs:subClassOf bae:BrendaCell . # astrocytoma cell
-obo:BTO_0000101 rdfs:subClassOf bae:BrendaCell . # astrocytoma cell line
-obo:BTO_0000104 rdfs:subClassOf bae:BrendaCell . # lymphoma cell line
-obo:BTO_0000110 rdfs:subClassOf bae:BrendaCell . # amniotic cell line
-obo:BTO_0000125 rdfs:subClassOf bae:BrendaCell . # blast cell
-obo:BTO_0000150 rdfs:subClassOf bae:BrendaCell . # breast cancer cell
-obo:BTO_0000152 rdfs:subClassOf bae:BrendaCell . # infected cell
-obo:BTO_0000161 rdfs:subClassOf bae:BrendaCell . # lung fibroblast cell line
-obo:BTO_0000167 rdfs:subClassOf bae:BrendaCell . # adenocarcinoma cell line
-obo:BTO_0000176 rdfs:subClassOf bae:BrendaCell . # carcinoma cell
-obo:BTO_0000177 rdfs:subClassOf bae:BrendaCell . # BG-1 cell
-obo:BTO_0000178 rdfs:subClassOf bae:BrendaCell . # adenoma cell
-obo:BTO_0000180 rdfs:subClassOf bae:BrendaCell . # cervical carcinoma cell
-obo:BTO_0000181 rdfs:subClassOf bae:BrendaCell . # Lewis lung carcinoma cell line
-obo:BTO_0000184 rdfs:subClassOf bae:BrendaCell . # medullary thyroid carcinoma cell
-obo:BTO_0000186 rdfs:subClassOf bae:BrendaCell . # lobular carcinoma cell
-obo:BTO_0000188 rdfs:subClassOf bae:BrendaCell . # colonic cell line
-obo:BTO_0000189 rdfs:subClassOf bae:BrendaCell . # small cell lung cancer cell
-obo:BTO_0000191 rdfs:subClassOf bae:BrendaCell . # medullary carcinoma cell
-obo:BTO_0000192 rdfs:subClassOf bae:BrendaCell . # nasopharyngeal carcinoma cell
-obo:BTO_0000193 rdfs:subClassOf bae:BrendaCell . # rectal cancer cell
-obo:BTO_0000194 rdfs:subClassOf bae:BrendaCell . # endometrioid carcinoma cell
-obo:BTO_0000196 rdfs:subClassOf bae:BrendaCell . # thyroid cancer cell
-obo:BTO_0000197 rdfs:subClassOf bae:BrendaCell . # carcinosarcoma cell
-obo:BTO_0000201 rdfs:subClassOf bae:BrendaCell . # pheochromocytoma cell line
-obo:BTO_0000218 rdfs:subClassOf bae:BrendaCell . # BALB/3T3 cell
-obo:BTO_0000223 rdfs:subClassOf bae:BrendaCell . # teratocarcinoma cell
-obo:BTO_0000224 rdfs:subClassOf bae:BrendaCell . # liver cell line
-obo:BTO_0000225 rdfs:subClassOf bae:BrendaCell . # CEM cell
-obo:BTO_0000228 rdfs:subClassOf bae:BrendaCell . # C-1300 cell
-obo:BTO_0000250 rdfs:subClassOf bae:BrendaCell . # chondrosarcoma cell
-obo:BTO_0000256 rdfs:subClassOf bae:BrendaCell . # myoblast cell line
-obo:BTO_0000257 rdfs:subClassOf bae:BrendaCell . # uterine cancer cell
-obo:BTO_0000259 rdfs:subClassOf bae:BrendaCell . # chromaffin cell
-obo:BTO_0000264 rdfs:subClassOf bae:BrendaCell . # bone marrow cell line
-obo:BTO_0000279 rdfs:subClassOf bae:BrendaCell . # testicular cancer cell
-obo:BTO_0000306 rdfs:subClassOf bae:BrendaCell . # teratocarcinoma cell line
-obo:BTO_0000308 rdfs:subClassOf bae:BrendaCell . # cytotoxic T-lymphocyte cell line
-obo:BTO_0000309 rdfs:subClassOf bae:BrendaCell . # bundle sheath cell
-obo:BTO_0000353 rdfs:subClassOf bae:BrendaCell . # lung cell line
-obo:BTO_0000356 rdfs:subClassOf bae:BrendaCell . # breast cancer cell line
-obo:BTO_0000362 rdfs:subClassOf bae:BrendaCell . # urinary bladder cancer cell
-obo:BTO_0000373 rdfs:subClassOf bae:BrendaCell . # Ehrlich ascites carcinoma cell
-obo:BTO_0000375 rdfs:subClassOf bae:BrendaCell . # keratinocyte cell line
-obo:BTO_0000383 rdfs:subClassOf bae:BrendaCell . # renal cell carcinoma cell line
-obo:BTO_0000392 rdfs:subClassOf bae:BrendaCell . # plasma cell
-obo:BTO_0000395 rdfs:subClassOf bae:BrendaCell . # alveolar cell
-obo:BTO_0000396 rdfs:subClassOf bae:BrendaCell . # EAhy 926 cell
-obo:BTO_0000400 rdfs:subClassOf bae:BrendaCell . # sarcoma cell line
-obo:BTO_0000403 rdfs:subClassOf bae:BrendaCell . # mastocytoma cell line
-obo:BTO_0000407 rdfs:subClassOf bae:BrendaCell . # osteosarcoma cell line
-obo:BTO_0000414 rdfs:subClassOf bae:BrendaCell . # epithelial cell
-obo:BTO_0000426 rdfs:subClassOf bae:BrendaCell . # erythroleukemia cell
-obo:BTO_0000427 rdfs:subClassOf bae:BrendaCell . # pituitary gland cell line
-obo:BTO_0000433 rdfs:subClassOf bae:BrendaCell . # exocrine acinar cell
-obo:BTO_0000453 rdfs:subClassOf bae:BrendaCell . # fibroblast cell line
-obo:BTO_0000456 rdfs:subClassOf bae:BrendaCell . # plasmacytoma cell line
-obo:BTO_0000459 rdfs:subClassOf bae:BrendaCell . # fibrosarcoma cell
-obo:BTO_0000460 rdfs:subClassOf bae:BrendaCell . # fibrosarcoma cell line
-obo:BTO_0000489 rdfs:subClassOf bae:BrendaCell . # intestinal cancer cell
-obo:BTO_0000492 rdfs:subClassOf bae:BrendaCell . # MST cell
-obo:BTO_0000498 rdfs:subClassOf bae:BrendaCell . # gastric cancer cell
-obo:BTO_0000526 rdfs:subClassOf bae:BrendaCell . # glioma cell
-obo:BTO_0000527 rdfs:subClassOf bae:BrendaCell . # glioblastoma cell
-obo:BTO_0000529 rdfs:subClassOf bae:BrendaCell . # C6 glioma cell
-obo:BTO_0000535 rdfs:subClassOf bae:BrendaCell . # germ cell
-obo:BTO_0000540 rdfs:subClassOf bae:BrendaCell . # pollen mother cell
-obo:BTO_0000542 rdfs:subClassOf bae:BrendaCell . # granulosa cell
-obo:BTO_0000544 rdfs:subClassOf bae:BrendaCell . # guard cell
-obo:BTO_0000551 rdfs:subClassOf bae:BrendaCell . # lung cancer cell
-obo:BTO_0000552 rdfs:subClassOf bae:BrendaCell . # HaCaT cell
-obo:BTO_0000574 rdfs:subClassOf bae:BrendaCell . # hematopoietic cell
-obo:BTO_0000576 rdfs:subClassOf bae:BrendaCell . # B-16 cell
-obo:BTO_0000577 rdfs:subClassOf bae:BrendaCell . # Morris hepatoma 3924A cell
-obo:BTO_0000578 rdfs:subClassOf bae:BrendaCell . # hepatoma cell line
-obo:BTO_0000579 rdfs:subClassOf bae:BrendaCell . # eye cancer cell
-obo:BTO_0000583 rdfs:subClassOf bae:BrendaCell . # bone marrow cancer cell
-obo:BTO_0000584 rdfs:subClassOf bae:BrendaCell . # pancreatic cancer cell
-obo:BTO_0000585 rdfs:subClassOf bae:BrendaCell . # intraocular melanoma cell
-obo:BTO_0000586 rdfs:subClassOf bae:BrendaCell . # colonic cancer cell
-obo:BTO_0000592 rdfs:subClassOf bae:BrendaCell . # adrenal gland cancer cell
-obo:BTO_0000594 rdfs:subClassOf bae:BrendaCell . # liver cancer cell
-obo:BTO_0000604 rdfs:subClassOf bae:BrendaCell . # adenocarcinoma cell
-obo:BTO_0000608 rdfs:subClassOf bae:BrendaCell . # hepatoma cell
-obo:BTO_0000610 rdfs:subClassOf bae:BrendaCell . # hybridoma cell
-obo:BTO_0000632 rdfs:subClassOf bae:BrendaCell . # insulinoma cell
-obo:BTO_0000638 rdfs:subClassOf bae:BrendaCell . # interrenal cell
-obo:BTO_0000658 rdfs:subClassOf bae:BrendaCell . # uterine adenocarcinoma cell
-obo:BTO_0000669 rdfs:subClassOf bae:BrendaCell . # embryonic cell line
-obo:BTO_0000680 rdfs:subClassOf bae:BrendaCell . # kidney cancer cell
-obo:BTO_0000681 rdfs:subClassOf bae:BrendaCell . # KM-3 cell
-obo:BTO_0000685 rdfs:subClassOf bae:BrendaCell . # Kupffer cell
-obo:BTO_0000686 rdfs:subClassOf bae:BrendaCell . # Kurloff cell
-obo:BTO_0000705 rdfs:subClassOf bae:BrendaCell . # Langerhans cell
-obo:BTO_0000711 rdfs:subClassOf bae:BrendaCell . # glioma cell line
-obo:BTO_0000716 rdfs:subClassOf bae:BrendaCell . # pancreatic beta cell line
-obo:BTO_0000725 rdfs:subClassOf bae:BrendaCell . # hematopoietic stem cell
-obo:BTO_0000727 rdfs:subClassOf bae:BrendaCell . # multiple myeloma cell line
-obo:BTO_0000729 rdfs:subClassOf bae:BrendaCell . # carcinoid cell
-obo:BTO_0000731 rdfs:subClassOf bae:BrendaCell . # acute lymphoblastic leukemia cell
-obo:BTO_0000737 rdfs:subClassOf bae:BrendaCell . # leukemia cell line
-obo:BTO_0000741 rdfs:subClassOf bae:BrendaCell . # lymphocytic leukemia cell line
-obo:BTO_0000743 rdfs:subClassOf bae:BrendaCell . # pre-B-lymphocyte cell line
-obo:BTO_0000745 rdfs:subClassOf bae:BrendaCell . # Lewis lung carcinoma cell
-obo:BTO_0000746 rdfs:subClassOf bae:BrendaCell . # preadipocyte cell line
-obo:BTO_0000755 rdfs:subClassOf bae:BrendaCell . # Leydig cell
-obo:BTO_0000760 rdfs:subClassOf bae:BrendaCell . # LLC-PK1 cell
-obo:BTO_0000762 rdfs:subClassOf bae:BrendaCell . # lung cancer cell line
-obo:BTO_0000773 rdfs:subClassOf bae:BrendaCell . # lymphoblastoid cell line
-obo:BTO_0000774 rdfs:subClassOf bae:BrendaCell . # lymphoblastoma cell
-obo:BTO_0000783 rdfs:subClassOf bae:BrendaCell . # pancreatic beta cell
-obo:BTO_0000785 rdfs:subClassOf bae:BrendaCell . # lymphoma cell
-obo:BTO_0000787 rdfs:subClassOf bae:BrendaCell . # gastric cancer cell line
-obo:BTO_0000792 rdfs:subClassOf bae:BrendaCell . # urinary bladder cancer cell line
-obo:BTO_0000794 rdfs:subClassOf bae:BrendaCell . # pancreatic cancer cell line
-obo:BTO_0000795 rdfs:subClassOf bae:BrendaCell . # L-5178-Y cell
-obo:BTO_0000797 rdfs:subClassOf bae:BrendaCell . # colonic cancer cell line
-obo:BTO_0000799 rdfs:subClassOf bae:BrendaCell . # lymphosarcoma cell
-obo:BTO_0000803 rdfs:subClassOf bae:BrendaCell . # pancreatic delta cell
-obo:BTO_0000811 rdfs:subClassOf bae:BrendaCell . # ovary cancer cell line
-obo:BTO_0000830 rdfs:subClassOf bae:BrendaCell . # mast cell
-obo:BTO_0000832 rdfs:subClassOf bae:BrendaCell . # mastocytoma cell
-obo:BTO_0000845 rdfs:subClassOf bae:BrendaCell . # meiotic cell
-obo:BTO_0000846 rdfs:subClassOf bae:BrendaCell . # erythroleukemia cell line
-obo:BTO_0000848 rdfs:subClassOf bae:BrendaCell . # melanoma cell
-obo:BTO_0000849 rdfs:subClassOf bae:BrendaCell . # melanoma cell line
-obo:BTO_0000850 rdfs:subClassOf bae:BrendaCell . # amelanotic melanoma cell
-obo:BTO_0000851 rdfs:subClassOf bae:BrendaCell . # adrenal cortex cell line
-obo:BTO_0000853 rdfs:subClassOf bae:BrendaCell . # mesangial cell
-obo:BTO_0000860 rdfs:subClassOf bae:BrendaCell . # CHRB-30 cell
-obo:BTO_0000872 rdfs:subClassOf bae:BrendaCell . # oligodendrocytic cell line
-obo:BTO_0000875 rdfs:subClassOf bae:BrendaCell . # N20.1 cell
-obo:BTO_0000878 rdfs:subClassOf bae:BrendaCell . # mononuclear cell
-obo:BTO_0000885 rdfs:subClassOf bae:BrendaCell . # tongue cell line
-obo:BTO_0000889 rdfs:subClassOf bae:BrendaCell . # Burkitt lymphoma cell line
-obo:BTO_0000891 rdfs:subClassOf bae:BrendaCell . # NTERA-2 cell
-obo:BTO_0000898 rdfs:subClassOf bae:BrendaCell . # myeloma cell
-obo:BTO_0000899 rdfs:subClassOf bae:BrendaCell . # myeloma cell line
-obo:BTO_0000906 rdfs:subClassOf bae:BrendaCell . # myeloid cell line
-obo:BTO_0000908 rdfs:subClassOf bae:BrendaCell . # myrosin cell
-obo:BTO_0000914 rdfs:subClassOf bae:BrendaCell . # natural killer cell
-obo:BTO_0000931 rdfs:subClassOf bae:BrendaCell . # neuroblastoma cell
-obo:BTO_0000932 rdfs:subClassOf bae:BrendaCell . # neuroblastoma cell line
-obo:BTO_0000939 rdfs:subClassOf bae:BrendaCell . # basal cell
-obo:BTO_0000947 rdfs:subClassOf bae:BrendaCell . # neuronal cell line
-obo:BTO_0000950 rdfs:subClassOf bae:BrendaCell . # Novikoff hepatoma cell
-obo:BTO_0000953 rdfs:subClassOf bae:BrendaCell . # nurse cell
-obo:BTO_0000955 rdfs:subClassOf bae:BrendaCell . # laryngeal cell line
-obo:BTO_0000963 rdfs:subClassOf bae:BrendaCell . # oligodendroglioma cell
-obo:BTO_0000969 rdfs:subClassOf bae:BrendaCell . # osteoclastoma cell
-obo:BTO_0000970 rdfs:subClassOf bae:BrendaCell . # osteosarcoma cell
-obo:BTO_0000977 rdfs:subClassOf bae:BrendaCell . # ovary cell line
-obo:BTO_0000986 rdfs:subClassOf bae:BrendaCell . # pachytene cell
-obo:BTO_0000990 rdfs:subClassOf bae:BrendaCell . # pancreatic alpha cell
-obo:BTO_0000993 rdfs:subClassOf bae:BrendaCell . # paneth cell
-obo:BTO_0001003 rdfs:subClassOf bae:BrendaCell . # parotid acinar cell
-obo:BTO_0001005 rdfs:subClassOf bae:BrendaCell . # amnion epithelial cell
-obo:BTO_0001011 rdfs:subClassOf bae:BrendaCell . # cerebellar Purkinje cell
-obo:BTO_0001018 rdfs:subClassOf bae:BrendaCell . # basophilic leukemia cell line
-obo:BTO_0001023 rdfs:subClassOf bae:BrendaCell . # ovary cancer cell
-obo:BTO_0001025 rdfs:subClassOf bae:BrendaCell . # peripheral blood mononuclear cell
-obo:BTO_0001033 rdfs:subClassOf bae:BrendaCell . # prostate cancer cell line
-obo:BTO_0001035 rdfs:subClassOf bae:BrendaCell . # hematopoietic cell line
-obo:BTO_0001037 rdfs:subClassOf bae:BrendaCell . # sensory cell
-obo:BTO_0001039 rdfs:subClassOf bae:BrendaCell . # peritubular cell
-obo:BTO_0001045 rdfs:subClassOf bae:BrendaCell . # T-lymphocyte cell line
-obo:BTO_0001054 rdfs:subClassOf bae:BrendaCell . # pheochromocytoma cell
-obo:BTO_0001055 rdfs:subClassOf bae:BrendaCell . # ovarian epithelial cell
-obo:BTO_0001056 rdfs:subClassOf bae:BrendaCell . # myeloid leukemia cell
-obo:BTO_0001065 rdfs:subClassOf bae:BrendaCell . # Tsu-Pr1 cell
-obo:BTO_0001076 rdfs:subClassOf bae:BrendaCell . # pituitary gland tumor cell
-obo:BTO_0001080 rdfs:subClassOf bae:BrendaCell . # Morris hepatoma cell
-obo:BTO_0001082 rdfs:subClassOf bae:BrendaCell . # MM46 cell
-obo:BTO_0001086 rdfs:subClassOf bae:BrendaCell . # embryonic stem cell
-obo:BTO_0001087 rdfs:subClassOf bae:BrendaCell . # plasmacytoma cell
-obo:BTO_0001094 rdfs:subClassOf bae:BrendaCell . # pre-B acute lymphoblastic leukemia cell
-obo:BTO_0001096 rdfs:subClassOf bae:BrendaCell . # lymphoid cell
-obo:BTO_0001100 rdfs:subClassOf bae:BrendaCell . # B-cell acute lymphoblastic leukemia cell
-obo:BTO_0001106 rdfs:subClassOf bae:BrendaCell . # T-cell acute lymphoblastic leukemia cell
-obo:BTO_0001120 rdfs:subClassOf bae:BrendaCell . # epithelial cell line
-obo:BTO_0001130 rdfs:subClassOf bae:BrendaCell . # prostate gland cancer cell
-obo:BTO_0001131 rdfs:subClassOf bae:BrendaCell . # BHK cell
-obo:BTO_0001155 rdfs:subClassOf bae:BrendaCell . # ray cell
-obo:BTO_0001169 rdfs:subClassOf bae:BrendaCell . # 3T3-F442A cell
-obo:BTO_0001170 rdfs:subClassOf bae:BrendaCell . # resting cell
-obo:BTO_0001176 rdfs:subClassOf bae:BrendaCell . # endothelial cell
-obo:BTO_0001178 rdfs:subClassOf bae:BrendaCell . # retinoblastoma cell
-obo:BTO_0001189 rdfs:subClassOf bae:BrendaCell . # FAZA cell
-obo:BTO_0001197 rdfs:subClassOf bae:BrendaCell . # S-180 cell
-obo:BTO_0001207 rdfs:subClassOf bae:BrendaCell . # sarcoma cell
-obo:BTO_0001211 rdfs:subClassOf bae:BrendaCell . # breast epithelial cell
-obo:BTO_0001214 rdfs:subClassOf bae:BrendaCell . # Yoshida sarcoma cell
-obo:BTO_0001216 rdfs:subClassOf bae:BrendaCell . # Schwann cell line
-obo:BTO_0001220 rdfs:subClassOf bae:BrendaCell . # Schwann cell
-obo:BTO_0001238 rdfs:subClassOf bae:BrendaCell . # Sertoli cell
-obo:BTO_0001242 rdfs:subClassOf bae:BrendaCell . # fetal cell line
-obo:BTO_0001245 rdfs:subClassOf bae:BrendaCell . # bronchoalveolar stem cell
-obo:BTO_0001251 rdfs:subClassOf bae:BrendaCell . # liver sinusoidal endothelial cell
-obo:BTO_0001263 rdfs:subClassOf bae:BrendaCell . # Friend erythroleukemia cell line
-obo:BTO_0001268 rdfs:subClassOf bae:BrendaCell . # somatic cell
-obo:BTO_0001271 rdfs:subClassOf bae:BrendaCell . # leukemia cell
-obo:BTO_0001283 rdfs:subClassOf bae:BrendaCell . # mitral cell
-obo:BTO_0001286 rdfs:subClassOf bae:BrendaCell . # skin cancer cell
-obo:BTO_0001289 rdfs:subClassOf bae:BrendaCell . # squamous cell carcinoma cell
-obo:BTO_0001294 rdfs:subClassOf bae:BrendaCell . # sporulating cell
-obo:BTO_0001298 rdfs:subClassOf bae:BrendaCell . # basal cell carcinoma cell
-obo:BTO_0001326 rdfs:subClassOf bae:BrendaCell . # cholangiocarcinoma cell
-obo:BTO_0001329 rdfs:subClassOf bae:BrendaCell . # gastrinoma cell
-obo:BTO_0001330 rdfs:subClassOf bae:BrendaCell . # hepatoma ascites cell
-obo:BTO_0001334 rdfs:subClassOf bae:BrendaCell . # papilloma cell
-obo:BTO_0001341 rdfs:subClassOf bae:BrendaCell . # S-49 cell
-obo:BTO_0001344 rdfs:subClassOf bae:BrendaCell . # adult T-cell lymphoma cell
-obo:BTO_0001359 rdfs:subClassOf bae:BrendaCell . # medulloblastoma cell line
-obo:BTO_0001405 rdfs:subClassOf bae:BrendaCell . # bronchial cancer cell
-obo:BTO_0001407 rdfs:subClassOf bae:BrendaCell . # neuroendocrine tumor cell
-obo:BTO_0001434 rdfs:subClassOf bae:BrendaCell . # vegetative cell
-obo:BTO_0001437 rdfs:subClassOf bae:BrendaCell . # embryonic carcinoma cell line
-obo:BTO_0001441 rdfs:subClassOf bae:BrendaCell . # marrow cell
-obo:BTO_0001454 rdfs:subClassOf bae:BrendaCell . # thymoma cell
-obo:BTO_0001455 rdfs:subClassOf bae:BrendaCell . # thymic carcinoma cell
-obo:BTO_0001470 rdfs:subClassOf bae:BrendaCell . # epidermal cell
-obo:BTO_0001474 rdfs:subClassOf bae:BrendaCell . # yolk sac erythroid cell
-obo:BTO_0001478 rdfs:subClassOf bae:BrendaCell . # zygotene cell
-obo:BTO_0001514 rdfs:subClassOf bae:BrendaCell . # biliary epithelial cell
-obo:BTO_0001518 rdfs:subClassOf bae:BrendaCell . # B-lymphoma cell line
-obo:BTO_0001519 rdfs:subClassOf bae:BrendaCell . # endothelial cell line
-obo:BTO_0001521 rdfs:subClassOf bae:BrendaCell . # pancreatic adenocarcinoma cell line
-obo:BTO_0001522 rdfs:subClassOf bae:BrendaCell . # B-lymphocyte cell line
-obo:BTO_0001523 rdfs:subClassOf bae:BrendaCell . # WIL-2 cell
-obo:BTO_0001530 rdfs:subClassOf bae:BrendaCell . # glioblastoma cell line
-obo:BTO_0001531 rdfs:subClassOf bae:BrendaCell . # glial cell line
-obo:BTO_0001532 rdfs:subClassOf bae:BrendaCell . # rectal cancer cell line
-obo:BTO_0001537 rdfs:subClassOf bae:BrendaCell . # small intestine cell line
-obo:BTO_0001540 rdfs:subClassOf bae:BrendaCell . # goblet cell
-obo:BTO_0001544 rdfs:subClassOf bae:BrendaCell . # chronic myeloid leukemia cell
-obo:BTO_0001545 rdfs:subClassOf bae:BrendaCell . # acute myeloid leukemia cell
-obo:BTO_0001546 rdfs:subClassOf bae:BrendaCell . # chronic lymphocytic leukemia cell
-obo:BTO_0001549 rdfs:subClassOf bae:BrendaCell . # megakaryocytic cell line
-obo:BTO_0001550 rdfs:subClassOf bae:BrendaCell . # Dami cell
-obo:BTO_0001555 rdfs:subClassOf bae:BrendaCell . # endometrial cancer cell line
-obo:BTO_0001557 rdfs:subClassOf bae:BrendaCell . # SF-767 cell
-obo:BTO_0001565 rdfs:subClassOf bae:BrendaCell . # HT-29-MTX cell
-obo:BTO_0001566 rdfs:subClassOf bae:BrendaCell . # HT-29 G cell
-obo:BTO_0001567 rdfs:subClassOf bae:BrendaCell . # MDA-MB-435 cell
-obo:BTO_0001573 rdfs:subClassOf bae:BrendaCell . # brain cancer cell
-obo:BTO_0001574 rdfs:subClassOf bae:BrendaCell . # chondrosarcoma cell line
-obo:BTO_0001575 rdfs:subClassOf bae:BrendaCell . # choriocarcinoma cell line
-obo:BTO_0001576 rdfs:subClassOf bae:BrendaCell . # choriocarcinoma cell
-obo:BTO_0001577 rdfs:subClassOf bae:BrendaCell . # esophageal cancer cell
-obo:BTO_0001581 rdfs:subClassOf bae:BrendaCell . # embryonic stem cell line
-obo:BTO_0001586 rdfs:subClassOf bae:BrendaCell . # lymphoid cell line
-obo:BTO_0001610 rdfs:subClassOf bae:BrendaCell . # thyroid cancer cell line
-obo:BTO_0001614 rdfs:subClassOf bae:BrendaCell . # colorectal cell line
-obo:BTO_0001615 rdfs:subClassOf bae:BrendaCell . # colorectal cancer cell
-obo:BTO_0001617 rdfs:subClassOf bae:BrendaCell . # DHL-9 cell
-obo:BTO_0001619 rdfs:subClassOf bae:BrendaCell . # skin fibroblast cell line
-obo:BTO_0001622 rdfs:subClassOf bae:BrendaCell . # fibroblastoma cell
-obo:BTO_0001623 rdfs:subClassOf bae:BrendaCell . # fibroma cell
-obo:BTO_0001625 rdfs:subClassOf bae:BrendaCell . # laryngeal cancer cell
-obo:BTO_0001631 rdfs:subClassOf bae:BrendaCell . # leiomyosarcoma cell
-obo:BTO_0001664 rdfs:subClassOf bae:BrendaCell . # hepatoblastoma cell line
-obo:BTO_0001666 rdfs:subClassOf bae:BrendaCell . # hepatoblastoma cell
-obo:BTO_0001668 rdfs:subClassOf bae:BrendaCell . # mast cell line
-obo:BTO_0001669 rdfs:subClassOf bae:BrendaCell . # HMC-1 cell
-obo:BTO_0001674 rdfs:subClassOf bae:BrendaCell . # Mel Im cell
-obo:BTO_0001676 rdfs:subClassOf bae:BrendaCell . # PC-12D cell
-obo:BTO_0001677 rdfs:subClassOf bae:BrendaCell . # SCHNEIDER-2 cell
-obo:BTO_0001683 rdfs:subClassOf bae:BrendaCell . # adenohypophysis tumor cell
-obo:BTO_0001690 rdfs:subClassOf bae:BrendaCell . # B-cell lymphoma cell
-obo:BTO_0001714 rdfs:subClassOf bae:BrendaCell . # duodenal adenocarcinoma cell
-obo:BTO_0001731 rdfs:subClassOf bae:BrendaCell . # glucagonoma cell
-obo:BTO_0001736 rdfs:subClassOf bae:BrendaCell . # vascular cancer cell
-obo:BTO_0001737 rdfs:subClassOf bae:BrendaCell . # hemangioendothelioma cell
-obo:BTO_0001738 rdfs:subClassOf bae:BrendaCell . # histiocytic lymphoma cell
-obo:BTO_0001756 rdfs:subClassOf bae:BrendaCell . # meningioma cell
-obo:BTO_0001757 rdfs:subClassOf bae:BrendaCell . # medulloblastoma cell
-obo:BTO_0001767 rdfs:subClassOf bae:BrendaCell . # neurosecretory cell
-obo:BTO_0001774 rdfs:subClassOf bae:BrendaCell . # oral cancer cell
-obo:BTO_0001780 rdfs:subClassOf bae:BrendaCell . # oxyntic cell
-obo:BTO_0001781 rdfs:subClassOf bae:BrendaCell . # parathyroid gland cancer cell
-obo:BTO_0001797 rdfs:subClassOf bae:BrendaCell . # promyelocytic leukemia cell
-obo:BTO_0001800 rdfs:subClassOf bae:BrendaCell . # retinal ganglion cell
-obo:BTO_0001802 rdfs:subClassOf bae:BrendaCell . # rhabdomyosarcoma cell
-obo:BTO_0001824 rdfs:subClassOf bae:BrendaCell . # synovial sarcoma cell
-obo:BTO_0001825 rdfs:subClassOf bae:BrendaCell . # T-cell lymphoma cell
-obo:BTO_0001854 rdfs:subClassOf bae:BrendaCell . # vascular endothelial cell
-obo:BTO_0001860 rdfs:subClassOf bae:BrendaCell . # yolk sac cancer cell
-obo:BTO_0001870 rdfs:subClassOf bae:BrendaCell . # OVCA-5 cell
-obo:BTO_0001874 rdfs:subClassOf bae:BrendaCell . # lens epithelial cell line
-obo:BTO_0001876 rdfs:subClassOf bae:BrendaCell . # thyroid cell line
-obo:BTO_0001879 rdfs:subClassOf bae:BrendaCell . # H9c2 cell
-obo:BTO_0001883 rdfs:subClassOf bae:BrendaCell . # acute myeloid leukemia cell line
-obo:BTO_0001888 rdfs:subClassOf bae:BrendaCell . # follicular thyroid cancer cell
-obo:BTO_0001895 rdfs:subClassOf bae:BrendaCell . # gastrointestinal endocrine cell
-obo:BTO_0001897 rdfs:subClassOf bae:BrendaCell . # hemocyte cell line
-obo:BTO_0001898 rdfs:subClassOf bae:BrendaCell . # mbn-2 cell
-obo:BTO_0001907 rdfs:subClassOf bae:BrendaCell . # NS-1 cell
-obo:BTO_0001911 rdfs:subClassOf bae:BrendaCell . # lung adenocarcinoma cell line
-obo:BTO_0001912 rdfs:subClassOf bae:BrendaCell . # breast adenocarcinoma cell line
-obo:BTO_0001914 rdfs:subClassOf bae:BrendaCell . # colorectal adenocarcinoma cell line
-obo:BTO_0001916 rdfs:subClassOf bae:BrendaCell . # LIM1215 cell
-obo:BTO_0001918 rdfs:subClassOf bae:BrendaCell . # LIM1863 cell
-obo:BTO_0001926 rdfs:subClassOf bae:BrendaCell . # hybridoma cell line
-obo:BTO_0001928 rdfs:subClassOf bae:BrendaCell . # AR4-2J cell
-obo:BTO_0001929 rdfs:subClassOf bae:BrendaCell . # ATDC-5 cell
-obo:BTO_0001931 rdfs:subClassOf bae:BrendaCell . # BJAB cell
-obo:BTO_0001933 rdfs:subClassOf bae:BrendaCell . # BRL cell
-obo:BTO_0001948 rdfs:subClassOf bae:BrendaCell . # JURKAT E-6.1 cell
-obo:BTO_0001949 rdfs:subClassOf bae:BrendaCell . # HUVEC cell
-obo:BTO_0001955 rdfs:subClassOf bae:BrendaCell . # REF-52 cell
-obo:BTO_0001964 rdfs:subClassOf bae:BrendaCell . # aorta smooth muscle cell line
-obo:BTO_0001966 rdfs:subClassOf bae:BrendaCell . # cervical cell line
-obo:BTO_0001967 rdfs:subClassOf bae:BrendaCell . # cervical cancer cell line
-obo:BTO_0001971 rdfs:subClassOf bae:BrendaCell . # plant cell line
-obo:BTO_0001972 rdfs:subClassOf bae:BrendaCell . # TBY-2 cell
-obo:BTO_0001975 rdfs:subClassOf bae:BrendaCell . # placental cell line
-obo:BTO_0001977 rdfs:subClassOf bae:BrendaCell . # Oc cell
-obo:BTO_0002008 rdfs:subClassOf bae:BrendaCell . # culture condition:antigen-presenting cell
-obo:BTO_0002016 rdfs:subClassOf bae:BrendaCell . # C81-61 cell
-obo:BTO_0002021 rdfs:subClassOf bae:BrendaCell . # prostate adenocarcinoma cell
-obo:BTO_0002022 rdfs:subClassOf bae:BrendaCell . # bronchial epithelial cell line
-obo:BTO_0002023 rdfs:subClassOf bae:BrendaCell . # HBE-1 cell
-obo:BTO_0002024 rdfs:subClassOf bae:BrendaCell . # squamous cell carcinoma cell line
-obo:BTO_0002026 rdfs:subClassOf bae:BrendaCell . # HSC-4 cell
-obo:BTO_0002027 rdfs:subClassOf bae:BrendaCell . # oral cancer cell line
-obo:BTO_0002029 rdfs:subClassOf bae:BrendaCell . # myoma cell
-obo:BTO_0002030 rdfs:subClassOf bae:BrendaCell . # natural killer cell line
-obo:BTO_0002031 rdfs:subClassOf bae:BrendaCell . # RNK-16 cell
-obo:BTO_0002042 rdfs:subClassOf bae:BrendaCell . # dendritic cell
-obo:BTO_0002049 rdfs:subClassOf bae:BrendaCell . # Chang cell
-obo:BTO_0002050 rdfs:subClassOf bae:BrendaCell . # osteogenic cell
-obo:BTO_0002052 rdfs:subClassOf bae:BrendaCell . # osteogenic cell line
-obo:BTO_0002054 rdfs:subClassOf bae:BrendaCell . # Dunn cell
-obo:BTO_0002057 rdfs:subClassOf bae:BrendaCell . # lung adenocarcinoma cell
-obo:BTO_0002058 rdfs:subClassOf bae:BrendaCell . # non-small cell lung cancer cell
-obo:BTO_0002059 rdfs:subClassOf bae:BrendaCell . # large cell carcinoma cell
-obo:BTO_0002060 rdfs:subClassOf bae:BrendaCell . # bronchioalveolar carcinoma cell
-obo:BTO_0002062 rdfs:subClassOf bae:BrendaCell . # B-lymphoblastoid cell line
-obo:BTO_0002064 rdfs:subClassOf bae:BrendaCell . # stromal cell
-obo:BTO_0002088 rdfs:subClassOf bae:BrendaCell . # ependymoma cell
-obo:BTO_0002093 rdfs:subClassOf bae:BrendaCell . # ganglioneuroma cell
-obo:BTO_0002101 rdfs:subClassOf bae:BrendaCell . # multiple myeloma cell
-obo:BTO_0002128 rdfs:subClassOf bae:BrendaCell . # TX3868 cell
-obo:BTO_0002135 rdfs:subClassOf bae:BrendaCell . # INS-1 cell
-obo:BTO_0002137 rdfs:subClassOf bae:BrendaCell . # MiaPaCa-2 cell
-obo:BTO_0002138 rdfs:subClassOf bae:BrendaCell . # MiaPaCa cell
-obo:BTO_0002143 rdfs:subClassOf bae:BrendaCell . # CEM-VCR R cell
-obo:BTO_0002145 rdfs:subClassOf bae:BrendaCell . # midgut cell line
-obo:BTO_0002170 rdfs:subClassOf bae:BrendaCell . # LOX cell
-obo:BTO_0002174 rdfs:subClassOf bae:BrendaCell . # parenchymal cell
-obo:BTO_0002177 rdfs:subClassOf bae:BrendaCell . # PR cell
-obo:BTO_0002178 rdfs:subClassOf bae:BrendaCell . # HMEpC cell
-obo:BTO_0002181 rdfs:subClassOf bae:BrendaCell . # HEK-293T cell
-obo:BTO_0002182 rdfs:subClassOf bae:BrendaCell . # 95D cell
-obo:BTO_0002183 rdfs:subClassOf bae:BrendaCell . # 95C cell
-obo:BTO_0002193 rdfs:subClassOf bae:BrendaCell . # SCC-13 cell
-obo:BTO_0002194 rdfs:subClassOf bae:BrendaCell . # NHK cell
-obo:BTO_0002195 rdfs:subClassOf bae:BrendaCell . # vascular smooth muscle cell line
-obo:BTO_0002205 rdfs:subClassOf bae:BrendaCell . # large cell lung cancer cell line
-obo:BTO_0002206 rdfs:subClassOf bae:BrendaCell . # small cell lung cancer cell line
-obo:BTO_0002211 rdfs:subClassOf bae:BrendaCell . # oral squamous cell carcinoma cell line
-obo:BTO_0002214 rdfs:subClassOf bae:BrendaCell . # A-1235 cell
-obo:BTO_0002215 rdfs:subClassOf bae:BrendaCell . # LN-319 cell
-obo:BTO_0002218 rdfs:subClassOf bae:BrendaCell . # chalazal cell
-obo:BTO_0002219 rdfs:subClassOf bae:BrendaCell . # adrenocortical carcinoma cell
-obo:BTO_0002221 rdfs:subClassOf bae:BrendaCell . # HLE-B3 cell
-obo:BTO_0002236 rdfs:subClassOf bae:BrendaCell . # ovarian cumulus cell
-obo:BTO_0002242 rdfs:subClassOf bae:BrendaCell . # oral epithelial cell
-obo:BTO_0002245 rdfs:subClassOf bae:BrendaCell . # foreskin fibroblast cell line
-obo:BTO_0002264 rdfs:subClassOf bae:BrendaCell . # dried cell
-obo:BTO_0002267 rdfs:subClassOf bae:BrendaCell . # rhabdomyosarcoma cell line
-obo:BTO_0002276 rdfs:subClassOf bae:BrendaCell . # immobilized cell
-obo:BTO_0002278 rdfs:subClassOf bae:BrendaCell . # macrophage cell line
-obo:BTO_0002279 rdfs:subClassOf bae:BrendaCell . # J-774 cell
-obo:BTO_0002280 rdfs:subClassOf bae:BrendaCell . # lignifying cell
-obo:BTO_0002284 rdfs:subClassOf bae:BrendaCell . # MIN-6 cell
-obo:BTO_0002285 rdfs:subClassOf bae:BrendaCell . # granulosa cell line
-obo:BTO_0002290 rdfs:subClassOf bae:BrendaCell . # primary cell line
-obo:BTO_0002306 rdfs:subClassOf bae:BrendaCell . # ARO cell
-obo:BTO_0002309 rdfs:subClassOf bae:BrendaCell . # myoepithelial cell
-obo:BTO_0002311 rdfs:subClassOf bae:BrendaCell . # mammary myoepithelial cell
-obo:BTO_0002312 rdfs:subClassOf bae:BrendaCell . # mature cell
-obo:BTO_0002313 rdfs:subClassOf bae:BrendaCell . # immature cell
-obo:BTO_0002314 rdfs:subClassOf bae:BrendaCell . # satellite cell
-obo:BTO_0002315 rdfs:subClassOf bae:BrendaCell . # supporting cell
-obo:BTO_0002316 rdfs:subClassOf bae:BrendaCell . # stellate cell
-obo:BTO_0002332 rdfs:subClassOf bae:BrendaCell . # monocytic leukemia cell line
-obo:BTO_0002334 rdfs:subClassOf bae:BrendaCell . # retinal pigment epithelium cell line
-obo:BTO_0002361 rdfs:subClassOf bae:BrendaCell . # osteochondroma cell
-obo:BTO_0002363 rdfs:subClassOf bae:BrendaCell . # pancreatic ductal carcinoma cell
-obo:BTO_0002372 rdfs:subClassOf bae:BrendaCell . # neuroepithelioma cell
-obo:BTO_0002373 rdfs:subClassOf bae:BrendaCell . # glioblastoma multiforme cell
-obo:BTO_0002380 rdfs:subClassOf bae:BrendaCell . # gastric adenocarcinoma cell line
-obo:BTO_0002382 rdfs:subClassOf bae:BrendaCell . # MKN-7 cell
-obo:BTO_0002385 rdfs:subClassOf bae:BrendaCell . # GLC-4 cell
-obo:BTO_0002386 rdfs:subClassOf bae:BrendaCell . # GLC-4/ADR cell
-obo:BTO_0002389 rdfs:subClassOf bae:BrendaCell . # U-1285 cell
-obo:BTO_0002391 rdfs:subClassOf bae:BrendaCell . # U-1285dox cell
-obo:BTO_0002392 rdfs:subClassOf bae:BrendaCell . # SGC-7901 cell
-obo:BTO_0002393 rdfs:subClassOf bae:BrendaCell . # N-27 cell
-obo:BTO_0002394 rdfs:subClassOf bae:BrendaCell . # DC-3F cell
-obo:BTO_0002395 rdfs:subClassOf bae:BrendaCell . # DC-3F/ADX cell
-obo:BTO_0002398 rdfs:subClassOf bae:BrendaCell . # prostate epithelium cell line
-obo:BTO_0002403 rdfs:subClassOf bae:BrendaCell . # OS-RC-2 cell
-obo:BTO_0002406 rdfs:subClassOf bae:BrendaCell . # eosinophilic leukemia cell line
-obo:BTO_0002414 rdfs:subClassOf bae:BrendaCell . # PG-CL3 cell
-obo:BTO_0002420 rdfs:subClassOf bae:BrendaCell . # monocytic leukemia cell
-obo:BTO_0002421 rdfs:subClassOf bae:BrendaCell . # eosinophilic leukemia cell
-obo:BTO_0002423 rdfs:subClassOf bae:BrendaCell . # mesothelioma cell
-obo:BTO_0002424 rdfs:subClassOf bae:BrendaCell . # mesothelioma cell line
-obo:BTO_0002426 rdfs:subClassOf bae:BrendaCell . # CHOP cell
-obo:BTO_0002428 rdfs:subClassOf bae:BrendaCell . # esophageal squamous cell carcinoma cell line
-obo:BTO_0002429 rdfs:subClassOf bae:BrendaCell . # HA22T/VGH cell
-obo:BTO_0002478 rdfs:subClassOf bae:BrendaCell . # cervical epithelial cell
-obo:BTO_0002482 rdfs:subClassOf bae:BrendaCell . # gonadotrophic cell
-obo:BTO_0002484 rdfs:subClassOf bae:BrendaCell . # columnar cell
-obo:BTO_0002489 rdfs:subClassOf bae:BrendaCell . # promyelocytic leukemia cell line
-obo:BTO_0002499 rdfs:subClassOf bae:BrendaCell . # companion cell
-obo:BTO_0002505 rdfs:subClassOf bae:BrendaCell . # anaplastic large cell lymphoma cell
-obo:BTO_0002509 rdfs:subClassOf bae:BrendaCell . # corticotropic cell
-obo:BTO_0002510 rdfs:subClassOf bae:BrendaCell . # myelomonocytic leukemia cell
-obo:BTO_0002513 rdfs:subClassOf bae:BrendaCell . # Ewing's sarcoma cell
-obo:BTO_0002515 rdfs:subClassOf bae:BrendaCell . # brain cortex cell line
-obo:BTO_0002517 rdfs:subClassOf bae:BrendaCell . # follicular lymphoma cell line
-obo:BTO_0002521 rdfs:subClassOf bae:BrendaCell . # diffuse large B-cell lymphoma cell
-obo:BTO_0002524 rdfs:subClassOf bae:BrendaCell . # HEK-293A cell
-obo:BTO_0002534 rdfs:subClassOf bae:BrendaCell . # HBL-3 cell
-obo:BTO_0002546 rdfs:subClassOf bae:BrendaCell . # KBM-5 cell
-obo:BTO_0002555 rdfs:subClassOf bae:BrendaCell . # HOSE cell
-obo:BTO_0002564 rdfs:subClassOf bae:BrendaCell . # OVCA-429 cell
-obo:BTO_0002565 rdfs:subClassOf bae:BrendaCell . # OVCA-432 cell
-obo:BTO_0002572 rdfs:subClassOf bae:BrendaCell . # MEF cell
-obo:BTO_0002590 rdfs:subClassOf bae:BrendaCell . # HEY cell
-obo:BTO_0002595 rdfs:subClassOf bae:BrendaCell . # leiomyosarcoma cell line
-obo:BTO_0002600 rdfs:subClassOf bae:BrendaCell . # astrocyte cell line
-obo:BTO_0002606 rdfs:subClassOf bae:BrendaCell . # glial cell
-obo:BTO_0002625 rdfs:subClassOf bae:BrendaCell . # mesenchymal cell
-obo:BTO_0002627 rdfs:subClassOf bae:BrendaCell . # T-lymphoblastoma cell
-obo:BTO_0002628 rdfs:subClassOf bae:BrendaCell . # B-lymphoblastoma cell
-obo:BTO_0002629 rdfs:subClassOf bae:BrendaCell . # T-lymphoblastoid cell line
-obo:BTO_0002637 rdfs:subClassOf bae:BrendaCell . # respiratory epithelium cell line
-obo:BTO_0002640 rdfs:subClassOf bae:BrendaCell . # CHO-EM9 cell
-obo:BTO_0002641 rdfs:subClassOf bae:BrendaCell . # CHO-AA8 cell
-obo:BTO_0002648 rdfs:subClassOf bae:BrendaCell . # ROS-17/2.8 cell
-obo:BTO_0002656 rdfs:subClassOf bae:BrendaCell . # sickle cell
-obo:BTO_0002658 rdfs:subClassOf bae:BrendaCell . # collecting duct cell line
-obo:BTO_0002662 rdfs:subClassOf bae:BrendaCell . # skeletal muscle cell line
-obo:BTO_0002664 rdfs:subClassOf bae:BrendaCell . # HTAU cell
-obo:BTO_0002666 rdfs:subClassOf bae:BrendaCell . # adult stem cell
-obo:BTO_0002667 rdfs:subClassOf bae:BrendaCell . # cord blood stem cell
-obo:BTO_0002668 rdfs:subClassOf bae:BrendaCell . # bone marrow stromal stem cell
-obo:BTO_0002669 rdfs:subClassOf bae:BrendaCell . # peripheral blood stem cell
-obo:BTO_0002687 rdfs:subClassOf bae:BrendaCell . # Leydig cell tumor cell
-obo:BTO_0002688 rdfs:subClassOf bae:BrendaCell . # vascular cell
-obo:BTO_0002691 rdfs:subClassOf bae:BrendaCell . # neuroendocrine cell
-obo:BTO_0002692 rdfs:subClassOf bae:BrendaCell . # enterochromaffin-like cell
-obo:BTO_0002694 rdfs:subClassOf bae:BrendaCell . # leiomyoma cell
-obo:BTO_0002695 rdfs:subClassOf bae:BrendaCell . # uterine leiomyoma cell
-obo:BTO_0002708 rdfs:subClassOf bae:BrendaCell . # GT1-7 cell
-obo:BTO_0002709 rdfs:subClassOf bae:BrendaCell . # head and neck squamous cell carcinoma cell line
-obo:BTO_0002714 rdfs:subClassOf bae:BrendaCell . # UM-SCC-22A cell
-obo:BTO_0002719 rdfs:subClassOf bae:BrendaCell . # primary effusion lymphoma cell line
-obo:BTO_0002727 rdfs:subClassOf bae:BrendaCell . # BCBL-1 cell
-obo:BTO_0002729 rdfs:subClassOf bae:BrendaCell . # ovarian serous carcinoma cell
-obo:BTO_0002731 rdfs:subClassOf bae:BrendaCell . # erythroid cell
-obo:BTO_0002741 rdfs:subClassOf bae:BrendaCell . # hepatic stellate cell
-obo:BTO_0002747 rdfs:subClassOf bae:BrendaCell . # PC-1 cell
-obo:BTO_0002748 rdfs:subClassOf bae:BrendaCell . # BL-2 cell
-obo:BTO_0002752 rdfs:subClassOf bae:BrendaCell . # PC-6 cell
-obo:BTO_0002768 rdfs:subClassOf bae:BrendaCell . # mammary epithelial cell line
-obo:BTO_0002769 rdfs:subClassOf bae:BrendaCell . # HME cell
-obo:BTO_0002770 rdfs:subClassOf bae:BrendaCell . # decidual cell
-obo:BTO_0002771 rdfs:subClassOf bae:BrendaCell . # olfactory ensheathing cell
-obo:BTO_0002773 rdfs:subClassOf bae:BrendaCell . # salivary gland cancer cell
-obo:BTO_0002775 rdfs:subClassOf bae:BrendaCell . # ANA-1 cell
-obo:BTO_0002786 rdfs:subClassOf bae:BrendaCell . # cystadenoma cell
-obo:BTO_0002787 rdfs:subClassOf bae:BrendaCell . # clear cell adenocarcinoma cell
-obo:BTO_0002788 rdfs:subClassOf bae:BrendaCell . # mucinous adenocarcinoma cell
-obo:BTO_0002790 rdfs:subClassOf bae:BrendaCell . # phloem parenchyma cell
-obo:BTO_0002803 rdfs:subClassOf bae:BrendaCell . # BLM cell
-obo:BTO_0002805 rdfs:subClassOf bae:BrendaCell . # M14 cell
-obo:BTO_0002808 rdfs:subClassOf bae:BrendaCell . # B16-BL6 cell
-obo:BTO_0002815 rdfs:subClassOf bae:BrendaCell . # transitional cell carcinoma cell
-obo:BTO_0002817 rdfs:subClassOf bae:BrendaCell . # esophageal cancer cell line
-obo:BTO_0002820 rdfs:subClassOf bae:BrendaCell . # oligodendroglioma cell line
-obo:BTO_0002821 rdfs:subClassOf bae:BrendaCell . # HOG cell
-obo:BTO_0002828 rdfs:subClassOf bae:BrendaCell . # HMEC-1 cell
-obo:BTO_0002836 rdfs:subClassOf bae:BrendaCell . # NCI-H460M cell
-obo:BTO_0002844 rdfs:subClassOf bae:BrendaCell . # breast invasive ductal carcinoma cell
-obo:BTO_0002846 rdfs:subClassOf bae:BrendaCell . # non-Hodgkin lymphoma cell
-obo:BTO_0002850 rdfs:subClassOf bae:BrendaCell . # theca cell
-obo:BTO_0002861 rdfs:subClassOf bae:BrendaCell . # esophageal squamous cell carcinoma cell
-obo:BTO_0002864 rdfs:subClassOf bae:BrendaCell . # T3M4 cell
-obo:BTO_0002865 rdfs:subClassOf bae:BrendaCell . # GER cell
-obo:BTO_0002869 rdfs:subClassOf bae:BrendaCell . # transitional cell carcinoma cell line
-obo:BTO_0002870 rdfs:subClassOf bae:BrendaCell . # RT-4 cell
-obo:BTO_0002876 rdfs:subClassOf bae:BrendaCell . # CL1-5 cell
-obo:BTO_0002878 rdfs:subClassOf bae:BrendaCell . # B-lymphoblastoid cell
-obo:BTO_0002881 rdfs:subClassOf bae:BrendaCell . # neural stem cell
-obo:BTO_0002886 rdfs:subClassOf bae:BrendaCell . # renal epithelium cell line
-obo:BTO_0002888 rdfs:subClassOf bae:BrendaCell . # Th-1 cell line
-obo:BTO_0002889 rdfs:subClassOf bae:BrendaCell . # alveolar macrophage cell line
-obo:BTO_0002890 rdfs:subClassOf bae:BrendaCell . # CA-77 cell
-obo:BTO_0002891 rdfs:subClassOf bae:BrendaCell . # neural stem cell line
-obo:BTO_0002892 rdfs:subClassOf bae:BrendaCell . # GEO cell
-obo:BTO_0002899 rdfs:subClassOf bae:BrendaCell . # K-1034 RPE cell
-obo:BTO_0002900 rdfs:subClassOf bae:BrendaCell . # monocyte-derived dendritic cell
-obo:BTO_0002901 rdfs:subClassOf bae:BrendaCell . # neural crest cell line
-obo:BTO_0002904 rdfs:subClassOf bae:BrendaCell . # non-Hodgkin lymphoma cell line
-obo:BTO_0002912 rdfs:subClassOf bae:BrendaCell . # neuroepithelioma cell line
-obo:BTO_0002916 rdfs:subClassOf bae:BrendaCell . # striated muscle cell
-obo:BTO_0002919 rdfs:subClassOf bae:BrendaCell . # retinoblastoma cell line
-obo:BTO_0002921 rdfs:subClassOf bae:BrendaCell . # LS174T-HM7 cell
-obo:BTO_0002922 rdfs:subClassOf bae:BrendaCell . # bronchial epithelial cell
-obo:BTO_0002924 rdfs:subClassOf bae:BrendaCell . # NHBE cell
-obo:BTO_0002926 rdfs:subClassOf bae:BrendaCell . # tracheobronchial epithelial cell line
-obo:BTO_0002927 rdfs:subClassOf bae:BrendaCell . # tracheobronchial epithelial cell
-obo:BTO_0002928 rdfs:subClassOf bae:BrendaCell . # adult stem cell line
-obo:BTO_0002931 rdfs:subClassOf bae:BrendaCell . # liver epithelial cell line
-obo:BTO_0002932 rdfs:subClassOf bae:BrendaCell . # cholangiocarcinoma cell line
-obo:BTO_0002936 rdfs:subClassOf bae:BrendaCell . # vaginal cell line
-obo:BTO_0002939 rdfs:subClassOf bae:BrendaCell . # serous adenocarcinoma cell
-obo:BTO_0002946 rdfs:subClassOf bae:BrendaCell . # MNT-1 cell
-obo:BTO_0002951 rdfs:subClassOf bae:BrendaCell . # 624 cell
-obo:BTO_0002959 rdfs:subClassOf bae:BrendaCell . # TP17 cell
-obo:BTO_0002965 rdfs:subClassOf bae:BrendaCell . # M10 cell
-obo:BTO_0002967 rdfs:subClassOf bae:BrendaCell . # SK-MEL-37 cell
-obo:BTO_0002971 rdfs:subClassOf bae:BrendaCell . # KJ29 cell
-obo:BTO_0002974 rdfs:subClassOf bae:BrendaCell . # HEK-293-EBNA cell
-obo:BTO_0002980 rdfs:subClassOf bae:BrendaCell . # pancreatic alpha cell line
-obo:BTO_0002995 rdfs:subClassOf bae:BrendaCell . # CCL-39 cell
-obo:BTO_0002997 rdfs:subClassOf bae:BrendaCell . # LAPC4 cell
-obo:BTO_0003028 rdfs:subClassOf bae:BrendaCell . # NCI-N417 cell
-obo:BTO_0003031 rdfs:subClassOf bae:BrendaCell . # HCA-7 cell
-obo:BTO_0003032 rdfs:subClassOf bae:BrendaCell . # HEK-293F cell
-obo:BTO_0003033 rdfs:subClassOf bae:BrendaCell . # HEK-293H cell
-obo:BTO_0003036 rdfs:subClassOf bae:BrendaCell . # hippocampal cell line
-obo:BTO_0003037 rdfs:subClassOf bae:BrendaCell . # HT-22 cell
-obo:BTO_0003039 rdfs:subClassOf bae:BrendaCell . # hypodermal seam cell
-obo:BTO_0003046 rdfs:subClassOf bae:BrendaCell . # neurofibroma cell
-obo:BTO_0003047 rdfs:subClassOf bae:BrendaCell . # neurilemoma cell
-obo:BTO_0003050 rdfs:subClassOf bae:BrendaCell . # MA-10 cell
-obo:BTO_0003051 rdfs:subClassOf bae:BrendaCell . # MBA-15 cell
-obo:BTO_0003054 rdfs:subClassOf bae:BrendaCell . # OVCA-8 cell
-obo:BTO_0003056 rdfs:subClassOf bae:BrendaCell . # NB-2 cell
-obo:BTO_0003057 rdfs:subClassOf bae:BrendaCell . # NB2-Sp cell
-obo:BTO_0003058 rdfs:subClassOf bae:BrendaCell . # NB2a/d1 cell
-obo:BTO_0003059 rdfs:subClassOf bae:BrendaCell . # oviduct epithelial cell line
-obo:BTO_0003061 rdfs:subClassOf bae:BrendaCell . # retinal cell line
-obo:BTO_0003072 rdfs:subClassOf bae:BrendaCell . # human lens epithelial cell line
-obo:BTO_0003073 rdfs:subClassOf bae:BrendaCell . # medullary thyroid carcinoma cell line
-obo:BTO_0003085 rdfs:subClassOf bae:BrendaCell . # uterine anchor cell
-obo:BTO_0003103 rdfs:subClassOf bae:BrendaCell . # pro-B-lymphocyte cell line
-obo:BTO_0003107 rdfs:subClassOf bae:BrendaCell . # foreign-body giant cell
-obo:BTO_0003108 rdfs:subClassOf bae:BrendaCell . # CL-1 prostate cancer cell
-obo:BTO_0003110 rdfs:subClassOf bae:BrendaCell . # CALO cell
-obo:BTO_0003124 rdfs:subClassOf bae:BrendaCell . # microvascular endothelial cell line
-obo:BTO_0003125 rdfs:subClassOf bae:BrendaCell . # human bladder microvascular endothelial cell
-obo:BTO_0003127 rdfs:subClassOf bae:BrendaCell . # human bone marrow endothelial cell line
-obo:BTO_0003129 rdfs:subClassOf bae:BrendaCell . # human brain microvascular endothelial cell
-obo:BTO_0003151 rdfs:subClassOf bae:BrendaCell . # HPAEC cell
-obo:BTO_0003152 rdfs:subClassOf bae:BrendaCell . # papillary thyroid cancer cell
-obo:BTO_0003160 rdfs:subClassOf bae:BrendaCell . # PrEC cell
-obo:BTO_0003162 rdfs:subClassOf bae:BrendaCell . # PrSC cell
-obo:BTO_0003165 rdfs:subClassOf bae:BrendaCell . # cervical adenocarcinoma cell
-obo:BTO_0003166 rdfs:subClassOf bae:BrendaCell . # 10T1/2 cell
-obo:BTO_0003181 rdfs:subClassOf bae:BrendaCell . # WEHI-7.2 cell
-obo:BTO_0003182 rdfs:subClassOf bae:BrendaCell . # NHEK cell
-obo:BTO_0003183 rdfs:subClassOf bae:BrendaCell . # melanocyte cell line
-obo:BTO_0003185 rdfs:subClassOf bae:BrendaCell . # NHDF cell
-obo:BTO_0003192 rdfs:subClassOf bae:BrendaCell . # renal cancer cell line
-obo:BTO_0003205 rdfs:subClassOf bae:BrendaCell . # salivary gland cell line
-obo:BTO_0003208 rdfs:subClassOf bae:BrendaCell . # anaplastic thyroid cancer cell
-obo:BTO_0003210 rdfs:subClassOf bae:BrendaCell . # papillary thyroid cancer cell line
-obo:BTO_0003212 rdfs:subClassOf bae:BrendaCell . # T-lymphoma cell line
-obo:BTO_0003213 rdfs:subClassOf bae:BrendaCell . # lung epithelium cell line
-obo:BTO_0003216 rdfs:subClassOf bae:BrendaCell . # melan-a cell
-obo:BTO_0003219 rdfs:subClassOf bae:BrendaCell . # TMK-1 cell
-obo:BTO_0003225 rdfs:subClassOf bae:BrendaCell . # neurilemoma cell line
-obo:BTO_0003227 rdfs:subClassOf bae:BrendaCell . # SMMC-7721 cell
-obo:BTO_0003231 rdfs:subClassOf bae:BrendaCell . # SHG-44 cell
-obo:BTO_0003232 rdfs:subClassOf bae:BrendaCell . # BT-325 cell
-obo:BTO_0003234 rdfs:subClassOf bae:BrendaCell . # FTO-2B cell
-obo:BTO_0003236 rdfs:subClassOf bae:BrendaCell . # gall bladder cancer cell line
-obo:BTO_0003237 rdfs:subClassOf bae:BrendaCell . # gall bladder cancer cell
-obo:BTO_0003245 rdfs:subClassOf bae:BrendaCell . # aortic endothelial cell
-obo:BTO_0003249 rdfs:subClassOf bae:BrendaCell . # brain endothelium cell line
-obo:BTO_0003250 rdfs:subClassOf bae:BrendaCell . # colonic epithelium cell line
-obo:BTO_0003253 rdfs:subClassOf bae:BrendaCell . # ELT-3 cell
-obo:BTO_0003263 rdfs:subClassOf bae:BrendaCell . # HEK-AD293 cell
-obo:BTO_0003264 rdfs:subClassOf bae:BrendaCell . # HL-1 cell
-obo:BTO_0003266 rdfs:subClassOf bae:BrendaCell . # HPAF-2 cell
-obo:BTO_0003270 rdfs:subClassOf bae:BrendaCell . # Me665/2 cell
-obo:BTO_0003280 rdfs:subClassOf bae:BrendaCell . # sessile cell
-obo:BTO_0003281 rdfs:subClassOf bae:BrendaCell . # planktonic cell
-obo:BTO_0003283 rdfs:subClassOf bae:BrendaCell . # SC-M1 cell
-obo:BTO_0003290 rdfs:subClassOf bae:BrendaCell . # PanIN cell
-obo:BTO_0003291 rdfs:subClassOf bae:BrendaCell . # P493-6 cell
-obo:BTO_0003293 rdfs:subClassOf bae:BrendaCell . # Rat-1 cell
-obo:BTO_0003296 rdfs:subClassOf bae:BrendaCell . # bone marrow stromal cell line
-obo:BTO_0003298 rdfs:subClassOf bae:BrendaCell . # mesenchymal stem cell
-obo:BTO_0003306 rdfs:subClassOf bae:BrendaCell . # Mat-Ly-Lu cell
-obo:BTO_0003310 rdfs:subClassOf bae:BrendaCell . # KMCH cell
-obo:BTO_0003312 rdfs:subClassOf bae:BrendaCell . # KM-12C cell
-obo:BTO_0003317 rdfs:subClassOf bae:BrendaCell . # INS-1E cell
-obo:BTO_0003318 rdfs:subClassOf bae:BrendaCell . # INS-1 823/13 cell
-obo:BTO_0003319 rdfs:subClassOf bae:BrendaCell . # Hepa-1 cell
-obo:BTO_0003321 rdfs:subClassOf bae:BrendaCell . # HCE cell
-obo:BTO_0003324 rdfs:subClassOf bae:BrendaCell . # cardiomyocyte cell line
-obo:BTO_0003326 rdfs:subClassOf bae:BrendaCell . # FLK cell
-obo:BTO_0003336 rdfs:subClassOf bae:BrendaCell . # pulmonary artery smooth muscle cell
-obo:BTO_0003339 rdfs:subClassOf bae:BrendaCell . # HCMEC/D3 cell
-obo:BTO_0003344 rdfs:subClassOf bae:BrendaCell . # CL1-4 cell
-obo:BTO_0003347 rdfs:subClassOf bae:BrendaCell . # C4-2 cell
-obo:BTO_0003349 rdfs:subClassOf bae:BrendaCell . # microglial cell line
-obo:BTO_0003350 rdfs:subClassOf bae:BrendaCell . # BV-2 cell
-obo:BTO_0003352 rdfs:subClassOf bae:BrendaCell . # brain capillary endothelial cell line
-obo:BTO_0003354 rdfs:subClassOf bae:BrendaCell . # B-cell chronic lymphocytic leukemia cell
-obo:BTO_0003357 rdfs:subClassOf bae:BrendaCell . # ARPE cell
-obo:BTO_0003393 rdfs:subClassOf bae:BrendaCell . # granule cell
-obo:BTO_0003413 rdfs:subClassOf bae:BrendaCell . # encysting cell
-obo:BTO_0003420 rdfs:subClassOf bae:BrendaCell . # trophoblast cell line
-obo:BTO_0003422 rdfs:subClassOf bae:BrendaCell . # AF5 cell
-obo:BTO_0003423 rdfs:subClassOf bae:BrendaCell . # lacrimal gland acinar cell
-obo:BTO_0003429 rdfs:subClassOf bae:BrendaCell . # BIC-1 cell
-obo:BTO_0003431 rdfs:subClassOf bae:BrendaCell . # dermatofibroma cell
-obo:BTO_0003436 rdfs:subClassOf bae:BrendaCell . # synovial cell line
-obo:BTO_0003438 rdfs:subClassOf bae:BrendaCell . # WM-9 cell
-obo:BTO_0003452 rdfs:subClassOf bae:BrendaCell . # adipocyte cell line
-obo:BTO_0003457 rdfs:subClassOf bae:BrendaCell . # endometrioma cell
-obo:BTO_0003474 rdfs:subClassOf bae:BrendaCell . # WM-239 cell
-obo:BTO_0003478 rdfs:subClassOf bae:BrendaCell . # SNU-638 cell
-obo:BTO_0003483 rdfs:subClassOf bae:BrendaCell . # sebaceous gland cell line
-obo:BTO_0003485 rdfs:subClassOf bae:BrendaCell . # RPAEC cell
-obo:BTO_0003492 rdfs:subClassOf bae:BrendaCell . # PLC-PRF-5 cell
-obo:BTO_0003494 rdfs:subClassOf bae:BrendaCell . # peripheral blood cell
-obo:BTO_0003505 rdfs:subClassOf bae:BrendaCell . # T-cell chronic lymphocytic leukemia cell
-obo:BTO_0003506 rdfs:subClassOf bae:BrendaCell . # SAF-1 cell
-obo:BTO_0003512 rdfs:subClassOf bae:BrendaCell . # alveolar epithelial cell line
-obo:BTO_0003513 rdfs:subClassOf bae:BrendaCell . # hepatic stellate cell line
-obo:BTO_0003516 rdfs:subClassOf bae:BrendaCell . # LX-2 cell
-obo:BTO_0003520 rdfs:subClassOf bae:BrendaCell . # HSC-T6 cell
-obo:BTO_0003525 rdfs:subClassOf bae:BrendaCell . # BSC cell
-obo:BTO_0003528 rdfs:subClassOf bae:BrendaCell . # GRX cell
-obo:BTO_0003539 rdfs:subClassOf bae:BrendaCell . # PNT2-C2 cell
-obo:BTO_0003540 rdfs:subClassOf bae:BrendaCell . # P4E6 cell
-obo:BTO_0003544 rdfs:subClassOf bae:BrendaCell . # KU-7 cell
-obo:BTO_0003545 rdfs:subClassOf bae:BrendaCell . # KU-1 cell
-obo:BTO_0003548 rdfs:subClassOf bae:BrendaCell . # SMS-KCN cell
-obo:BTO_0003556 rdfs:subClassOf bae:BrendaCell . # SN-56 cell
-obo:BTO_0003560 rdfs:subClassOf bae:BrendaCell . # CCE cell
-obo:BTO_0003562 rdfs:subClassOf bae:BrendaCell . # MB-49 cell
-obo:BTO_0003566 rdfs:subClassOf bae:BrendaCell . # alphaT3-1 cell
-obo:BTO_0003568 rdfs:subClassOf bae:BrendaCell . # mammary gland cell line
-obo:BTO_0003569 rdfs:subClassOf bae:BrendaCell . # C57MG cell
-obo:BTO_0003572 rdfs:subClassOf bae:BrendaCell . # HL60/ADR cell
-obo:BTO_0003578 rdfs:subClassOf bae:BrendaCell . # gingival cell line
-obo:BTO_0003581 rdfs:subClassOf bae:BrendaCell . # renal glomerular cell line
-obo:BTO_0003583 rdfs:subClassOf bae:BrendaCell . # neuroendocrine tumor cell line
-obo:BTO_0003586 rdfs:subClassOf bae:BrendaCell . # Hep-G2/C3A cell
-obo:BTO_0003588 rdfs:subClassOf bae:BrendaCell . # HeLa-MAGI cell
-obo:BTO_0003596 rdfs:subClassOf bae:BrendaCell . # uterine sarcoma cell
-obo:BTO_0003599 rdfs:subClassOf bae:BrendaCell . # human lung microvascular endothelial cell
-obo:BTO_0003600 rdfs:subClassOf bae:BrendaCell . # M cell
-obo:BTO_0003613 rdfs:subClassOf bae:BrendaCell . # lung squamous cell carcinoma cell
-obo:BTO_0003614 rdfs:subClassOf bae:BrendaCell . # oral squamous cell carcinoma cell
-obo:BTO_0003620 rdfs:subClassOf bae:BrendaCell . # BMMC cell
-obo:BTO_0003621 rdfs:subClassOf bae:BrendaCell . # serosal mast cell
-obo:BTO_0003622 rdfs:subClassOf bae:BrendaCell . # mucosal mast cell
-obo:BTO_0003630 rdfs:subClassOf bae:BrendaCell . # CT-26 cell
-obo:BTO_0003640 rdfs:subClassOf bae:BrendaCell . # esophageal cell line
-obo:BTO_0003642 rdfs:subClassOf bae:BrendaCell . # Hca-F cell
-obo:BTO_0003643 rdfs:subClassOf bae:BrendaCell . # HD-11 cell
-obo:BTO_0003645 rdfs:subClassOf bae:BrendaCell . # salivary gland tumor cell line
-obo:BTO_0003646 rdfs:subClassOf bae:BrendaCell . # pleomorphic adenoma cell
-obo:BTO_0003651 rdfs:subClassOf bae:BrendaCell . # spindle cell
-obo:BTO_0003652 rdfs:subClassOf bae:BrendaCell . # synovial cell
-obo:BTO_0003659 rdfs:subClassOf bae:BrendaCell . # secretory cell
-obo:BTO_0003666 rdfs:subClassOf bae:BrendaCell . # outer hair cell
-obo:BTO_0003667 rdfs:subClassOf bae:BrendaCell . # inner hair cell
-obo:BTO_0003672 rdfs:subClassOf bae:BrendaCell . # interdigitating reticulum cell
-obo:BTO_0003681 rdfs:subClassOf bae:BrendaCell . # hairy cell leukemia cell line
-obo:BTO_0003682 rdfs:subClassOf bae:BrendaCell . # hairy cell leukemia cell
-obo:BTO_0003689 rdfs:subClassOf bae:BrendaCell . # mucous cell
-obo:BTO_0003690 rdfs:subClassOf bae:BrendaCell . # mucous acinar cell
-obo:BTO_0003692 rdfs:subClassOf bae:BrendaCell . # prostatic intraepithelial neoplasia cell
-obo:BTO_0003694 rdfs:subClassOf bae:BrendaCell . # CNS cell line
-obo:BTO_0003695 rdfs:subClassOf bae:BrendaCell . # CAD cell
-obo:BTO_0003696 rdfs:subClassOf bae:BrendaCell . # ATRkd cell
-obo:BTO_0003697 rdfs:subClassOf bae:BrendaCell . # endometrial stromal cell
-obo:BTO_0003704 rdfs:subClassOf bae:BrendaCell . # H4 neuroglioma cell
-obo:BTO_0003713 rdfs:subClassOf bae:BrendaCell . # WM-793 cell
-obo:BTO_0003714 rdfs:subClassOf bae:BrendaCell . # VMRC-RCW cell
-obo:BTO_0003716 rdfs:subClassOf bae:BrendaCell . # ScN2a cell
-obo:BTO_0003736 rdfs:subClassOf bae:BrendaCell . # thyroid epithelial cell
-obo:BTO_0003744 rdfs:subClassOf bae:BrendaCell . # liposarcoma cell line
-obo:BTO_0003745 rdfs:subClassOf bae:BrendaCell . # liposarcoma cell
-obo:BTO_0003758 rdfs:subClassOf bae:BrendaCell . # STAV-AB cell
-obo:BTO_0003764 rdfs:subClassOf bae:BrendaCell . # NCI cell
-obo:BTO_0003765 rdfs:subClassOf bae:BrendaCell . # dermatofibroma cell line
-obo:BTO_0003766 rdfs:subClassOf bae:BrendaCell . # giant cell tumor cell line
-obo:BTO_0003771 rdfs:subClassOf bae:BrendaCell . # T2 cell
-obo:BTO_0003773 rdfs:subClassOf bae:BrendaCell . # oropharyngeal squamous cell carcinoma cell
-obo:BTO_0003779 rdfs:subClassOf bae:BrendaCell . # RN-46A cell
-obo:BTO_0003781 rdfs:subClassOf bae:BrendaCell . # RCC 786-O cell
-obo:BTO_0003782 rdfs:subClassOf bae:BrendaCell . # rectal adenocarcinoma cell
-obo:BTO_0003783 rdfs:subClassOf bae:BrendaCell . # rectal adenocarcinoma cell line
-obo:BTO_0003789 rdfs:subClassOf bae:BrendaCell . # PR-Mel cell
-obo:BTO_0003790 rdfs:subClassOf bae:BrendaCell . # MR-Mel cell
-obo:BTO_0003792 rdfs:subClassOf bae:BrendaCell . # OV-2008 cell
-obo:BTO_0003796 rdfs:subClassOf bae:BrendaCell . # periglomerular cell
-obo:BTO_0003800 rdfs:subClassOf bae:BrendaCell . # PCCL-3 cell
-obo:BTO_0003804 rdfs:subClassOf bae:BrendaCell . # ovarian serous adenocarcinoma cell line
-obo:BTO_0003845 rdfs:subClassOf bae:BrendaCell . # A2780/CP70 cell
-obo:BTO_0003848 rdfs:subClassOf bae:BrendaCell . # adenoid cystic carcinoma cell
-obo:BTO_0003849 rdfs:subClassOf bae:BrendaCell . # adenosquamous carcinoma cell
-obo:BTO_0003856 rdfs:subClassOf bae:BrendaCell . # BON-1 cell
-obo:BTO_0003857 rdfs:subClassOf bae:BrendaCell . # bone marrow-derived dendritic cell
-obo:BTO_0003858 rdfs:subClassOf bae:BrendaCell . # chondrocyte cell line
-obo:BTO_0003860 rdfs:subClassOf bae:BrendaCell . # T/C-28a2 cell
-obo:BTO_0003861 rdfs:subClassOf bae:BrendaCell . # inflammatory cell
-obo:BTO_0003865 rdfs:subClassOf bae:BrendaCell . # enteroendocrine cell
-obo:BTO_0003871 rdfs:subClassOf bae:BrendaCell . # uterine endometrial cancer cell
-obo:BTO_0003872 rdfs:subClassOf bae:BrendaCell . # foam cell
-obo:BTO_0003875 rdfs:subClassOf bae:BrendaCell . # FTC-236 cell
-obo:BTO_0003877 rdfs:subClassOf bae:BrendaCell . # G-292 cell
-obo:BTO_0003881 rdfs:subClassOf bae:BrendaCell . # HSC-2 cell
-obo:BTO_0003884 rdfs:subClassOf bae:BrendaCell . # HMT-3522 cell
-obo:BTO_0003894 rdfs:subClassOf bae:BrendaCell . # skin carcinoma cell line
-obo:BTO_0003898 rdfs:subClassOf bae:BrendaCell . # GT1 cell
-obo:BTO_0003907 rdfs:subClassOf bae:BrendaCell . # uroepithelial cell line
-obo:BTO_0003909 rdfs:subClassOf bae:BrendaCell . # bile duct cell line
-obo:BTO_0003912 rdfs:subClassOf bae:BrendaCell . # IMCD cell
-obo:BTO_0003921 rdfs:subClassOf bae:BrendaCell . # KHOS cell
-obo:BTO_0003929 rdfs:subClassOf bae:BrendaCell . # MM1-R cell
-obo:BTO_0003932 rdfs:subClassOf bae:BrendaCell . # KMS-11 cell
-obo:BTO_0003936 rdfs:subClassOf bae:BrendaCell . # laryngeal squamous cell carcinoma cell
-obo:BTO_0003944 rdfs:subClassOf bae:BrendaCell . # Mel-Ab cell
-obo:BTO_0003945 rdfs:subClassOf bae:BrendaCell . # MN-9D cell
-obo:BTO_0003946 rdfs:subClassOf bae:BrendaCell . # MMDD1 cell
-obo:BTO_0003952 rdfs:subClassOf bae:BrendaCell . # mesenchymal stromal cell
-obo:BTO_0003955 rdfs:subClassOf bae:BrendaCell . # N-11 cell
-obo:BTO_0003957 rdfs:subClassOf bae:BrendaCell . # N-9 cell
-obo:BTO_0003960 rdfs:subClassOf bae:BrendaCell . # nasopharyngeal carcinoma cell line
-obo:BTO_0003964 rdfs:subClassOf bae:BrendaCell . # OECM-1 cell
-obo:BTO_0003967 rdfs:subClassOf bae:BrendaCell . # OSRGA cell
-obo:BTO_0003972 rdfs:subClassOf bae:BrendaCell . # prostate gland stromal cell
-obo:BTO_0003981 rdfs:subClassOf bae:BrendaCell . # SAS cell
-obo:BTO_0003982 rdfs:subClassOf bae:BrendaCell . # retinal stem cell
-obo:BTO_0003984 rdfs:subClassOf bae:BrendaCell . # A-375P cell
-obo:BTO_0003998 rdfs:subClassOf bae:BrendaCell . # 41-M cell
-obo:BTO_0004002 rdfs:subClassOf bae:BrendaCell . # HEMn cell
-obo:BTO_0004003 rdfs:subClassOf bae:BrendaCell . # NA cell
-obo:BTO_0004004 rdfs:subClassOf bae:BrendaCell . # 3-LL cell
-obo:BTO_0004007 rdfs:subClassOf bae:BrendaCell . # porcine aortic endothelial cell
-obo:BTO_0004010 rdfs:subClassOf bae:BrendaCell . # HT-2 cell
-obo:BTO_0004012 rdfs:subClassOf bae:BrendaCell . # ROS cell
-obo:BTO_0004013 rdfs:subClassOf bae:BrendaCell . # Colon-26 cell
-obo:BTO_0004035 rdfs:subClassOf bae:BrendaCell . # 222 cell
-obo:BTO_0004044 rdfs:subClassOf bae:BrendaCell . # amacrine cell
-obo:BTO_0004049 rdfs:subClassOf bae:BrendaCell . # adult T-cell lymphoma cell line
-obo:BTO_0004050 rdfs:subClassOf bae:BrendaCell . # BEL-7402 cell
-obo:BTO_0004051 rdfs:subClassOf bae:BrendaCell . # bipolar cell
-obo:BTO_0004052 rdfs:subClassOf bae:BrendaCell . # bone marrow stem cell
-obo:BTO_0004054 rdfs:subClassOf bae:BrendaCell . # umbilical cord blood cell
-obo:BTO_0004055 rdfs:subClassOf bae:BrendaCell . # COS cell
-obo:BTO_0004058 rdfs:subClassOf bae:BrendaCell . # C3H10T1/2 cell
-obo:BTO_0004065 rdfs:subClassOf bae:BrendaCell . # CHO-MG cell
-obo:BTO_0004087 rdfs:subClassOf bae:BrendaCell . # mammary gland tumor cell
-obo:BTO_0004091 rdfs:subClassOf bae:BrendaCell . # embryonic neural stem cell
-obo:BTO_0004093 rdfs:subClassOf bae:BrendaCell . # endothelial progenitor cell
-obo:BTO_0004094 rdfs:subClassOf bae:BrendaCell . # epithelial ovarian cancer cell
-obo:BTO_0004095 rdfs:subClassOf bae:BrendaCell . # EONT cell
-obo:BTO_0004096 rdfs:subClassOf bae:BrendaCell . # coronary artery endothelial cell
-obo:BTO_0004097 rdfs:subClassOf bae:BrendaCell . # epididymal clear cell
-obo:BTO_0004098 rdfs:subClassOf bae:BrendaCell . # renal clear cell
-obo:BTO_0004105 rdfs:subClassOf bae:BrendaCell . # FPMI-CF-203 cell
-obo:BTO_0004111 rdfs:subClassOf bae:BrendaCell . # gastrointestinal stromal tumor cell
-obo:BTO_0004112 rdfs:subClassOf bae:BrendaCell . # GBC-SD cell
-obo:BTO_0004114 rdfs:subClassOf bae:BrendaCell . # adrenocortical carcinoma cell line
-obo:BTO_0004115 rdfs:subClassOf bae:BrendaCell . # HAC cell
-obo:BTO_0004116 rdfs:subClassOf bae:BrendaCell . # HEP-3B2 cell
-obo:BTO_0004117 rdfs:subClassOf bae:BrendaCell . # HFK cell
-obo:BTO_0004120 rdfs:subClassOf bae:BrendaCell . # horizontal cell
-obo:BTO_0004122 rdfs:subClassOf bae:BrendaCell . # bone marrow stromal cell
-obo:BTO_0004126 rdfs:subClassOf bae:BrendaCell . # Huh-7.5 cell
-obo:BTO_0004139 rdfs:subClassOf bae:BrendaCell . # LAD-2 cell
-obo:BTO_0004160 rdfs:subClassOf bae:BrendaCell . # Ma-1 cell
-obo:BTO_0004166 rdfs:subClassOf bae:BrendaCell . # myofibroblast cell line
-obo:BTO_0004168 rdfs:subClassOf bae:BrendaCell . # MHCC-97 cell
-obo:BTO_0004169 rdfs:subClassOf bae:BrendaCell . # MHCC97-H cell
-obo:BTO_0004170 rdfs:subClassOf bae:BrendaCell . # MHCC97-L cell
-obo:BTO_0004178 rdfs:subClassOf bae:BrendaCell . # leukemic stem cell
-obo:BTO_0004181 rdfs:subClassOf bae:BrendaCell . # NCI/ADR-RES cell
-obo:BTO_0004190 rdfs:subClassOf bae:BrendaCell . # pacemaker cell
-obo:BTO_0004191 rdfs:subClassOf bae:BrendaCell . # PC-J cell
-obo:BTO_0004200 rdfs:subClassOf bae:BrendaCell . # RCSN-3 cell
-obo:BTO_0004201 rdfs:subClassOf bae:BrendaCell . # Ewing's sarcoma cell line
-obo:BTO_0004203 rdfs:subClassOf bae:BrendaCell . # RIE-1 cell
-obo:BTO_0004210 rdfs:subClassOf bae:BrendaCell . # seminoma cell
-obo:BTO_0004221 rdfs:subClassOf bae:BrendaCell . # SN-12C cell
-obo:BTO_0004223 rdfs:subClassOf bae:BrendaCell . # cervical squamous cell carcinoma cell
-obo:BTO_0004226 rdfs:subClassOf bae:BrendaCell . # TAMH cell
-obo:BTO_0004229 rdfs:subClassOf bae:BrendaCell . # testicular cell line
-obo:BTO_0004232 rdfs:subClassOf bae:BrendaCell . # tsA-201 cell
-obo:BTO_0004236 rdfs:subClassOf bae:BrendaCell . # Y1-BS1 cell
-obo:BTO_0004237 rdfs:subClassOf bae:BrendaCell . # myometrial cell line
-obo:BTO_0004238 rdfs:subClassOf bae:BrendaCell . # interstitial cell
-obo:BTO_0004243 rdfs:subClassOf bae:BrendaCell . # trypanosomoid cell line
-obo:BTO_0004248 rdfs:subClassOf bae:BrendaCell . # Xenopus A6 cell
-obo:BTO_0004254 rdfs:subClassOf bae:BrendaCell . # cancer stem cell
-obo:BTO_0004255 rdfs:subClassOf bae:BrendaCell . # Ewing's family tumor cell
-obo:BTO_0004257 rdfs:subClassOf bae:BrendaCell . # extraosseus Ewing's sarcoma cell
-obo:BTO_0004258 rdfs:subClassOf bae:BrendaCell . # primitive neuroectodermal tumor cell
-obo:BTO_0004259 rdfs:subClassOf bae:BrendaCell . # primitive neuroectodermal tumor cell line
-obo:BTO_0004260 rdfs:subClassOf bae:BrendaCell . # Askin's tumor cell
-obo:BTO_0004261 rdfs:subClassOf bae:BrendaCell . # peripheral primitive neuroectodermal tumor cell
-obo:BTO_0004262 rdfs:subClassOf bae:BrendaCell . # cerebral giant cell
-obo:BTO_0004265 rdfs:subClassOf bae:BrendaCell . # EJ cell
-obo:BTO_0004266 rdfs:subClassOf bae:BrendaCell . # H-10 cell
-obo:BTO_0004267 rdfs:subClassOf bae:BrendaCell . # follicular dendritic cell
-obo:BTO_0004269 rdfs:subClassOf bae:BrendaCell . # liver cancer stem cell
-obo:BTO_0004270 rdfs:subClassOf bae:BrendaCell . # adult liver stem cell
-obo:BTO_0004272 rdfs:subClassOf bae:BrendaCell . # hyalocyte cell line
-obo:BTO_0004278 rdfs:subClassOf bae:BrendaCell . # cerebellar granule cell
-obo:BTO_0004286 rdfs:subClassOf bae:BrendaCell . # basophilic leukemia cell
-obo:BTO_0004296 rdfs:subClassOf bae:BrendaCell . # umbilical vein endothelial cell
-obo:BTO_0004297 rdfs:subClassOf bae:BrendaCell . # colonic epithelial cell
-obo:BTO_0004298 rdfs:subClassOf bae:BrendaCell . # corneal epithelial cell
-obo:BTO_0004299 rdfs:subClassOf bae:BrendaCell . # lung epithelial cell
-obo:BTO_0004300 rdfs:subClassOf bae:BrendaCell . # mammary epithelial cell
-obo:BTO_0004301 rdfs:subClassOf bae:BrendaCell . # neuroepithelial cell
-obo:BTO_0004306 rdfs:subClassOf bae:BrendaCell . # NCM-460 cell
-obo:BTO_0004324 rdfs:subClassOf bae:BrendaCell . # osteoblast cell line
-obo:BTO_0004325 rdfs:subClassOf bae:BrendaCell . # 2T3 cell
-obo:BTO_0004333 rdfs:subClassOf bae:BrendaCell . # Do11.10 cell
-obo:BTO_0004339 rdfs:subClassOf bae:BrendaCell . # ScGT1 cell
-obo:BTO_0004360 rdfs:subClassOf bae:BrendaCell . # angiomyolipoma cell
-obo:BTO_0004365 rdfs:subClassOf bae:BrendaCell . # gastroesophageal cancer cell
-obo:BTO_0004384 rdfs:subClassOf bae:BrendaCell . # osteoclast stem cell
-obo:BTO_0004389 rdfs:subClassOf bae:BrendaCell . # angiomyolipoma cell line
-obo:BTO_0004392 rdfs:subClassOf bae:BrendaCell . # skeletal muscle cell
-obo:BTO_0004397 rdfs:subClassOf bae:BrendaCell . # B-103 cell
-obo:BTO_0004398 rdfs:subClassOf bae:BrendaCell . # meningioma cell line
-obo:BTO_0004402 rdfs:subClassOf bae:BrendaCell . # bronchial smooth muscle cell
-obo:BTO_0004405 rdfs:subClassOf bae:BrendaCell . # 3D5 cell
-obo:BTO_0004410 rdfs:subClassOf bae:BrendaCell . # culture condition:CD8+ cell
-obo:BTO_0004416 rdfs:subClassOf bae:BrendaCell . # Daltons lymphoma cell
-obo:BTO_0004420 rdfs:subClassOf bae:BrendaCell . # digestive cell
-obo:BTO_0004438 rdfs:subClassOf bae:BrendaCell . # HSCC cell
-obo:BTO_0004462 rdfs:subClassOf bae:BrendaCell . # K-562R cell
-obo:BTO_0004467 rdfs:subClassOf bae:BrendaCell . # LbetaT2 cell
-obo:BTO_0004471 rdfs:subClassOf bae:BrendaCell . # Mahlavu cell
-obo:BTO_0004472 rdfs:subClassOf bae:BrendaCell . # mantle cell lymphoma cell
-obo:BTO_0004475 rdfs:subClassOf bae:BrendaCell . # MEL cell
-obo:BTO_0004476 rdfs:subClassOf bae:BrendaCell . # MES-23.5 cell
-obo:BTO_0004481 rdfs:subClassOf bae:BrendaCell . # neural crest-derived stem cell
-obo:BTO_0004482 rdfs:subClassOf bae:BrendaCell . # ovarian surface epithelial cell line
-obo:BTO_0004484 rdfs:subClassOf bae:BrendaCell . # ovarian surface epithelial cell
-obo:BTO_0004487 rdfs:subClassOf bae:BrendaCell . # OV-MZ-6 cell
-obo:BTO_0004488 rdfs:subClassOf bae:BrendaCell . # NSC-34 cell
-obo:BTO_0004492 rdfs:subClassOf bae:BrendaCell . # gastric epithelial cell
-obo:BTO_0004493 rdfs:subClassOf bae:BrendaCell . # gastric epithelium cell line
-obo:BTO_0004494 rdfs:subClassOf bae:BrendaCell . # RGM-1 cell
-obo:BTO_0004498 rdfs:subClassOf bae:BrendaCell . # THCE cell
-obo:BTO_0004499 rdfs:subClassOf bae:BrendaCell . # prostate gland intraepithelial neoplasia cell line
-obo:BTO_0004508 rdfs:subClassOf bae:BrendaCell . # endothelioma cell
-obo:BTO_0004509 rdfs:subClassOf bae:BrendaCell . # endothelioma cell line
-obo:BTO_0004513 rdfs:subClassOf bae:BrendaCell . # Sertoli cell line
-obo:BTO_0004519 rdfs:subClassOf bae:BrendaCell . # myometrial cell
-obo:BTO_0004522 rdfs:subClassOf bae:BrendaCell . # Leydig cell line
-obo:BTO_0004530 rdfs:subClassOf bae:BrendaCell . # F5 meningioma cell
-obo:BTO_0004533 rdfs:subClassOf bae:BrendaCell . # respiratory epithelium cell
-obo:BTO_0004535 rdfs:subClassOf bae:BrendaCell . # medullary collecting duct cell
-obo:BTO_0004537 rdfs:subClassOf bae:BrendaCell . # cortical collecting duct cell
-obo:BTO_0004541 rdfs:subClassOf bae:BrendaCell . # connecting tubule cell
-obo:BTO_0004542 rdfs:subClassOf bae:BrendaCell . # principal cell
-obo:BTO_0004543 rdfs:subClassOf bae:BrendaCell . # inner medullary collecting duct cell
-obo:BTO_0004561 rdfs:subClassOf bae:BrendaCell . # thymic stromal cell
-obo:BTO_0004562 rdfs:subClassOf bae:BrendaCell . # thymic cortical epithelial cell
-obo:BTO_0004563 rdfs:subClassOf bae:BrendaCell . # thymic medullary epithelial cell
-obo:BTO_0004564 rdfs:subClassOf bae:BrendaCell . # thymic dendritic cell
-obo:BTO_0004566 rdfs:subClassOf bae:BrendaCell . # Rb-1 cell
-obo:BTO_0004567 rdfs:subClassOf bae:BrendaCell . # sessile serrated adenoma cell
-obo:BTO_0004574 rdfs:subClassOf bae:BrendaCell . # dermal microvascular endothelial cell
-obo:BTO_0004575 rdfs:subClassOf bae:BrendaCell . # nephroblastoma cell
-obo:BTO_0004576 rdfs:subClassOf bae:BrendaCell . # smooth muscle cell
-obo:BTO_0004577 rdfs:subClassOf bae:BrendaCell . # aortic smooth muscle cell
-obo:BTO_0004578 rdfs:subClassOf bae:BrendaCell . # vascular smooth muscle cell
-obo:BTO_0004585 rdfs:subClassOf bae:BrendaCell . # acute promyelocytic leukemia cell
-obo:BTO_0004595 rdfs:subClassOf bae:BrendaCell . # D-407 cell
-obo:BTO_0004599 rdfs:subClassOf bae:BrendaCell . # TE-13 cell
-obo:BTO_0004601 rdfs:subClassOf bae:BrendaCell . # TE-1 cell
-obo:BTO_0004602 rdfs:subClassOf bae:BrendaCell . # human aortic endothelial cell
-obo:BTO_0004603 rdfs:subClassOf bae:BrendaCell . # HBE cell
-obo:BTO_0004606 rdfs:subClassOf bae:BrendaCell . # MDCK-1 cell
-obo:BTO_0004607 rdfs:subClassOf bae:BrendaCell . # MDCK-2 cell
-obo:BTO_0004609 rdfs:subClassOf bae:BrendaCell . # TALH cell
-obo:BTO_0004623 rdfs:subClassOf bae:BrendaCell . # OCI-M2 cell
-obo:BTO_0004624 rdfs:subClassOf bae:BrendaCell . # YN-1 cell
-obo:BTO_0004625 rdfs:subClassOf bae:BrendaCell . # plasmacytoid dendritic cell
-obo:BTO_0004640 rdfs:subClassOf bae:BrendaCell . # FD-2 cell
-obo:BTO_0004641 rdfs:subClassOf bae:BrendaCell . # tracheal cell line
-obo:BTO_0004656 rdfs:subClassOf bae:BrendaCell . # follicular lymphoma cell
-obo:BTO_0004660 rdfs:subClassOf bae:BrendaCell . # human amniotic epithelial cell
-obo:BTO_0004720 rdfs:subClassOf bae:BrendaCell . # mural cell
-obo:BTO_0004721 rdfs:subClassOf bae:BrendaCell . # myeloid dendritic cell
-obo:BTO_0004730 rdfs:subClassOf bae:BrendaCell . # myeloid progenitor cell
-obo:BTO_0004731 rdfs:subClassOf bae:BrendaCell . # lymphoid progenitor cell
-obo:BTO_0004744 rdfs:subClassOf bae:BrendaCell . # hair cell
-obo:BTO_0004752 rdfs:subClassOf bae:BrendaCell . # adipose-derived stromal cell
-obo:BTO_0004758 rdfs:subClassOf bae:BrendaCell . # arterial endothelial cell
-obo:BTO_0004759 rdfs:subClassOf bae:BrendaCell . # venous endothelial cell
-obo:BTO_0004770 rdfs:subClassOf bae:BrendaCell . # TAD-2 cell
-obo:BTO_0004771 rdfs:subClassOf bae:BrendaCell . # NPA cell
-obo:BTO_0004773 rdfs:subClassOf bae:BrendaCell . # trophoblast stem cell line
-obo:BTO_0004774 rdfs:subClassOf bae:BrendaCell . # trophoblast stem cell
-obo:BTO_0004779 rdfs:subClassOf bae:BrendaCell . # soft tissue sarcoma cell
-obo:BTO_0004780 rdfs:subClassOf bae:BrendaCell . # soft tissue sarcoma cell line
-obo:BTO_0004783 rdfs:subClassOf bae:BrendaCell . # SeAx cell
-obo:BTO_0004785 rdfs:subClassOf bae:BrendaCell . # Ewing's sarcoma family tumor cell line
-obo:BTO_0004787 rdfs:subClassOf bae:BrendaCell . # SK-N-LO cell
-obo:BTO_0004796 rdfs:subClassOf bae:BrendaCell . # 253J cell
-obo:BTO_0004799 rdfs:subClassOf bae:BrendaCell . # AILNCaP cell
-obo:BTO_0004804 rdfs:subClassOf bae:BrendaCell . # buccal epithelial cell
-obo:BTO_0004811 rdfs:subClassOf bae:BrendaCell . # Clara cell
-obo:BTO_0004812 rdfs:subClassOf bae:BrendaCell . # dermal dendritic cell
-obo:BTO_0004816 rdfs:subClassOf bae:BrendaCell . # ERpP cell
-obo:BTO_0004827 rdfs:subClassOf bae:BrendaCell . # hFOB cell
-obo:BTO_0004830 rdfs:subClassOf bae:BrendaCell . # epidermal cell line
-obo:BTO_0004831 rdfs:subClassOf bae:BrendaCell . # JB6 cell
-obo:BTO_0004833 rdfs:subClassOf bae:BrendaCell . # large cell neuroendocrine carcinoma cell
-obo:BTO_0004837 rdfs:subClassOf bae:BrendaCell . # MRC5-SV cell
-obo:BTO_0004845 rdfs:subClassOf bae:BrendaCell . # NHOst cell
-obo:BTO_0004850 rdfs:subClassOf bae:BrendaCell . # bone marrow cell
-obo:BTO_0004851 rdfs:subClassOf bae:BrendaCell . # mammary ductal carcinoma cell
-obo:BTO_0004854 rdfs:subClassOf bae:BrendaCell . # PK-1 cell
-obo:BTO_0004862 rdfs:subClassOf bae:BrendaCell . # HEI-OC1 cell
-obo:BTO_0004864 rdfs:subClassOf bae:BrendaCell . # HMC cell
-obo:BTO_0004868 rdfs:subClassOf bae:BrendaCell . # anaplastic large cell lymphoma cell line
-obo:BTO_0004877 rdfs:subClassOf bae:BrendaCell . # distal tip cell
-obo:BTO_0004897 rdfs:subClassOf bae:BrendaCell . # CHO-LY-B cell
-obo:BTO_0004901 rdfs:subClassOf bae:BrendaCell . # non-neuronal cell
-obo:BTO_0004910 rdfs:subClassOf bae:BrendaCell . # retinal pigment epithelial cell
-obo:BTO_0004911 rdfs:subClassOf bae:BrendaCell . # erythroid progenitor cell
-obo:BTO_0004919 rdfs:subClassOf bae:BrendaCell . # ZR-75 cell
-obo:BTO_0004921 rdfs:subClassOf bae:BrendaCell . # swine testicular cell line
-obo:BTO_0004925 rdfs:subClassOf bae:BrendaCell . # HRA cell
-obo:BTO_0004953 rdfs:subClassOf bae:BrendaCell . # MGC-803 cell
-obo:BTO_0004958 rdfs:subClassOf bae:BrendaCell . # F9-12 cell
-obo:BTO_0004959 rdfs:subClassOf bae:BrendaCell . # C4-2B cell
-obo:BTO_0004961 rdfs:subClassOf bae:BrendaCell . # acute megakaryoblastic leukemia cell line
-obo:BTO_0004963 rdfs:subClassOf bae:BrendaCell . # acute megakaryoblastic leukemia cell
-obo:BTO_0004965 rdfs:subClassOf bae:BrendaCell . # TTA-1 cell
-obo:BTO_0004966 rdfs:subClassOf bae:BrendaCell . # Rat-1/BB16 cell
-obo:BTO_0004973 rdfs:subClassOf bae:BrendaCell . # Hodgkin lymphoma cell line
-obo:BTO_0004974 rdfs:subClassOf bae:BrendaCell . # Hodgkin lymphoma cell
-obo:BTO_0004975 rdfs:subClassOf bae:BrendaCell . # embryogenic cell line
-obo:BTO_0004976 rdfs:subClassOf bae:BrendaCell . # tongue cancer cell
-obo:BTO_0004980 rdfs:subClassOf bae:BrendaCell . # uveal melanoma cell
-obo:BTO_0004996 rdfs:subClassOf bae:BrendaCell . # myelinating Schwann cell
-obo:BTO_0004997 rdfs:subClassOf bae:BrendaCell . # non-myelinating Schwann cell
-obo:BTO_0005001 rdfs:subClassOf bae:BrendaCell . # retinal microvascular endothelial cell
-obo:BTO_0005004 rdfs:subClassOf bae:BrendaCell . # UROtsa cell
-obo:BTO_0005007 rdfs:subClassOf bae:BrendaCell . # psammomatous meningioma cell
-obo:BTO_0005014 rdfs:subClassOf bae:BrendaCell . # B-cell leukemia cell
-obo:BTO_0005023 rdfs:subClassOf bae:BrendaCell . # cEND cell
-obo:BTO_0005025 rdfs:subClassOf bae:BrendaCell . # HEK-293-TrkB cell
-obo:BTO_0005029 rdfs:subClassOf bae:BrendaCell . # HEK-293FT cell
-obo:BTO_0005034 rdfs:subClassOf bae:BrendaCell . # DT-40 3KO cell
-obo:BTO_0005036 rdfs:subClassOf bae:BrendaCell . # Fanconi anemia lymphoid cell line
-obo:BTO_0005039 rdfs:subClassOf bae:BrendaCell . # HN-30 cell
-obo:BTO_0005040 rdfs:subClassOf bae:BrendaCell . # HN-12 cell
-obo:BTO_0005043 rdfs:subClassOf bae:BrendaCell . # M1 melanoma cell
-obo:BTO_0005049 rdfs:subClassOf bae:BrendaCell . # prostate adenocarcinoma cell line
-obo:BTO_0005054 rdfs:subClassOf bae:BrendaCell . # macrophage foam cell
-obo:BTO_0005059 rdfs:subClassOf bae:BrendaCell . # TZM-bl cell
-obo:BTO_0005060 rdfs:subClassOf bae:BrendaCell . # UACC-903 cell
-obo:BTO_0005067 rdfs:subClassOf bae:BrendaCell . # PAM212 cell
-obo:BTO_0005068 rdfs:subClassOf bae:BrendaCell . # SK-CO15 cell
-obo:BTO_0005071 rdfs:subClassOf bae:BrendaCell . # PC3-MM2 cell
-obo:BTO_0005083 rdfs:subClassOf bae:BrendaCell . # plant mucous cell
-obo:BTO_0005092 rdfs:subClassOf bae:BrendaCell . # chondrogenic cell
-obo:BTO_0005093 rdfs:subClassOf bae:BrendaCell . # intercalated cell
-obo:BTO_0005096 rdfs:subClassOf bae:BrendaCell . # epithelial stem cell
-obo:BTO_0005097 rdfs:subClassOf bae:BrendaCell . # skin stem cell
-obo:BTO_0005098 rdfs:subClassOf bae:BrendaCell . # epidermal stem cell
-obo:BTO_0005099 rdfs:subClassOf bae:BrendaCell . # follicular stem cell
-obo:BTO_0005101 rdfs:subClassOf bae:BrendaCell . # coronary artery smooth muscle cell
-obo:BTO_0005103 rdfs:subClassOf bae:BrendaCell . # NB-1 cell
-obo:BTO_0005110 rdfs:subClassOf bae:BrendaCell . # ameloblastoma cell
-obo:BTO_0005117 rdfs:subClassOf bae:BrendaCell . # retinal ganglion cell line
-obo:BTO_0005118 rdfs:subClassOf bae:BrendaCell . # RGC-5 cell
-obo:BTO_0005128 rdfs:subClassOf bae:BrendaCell . # M12 prostate cancer cell
-obo:BTO_0005129 rdfs:subClassOf bae:BrendaCell . # A2780/S cell
-obo:BTO_0005136 rdfs:subClassOf bae:BrendaCell . # ES-E14 cell
-obo:BTO_0005155 rdfs:subClassOf bae:BrendaCell . # CEM-VBL100 cell
-obo:BTO_0005158 rdfs:subClassOf bae:BrendaCell . # juxtaglomerular cell
-obo:BTO_0005159 rdfs:subClassOf bae:BrendaCell . # extraglomerular mesangial cell
-obo:BTO_0005161 rdfs:subClassOf bae:BrendaCell . # KAT-18 cell
-obo:BTO_0005167 rdfs:subClassOf bae:BrendaCell . # HSC-1 cell
-obo:BTO_0005191 rdfs:subClassOf bae:BrendaCell . # Patu-8988 cell
-obo:BTO_0005195 rdfs:subClassOf bae:BrendaCell . # K-562/R7 cell
-obo:BTO_0005196 rdfs:subClassOf bae:BrendaCell . # KBv200 cell
-obo:BTO_0005198 rdfs:subClassOf bae:BrendaCell . # adipose-derived stem cell
-obo:BTO_0005201 rdfs:subClassOf bae:BrendaCell . # brain endothelial cell
-obo:BTO_0005204 rdfs:subClassOf bae:BrendaCell . # Ca9-22 cell
-obo:BTO_0005212 rdfs:subClassOf bae:BrendaCell . # cervical intraepithelial neoplasia cell
-obo:BTO_0005215 rdfs:subClassOf bae:BrendaCell . # KB-C2 cell
-obo:BTO_0005218 rdfs:subClassOf bae:BrendaCell . # MC57 cell
-obo:BTO_0005220 rdfs:subClassOf bae:BrendaCell . # PC-3M cell
-obo:BTO_0005238 rdfs:subClassOf bae:BrendaCell . # T-REx 293 cell
-obo:BTO_0005258 rdfs:subClassOf bae:BrendaCell . # oropharyngeal cancer cell
-obo:BTO_0005259 rdfs:subClassOf bae:BrendaCell . # oropharyngeal carcinoma cell line
-obo:BTO_0005261 rdfs:subClassOf bae:BrendaCell . # B-lymphoblast cell line
-obo:BTO_0005262 rdfs:subClassOf bae:BrendaCell . # NEF cell
-obo:BTO_0005264 rdfs:subClassOf bae:BrendaCell . # mucoepidermoid carcinoma cell
-obo:BTO_0005283 rdfs:subClassOf bae:BrendaCell . # TS-20 cell
-obo:BTO_0005288 rdfs:subClassOf bae:BrendaCell . # CL-48 cell
-obo:BTO_0005300 rdfs:subClassOf bae:BrendaCell . # muscle stem cell
-obo:BTO_0005301 rdfs:subClassOf bae:BrendaCell . # NPrEC cell
-obo:BTO_0005316 rdfs:subClassOf bae:BrendaCell . # malignant peripheral nerve sheath cancer cell
-obo:BTO_0005319 rdfs:subClassOf bae:BrendaCell . # embryonic germ cell
-obo:BTO_0005322 rdfs:subClassOf bae:BrendaCell . # chronic myelogenous leukemia progenitor cell
-obo:BTO_0005352 rdfs:subClassOf bae:BrendaCell . # 1-LN cell
-obo:BTO_0005362 rdfs:subClassOf bae:BrendaCell . # trophoblast giant cell
-obo:BTO_0005364 rdfs:subClassOf bae:BrendaCell . # D-54MG cell
-obo:BTO_0005372 rdfs:subClassOf bae:BrendaCell . # SK-N-MC-IXC cell
-obo:BTO_0005375 rdfs:subClassOf bae:BrendaCell . # oral cell line
-obo:BTO_0005388 rdfs:subClassOf bae:BrendaCell . # SUM-149 cell
-obo:BTO_0005397 rdfs:subClassOf bae:BrendaCell . # SH-EP cell
-obo:BTO_0005399 rdfs:subClassOf bae:BrendaCell . # POS cell
-obo:BTO_0005400 rdfs:subClassOf bae:BrendaCell . # BPH cell
-obo:BTO_0005403 rdfs:subClassOf bae:BrendaCell . # glycogen cell
-obo:BTO_0005453 rdfs:subClassOf bae:BrendaCell . # culture condition:CD4+ cell
-obo:BTO_0005490 rdfs:subClassOf bae:BrendaCell . # MM-1 cell
-obo:CLO_0001056 rdfs:subClassOf bae:BrendaCell . # 1205Lu cell
-obo:CLO_0001088 rdfs:subClassOf bae:BrendaCell . # 143B cell
-obo:CLO_0001200 rdfs:subClassOf bae:BrendaCell . # 22Rv1 cell
-obo:CLO_0001230 rdfs:subClassOf bae:BrendaCell . # HEK-293 cell
-obo:CLO_0001352 rdfs:subClassOf bae:BrendaCell . # 3T3-L1 cell
-obo:CLO_0001401 rdfs:subClassOf bae:BrendaCell . # 4T1 cell
-obo:CLO_0001570 rdfs:subClassOf bae:BrendaCell . # A-253 cell
-obo:CLO_0001571 rdfs:subClassOf bae:BrendaCell . # A2780 cell
-obo:CLO_0001582 rdfs:subClassOf bae:BrendaCell . # A-375 cell
-obo:CLO_0001590 rdfs:subClassOf bae:BrendaCell . # A-427 cell
-obo:CLO_0001596 rdfs:subClassOf bae:BrendaCell . # A-498 cell
-obo:CLO_0001606 rdfs:subClassOf bae:BrendaCell . # A-673 cell
-obo:CLO_0001656 rdfs:subClassOf bae:BrendaCell . # ACT-1 cell
-obo:CLO_0001662 rdfs:subClassOf bae:BrendaCell . # ADF cell
-obo:CLO_0001745 rdfs:subClassOf bae:BrendaCell . # ARH-77 cell
-obo:CLO_0001756 rdfs:subClassOf bae:BrendaCell . # AsPC-1 cell
-obo:CLO_0001766 rdfs:subClassOf bae:BrendaCell . # AtT-20 cell
-obo:CLO_0001793 rdfs:subClassOf bae:BrendaCell . # B16-F1 cell
-obo:CLO_0001794 rdfs:subClassOf bae:BrendaCell . # B16-F10 cell
-obo:CLO_0001925 rdfs:subClassOf bae:BrendaCell . # BEAS-2B cell
-obo:CLO_0001933 rdfs:subClassOf bae:BrendaCell . # Beta-TC-6 cell
-obo:CLO_0001934 rdfs:subClassOf bae:BrendaCell . # BEWO cell
-obo:CLO_0001965 rdfs:subClassOf bae:BrendaCell . # BHK-21 cell
-obo:CLO_0002000 rdfs:subClassOf bae:BrendaCell . # Bm N cell
-obo:CLO_0002022 rdfs:subClassOf bae:BrendaCell . # BPH-1 cell
-obo:CLO_0002052 rdfs:subClassOf bae:BrendaCell . # BV-173 cell
-obo:CLO_0002057 rdfs:subClassOf bae:BrendaCell . # BW5147 cell
-obo:CLO_0002065 rdfs:subClassOf bae:BrendaCell . # BxPC-3 cell
-obo:CLO_0002086 rdfs:subClassOf bae:BrendaCell . # C127I cell
-obo:CLO_0002168 rdfs:subClassOf bae:BrendaCell . # CA-46 cell
-obo:CLO_0002176 rdfs:subClassOf bae:BrendaCell . # Caki-1 cell
-obo:CLO_0002193 rdfs:subClassOf bae:BrendaCell . # Calu-6 cell
-obo:CLO_0002201 rdfs:subClassOf bae:BrendaCell . # CaSki cell
-obo:CLO_0002309 rdfs:subClassOf bae:BrendaCell . # CCD-18Co cell
-obo:CLO_0002360 rdfs:subClassOf bae:BrendaCell . # CESS cell
-obo:CLO_0002526 rdfs:subClassOf bae:BrendaCell . # CMK cell
-obo:CLO_0002532 rdfs:subClassOf bae:BrendaCell . # CMT-93 cell
-obo:CLO_0002571 rdfs:subClassOf bae:BrendaCell . # Colo-320 cell
-obo:CLO_0002574 rdfs:subClassOf bae:BrendaCell . # COLO-699 cell
-obo:CLO_0002596 rdfs:subClassOf bae:BrendaCell . # COS-1 cell
-obo:CLO_0002640 rdfs:subClassOf bae:BrendaCell . # CV-1 cell
-obo:CLO_0002650 rdfs:subClassOf bae:BrendaCell . # CX-1 cell
-obo:CLO_0002699 rdfs:subClassOf bae:BrendaCell . # Daoy cell
-obo:CLO_0002708 rdfs:subClassOf bae:BrendaCell . # DAUDI cell
-obo:CLO_0002767 rdfs:subClassOf bae:BrendaCell . # DG-75 cell
-obo:CLO_0002807 rdfs:subClassOf bae:BrendaCell . # DON cell
-obo:CLO_0002882 rdfs:subClassOf bae:BrendaCell . # ECV-304 cell
-obo:CLO_0002913 rdfs:subClassOf bae:BrendaCell . # EL4 cell
-obo:CLO_0002988 rdfs:subClassOf bae:BrendaCell . # F-9 cell
-obo:CLO_0003396 rdfs:subClassOf bae:BrendaCell . # FRTL-5 cell
-obo:CLO_0003402 rdfs:subClassOf bae:BrendaCell . # FTC-133 cell
-obo:CLO_0003413 rdfs:subClassOf bae:BrendaCell . # G cell
-obo:CLO_0003450 rdfs:subClassOf bae:BrendaCell . # GAMG cell
-obo:CLO_0003487 rdfs:subClassOf bae:BrendaCell . # GH3 cell
-obo:CLO_0003490 rdfs:subClassOf bae:BrendaCell . # GH4-C1 cell
-obo:CLO_0003612 rdfs:subClassOf bae:BrendaCell . # H9 cell
-obo:CLO_0003663 rdfs:subClassOf bae:BrendaCell . # HCN-1A cell
-obo:CLO_0003664 rdfs:subClassOf bae:BrendaCell . # HCN-2 cell
-obo:CLO_0003667 rdfs:subClassOf bae:BrendaCell . # HCT-8 cell
-obo:CLO_0003679 rdfs:subClassOf bae:BrendaCell . # HEL cell
-obo:CLO_0003682 rdfs:subClassOf bae:BrendaCell . # HEL-92.1.7 cell
-obo:CLO_0003684 rdfs:subClassOf bae:BrendaCell . # HeLa cell
-obo:CLO_0003699 rdfs:subClassOf bae:BrendaCell . # HELA-S3 cell
-obo:CLO_0003706 rdfs:subClassOf bae:BrendaCell . # HEp-2 cell
-obo:CLO_0003734 rdfs:subClassOf bae:BrendaCell . # HFL-1 cell
-obo:CLO_0003740 rdfs:subClassOf bae:BrendaCell . # HGF cell
-obo:CLO_0003758 rdfs:subClassOf bae:BrendaCell . # HIT-T15 cell
-obo:CLO_0003771 rdfs:subClassOf bae:BrendaCell . # HK-2 cell
-obo:CLO_0003782 rdfs:subClassOf bae:BrendaCell . # HL-60/MX-2 cell
-obo:CLO_0003786 rdfs:subClassOf bae:BrendaCell . # HMV-II cell
-obo:CLO_0003814 rdfs:subClassOf bae:BrendaCell . # HPAC cell
-obo:CLO_0003817 rdfs:subClassOf bae:BrendaCell . # HPB-ALL cell
-obo:CLO_0003836 rdfs:subClassOf bae:BrendaCell . # HRT-18 cell
-obo:CLO_0004041 rdfs:subClassOf bae:BrendaCell . # Hs 68 cell
-obo:CLO_0004276 rdfs:subClassOf bae:BrendaCell . # HT-1080 cell
-obo:CLO_0004278 rdfs:subClassOf bae:BrendaCell . # HT-1197 cell
-obo:CLO_0004279 rdfs:subClassOf bae:BrendaCell . # HT-1376 cell
-obo:CLO_0004288 rdfs:subClassOf bae:BrendaCell . # HTC cell
-obo:CLO_0004304 rdfs:subClassOf bae:BrendaCell . # HuT 78 cell
-obo:CLO_0004341 rdfs:subClassOf bae:BrendaCell . # IEC-18 cell
-obo:CLO_0004342 rdfs:subClassOf bae:BrendaCell . # IEC-6 cell
-obo:CLO_0006672 rdfs:subClassOf bae:BrendaCell . # IGROV-1 cell
-obo:CLO_0006951 rdfs:subClassOf bae:BrendaCell . # IMR-90 cell
-obo:CLO_0006954 rdfs:subClassOf bae:BrendaCell . # Intestine 407 cell
-obo:CLO_0007002 rdfs:subClassOf bae:BrendaCell . # J558L cell
-obo:CLO_0007017 rdfs:subClassOf bae:BrendaCell . # JEG-3 cell
-obo:CLO_0007059 rdfs:subClassOf bae:BrendaCell . # K-562 cell
-obo:CLO_0007065 rdfs:subClassOf bae:BrendaCell . # KARPAS-299 cell
-obo:CLO_0007066 rdfs:subClassOf bae:BrendaCell . # KARPAS-422 cell
-obo:CLO_0007073 rdfs:subClassOf bae:BrendaCell . # KATO-III cell
-obo:CLO_0007074 rdfs:subClassOf bae:BrendaCell . # KB cell
-obo:CLO_0007079 rdfs:subClassOf bae:BrendaCell . # Kc cell
-obo:CLO_0007095 rdfs:subClassOf bae:BrendaCell . # KG-1A cell
-obo:CLO_0007104 rdfs:subClassOf bae:BrendaCell . # KLE cell
-obo:CLO_0007132 rdfs:subClassOf bae:BrendaCell . # KYSE-30 cell
-obo:CLO_0007189 rdfs:subClassOf bae:BrendaCell . # L-428 cell
-obo:CLO_0007335 rdfs:subClassOf bae:BrendaCell . # LLC-WRC 256 cell
-obo:CLO_0007378 rdfs:subClassOf bae:BrendaCell . # LoVo cell
-obo:CLO_0007393 rdfs:subClassOf bae:BrendaCell . # LS 174T cell
-obo:CLO_0007394 rdfs:subClassOf bae:BrendaCell . # LS 180 cell
-obo:CLO_0007484 rdfs:subClassOf bae:BrendaCell . # M5076 cell
-obo:CLO_0007492 rdfs:subClassOf bae:BrendaCell . # MA 104 cell
-obo:CLO_0007529 rdfs:subClassOf bae:BrendaCell . # MALME-3M cell
-obo:CLO_0007600 rdfs:subClassOf bae:BrendaCell . # MCF-10F cell
-obo:CLO_0007606 rdfs:subClassOf bae:BrendaCell . # MCF-7 cell
-obo:CLO_0007636 rdfs:subClassOf bae:BrendaCell . # MDA-MB-361 cell
-obo:CLO_0007639 rdfs:subClassOf bae:BrendaCell . # MDA-MB-436 cell
-obo:CLO_0007641 rdfs:subClassOf bae:BrendaCell . # MDA-MB-468 cell
-obo:CLO_0007642 rdfs:subClassOf bae:BrendaCell . # MDBK cell
-obo:CLO_0007646 rdfs:subClassOf bae:BrendaCell . # MDCK cell
-obo:CLO_0007668 rdfs:subClassOf bae:BrendaCell . # MEG-01 cell
-obo:CLO_0007687 rdfs:subClassOf bae:BrendaCell . # MEWO cell
-obo:CLO_0007699 rdfs:subClassOf bae:BrendaCell . # MG-63 cell
-obo:CLO_0007709 rdfs:subClassOf bae:BrendaCell . # MH1C1 cell
-obo:CLO_0007735 rdfs:subClassOf bae:BrendaCell . # ML-1 cell
-obo:CLO_0007825 rdfs:subClassOf bae:BrendaCell . # MOLT-4 cell
-obo:CLO_0007827 rdfs:subClassOf bae:BrendaCell . # MONO-MAC-1 cell
-obo:CLO_0007828 rdfs:subClassOf bae:BrendaCell . # MONO-MAC-6 cell
-obo:CLO_0007854 rdfs:subClassOf bae:BrendaCell . # MPC-11 cell
-obo:CLO_0007880 rdfs:subClassOf bae:BrendaCell . # MSTO-211H cell
-obo:CLO_0007891 rdfs:subClassOf bae:BrendaCell . # MT-4 cell
-obo:CLO_0007950 rdfs:subClassOf bae:BrendaCell . # NBT-II cell
-obo:CLO_0007952 rdfs:subClassOf bae:BrendaCell . # NC-37 cell
-obo:CLO_0007986 rdfs:subClassOf bae:BrendaCell . # NCI-H1299 cell
-obo:CLO_0008035 rdfs:subClassOf bae:BrendaCell . # NCI-H1975 cell
-obo:CLO_0008085 rdfs:subClassOf bae:BrendaCell . # NCI-H358 cell
-obo:CLO_0008087 rdfs:subClassOf bae:BrendaCell . # NCI-H441 cell
-obo:CLO_0008121 rdfs:subClassOf bae:BrendaCell . # NCI-H838 cell
-obo:CLO_0008127 rdfs:subClassOf bae:BrendaCell . # NCI-H929 cell
-obo:CLO_0008129 rdfs:subClassOf bae:BrendaCell . # NCI-N87 cell
-obo:CLO_0008132 rdfs:subClassOf bae:BrendaCell . # NCTC 2544 cell
-obo:CLO_0008154 rdfs:subClassOf bae:BrendaCell . # Neuro-2a cell
-obo:CLO_0008186 rdfs:subClassOf bae:BrendaCell . # NMuMG cell
-obo:CLO_0008205 rdfs:subClassOf bae:BrendaCell . # NS20Y cell
-obo:CLO_0008235 rdfs:subClassOf bae:BrendaCell . # OCI-AML2 cell
-obo:CLO_0008236 rdfs:subClassOf bae:BrendaCell . # OCI-AML5 cell
-obo:CLO_0008240 rdfs:subClassOf bae:BrendaCell . # OE-33 cell
-obo:CLO_0008327 rdfs:subClassOf bae:BrendaCell . # P388D1 cell
-obo:CLO_0008340 rdfs:subClassOf bae:BrendaCell . # P-815 cell
-obo:CLO_0008395 rdfs:subClassOf bae:BrendaCell . # PC-3 cell
-obo:CLO_0008416 rdfs:subClassOf bae:BrendaCell . # PEER cell
-obo:CLO_0008426 rdfs:subClassOf bae:BrendaCell . # PG cell
-obo:CLO_0008447 rdfs:subClassOf bae:BrendaCell . # PK-15 cell
-obo:CLO_0008460 rdfs:subClassOf bae:BrendaCell . # PLHC-1 cell
-obo:CLO_0008475 rdfs:subClassOf bae:BrendaCell . # PNT-1A cell
-obo:CLO_0008476 rdfs:subClassOf bae:BrendaCell . # PNT-2 cell
-obo:CLO_0008486 rdfs:subClassOf bae:BrendaCell . # Pro-5 cell
-obo:CLO_0008697 rdfs:subClassOf bae:BrendaCell . # R1 cell
-obo:CLO_0008734 rdfs:subClassOf bae:BrendaCell . # RAJI cell
-obo:CLO_0008762 rdfs:subClassOf bae:BrendaCell . # RBL-1 cell
-obo:CLO_0008770 rdfs:subClassOf bae:BrendaCell . # RD cell
-obo:CLO_0008774 rdfs:subClassOf bae:BrendaCell . # RD-ES cell
-obo:CLO_0008781 rdfs:subClassOf bae:BrendaCell . # REH cell
-obo:CLO_0008799 rdfs:subClassOf bae:BrendaCell . # RFL-6 cell
-obo:CLO_0008825 rdfs:subClassOf bae:BrendaCell . # RKO cell
-obo:CLO_0008828 rdfs:subClassOf bae:BrendaCell . # RL cell
-obo:CLO_0008873 rdfs:subClassOf bae:BrendaCell . # RPMI-8226 cell
-obo:CLO_0008876 rdfs:subClassOf bae:BrendaCell . # RPMI-2650 cell
-obo:CLO_0008987 rdfs:subClassOf bae:BrendaCell . # SF-21 cell
-obo:CLO_0008988 rdfs:subClassOf bae:BrendaCell . # SF-9 cell
-obo:CLO_0009019 rdfs:subClassOf bae:BrendaCell . # SIRC cell
-obo:CLO_0009039 rdfs:subClassOf bae:BrendaCell . # SK-LU-1 cell
-obo:CLO_0009043 rdfs:subClassOf bae:BrendaCell . # SK-MEL-28 cell
-obo:CLO_0009045 rdfs:subClassOf bae:BrendaCell . # SK-MEL-30 cell
-obo:CLO_0009051 rdfs:subClassOf bae:BrendaCell . # SK-N-AS cell
-obo:CLO_0009052 rdfs:subClassOf bae:BrendaCell . # SK-N-BE(2) cell
-obo:CLO_0009058 rdfs:subClassOf bae:BrendaCell . # SK-N-MC cell
-obo:CLO_0009097 rdfs:subClassOf bae:BrendaCell . # SNU-387 cell
-obo:CLO_0009126 rdfs:subClassOf bae:BrendaCell . # SR cell
-obo:CLO_0009183 rdfs:subClassOf bae:BrendaCell . # SW-1116 cell
-obo:CLO_0009196 rdfs:subClassOf bae:BrendaCell . # SW-620 cell
-obo:CLO_0009216 rdfs:subClassOf bae:BrendaCell . # SW-48 cell
-obo:CLO_0009217 rdfs:subClassOf bae:BrendaCell . # SW-480 cell
-obo:CLO_0009222 rdfs:subClassOf bae:BrendaCell . # SW626 cell
-obo:CLO_0009225 rdfs:subClassOf bae:BrendaCell . # SW-948 cell
-obo:CLO_0009237 rdfs:subClassOf bae:BrendaCell . # T/G HA-VSMC cell
-obo:CLO_0009245 rdfs:subClassOf bae:BrendaCell . # T24 cell
-obo:CLO_0009254 rdfs:subClassOf bae:BrendaCell . # T84 cell
-obo:CLO_0009320 rdfs:subClassOf bae:BrendaCell . # TE-8 cell
-obo:CLO_0009324 rdfs:subClassOf bae:BrendaCell . # Tera-2 cell
-obo:CLO_0009326 rdfs:subClassOf bae:BrendaCell . # TF-1 cell
-obo:CLO_0009357 rdfs:subClassOf bae:BrendaCell . # TK6 cell
-obo:CLO_0009368 rdfs:subClassOf bae:BrendaCell . # TM-4 cell
-obo:CLO_0009452 rdfs:subClassOf bae:BrendaCell . # U-138MG cell
-obo:CLO_0009456 rdfs:subClassOf bae:BrendaCell . # U-251 MG cell
-obo:CLO_0009457 rdfs:subClassOf bae:BrendaCell . # U-266 cell
-obo:CLO_0009459 rdfs:subClassOf bae:BrendaCell . # U-343 MGa cell
-obo:CLO_0009461 rdfs:subClassOf bae:BrendaCell . # U-373 MG cell
-obo:CLO_0009465 rdfs:subClassOf bae:BrendaCell . # U-937 cell
-obo:CLO_0009500 rdfs:subClassOf bae:BrendaCell . # V-79 cell
-obo:CLO_0009504 rdfs:subClassOf bae:BrendaCell . # V79-4 cell
-obo:CLO_0009575 rdfs:subClassOf bae:BrendaCell . # WEHI-231 cell
-obo:CLO_0009594 rdfs:subClassOf bae:BrendaCell . # WI-38 cell
-obo:CLO_0009604 rdfs:subClassOf bae:BrendaCell . # WIL2-NS cell
-obo:CLO_0009609 rdfs:subClassOf bae:BrendaCell . # WISH cell
-obo:CLO_0009635 rdfs:subClassOf bae:BrendaCell . # WSS-1 cell
-obo:CLO_0009709 rdfs:subClassOf bae:BrendaCell . # Y79 cell
-obo:CLO_0009727 rdfs:subClassOf bae:BrendaCell . # ZR-75-1 cell
-obo:CLO_0009728 rdfs:subClassOf bae:BrendaCell . # ZR-75-30 cell
-obo:CLO_0009833 rdfs:subClassOf bae:BrendaCell . # BCWM.1 cell
-obo:CLO_0009848 rdfs:subClassOf bae:BrendaCell . # MOLM-13 cell
-obo:CLO_0009858 rdfs:subClassOf bae:BrendaCell . # RPMI-8866 cell
-obo:CLO_0009902 rdfs:subClassOf bae:BrendaCell . # SF-268 cell
-obo:CLO_0037097 rdfs:subClassOf bae:BrendaCell . # OVISE cell
-obo:CLO_0037116 rdfs:subClassOf bae:BrendaCell . # LNCaP cell
-obo:CLO_0037117 rdfs:subClassOf bae:BrendaCell . # VCaP cell
-obo:CLO_0037142 rdfs:subClassOf bae:BrendaCell . # MKN-28 cell
-obo:CLO_0037180 rdfs:subClassOf bae:BrendaCell . # MCF12A cell
+obo:BTO_0000003 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intestinal cell line
+obo:BTO_0000006 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteoblastoma cell
+obo:BTO_0000028 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic acinar cell
+obo:BTO_0000032 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colonic adenocarcinoma cell
+obo:BTO_0000036 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric adenocarcinoma cell
+obo:BTO_0000037 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal cell carcinoma cell
+obo:BTO_0000067 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # kidney cell line
+obo:BTO_0000094 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ascites tumor cell
+obo:BTO_0000100 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # astrocytoma cell
+obo:BTO_0000101 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # astrocytoma cell line
+obo:BTO_0000104 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphoma cell line
+obo:BTO_0000110 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amniotic cell line
+obo:BTO_0000125 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blast cell
+obo:BTO_0000150 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # breast cancer cell
+obo:BTO_0000152 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # infected cell
+obo:BTO_0000161 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung fibroblast cell line
+obo:BTO_0000167 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adenocarcinoma cell line
+obo:BTO_0000176 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # carcinoma cell
+obo:BTO_0000177 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BG-1 cell
+obo:BTO_0000178 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adenoma cell
+obo:BTO_0000180 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical carcinoma cell
+obo:BTO_0000181 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Lewis lung carcinoma cell line
+obo:BTO_0000184 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medullary thyroid carcinoma cell
+obo:BTO_0000186 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lobular carcinoma cell
+obo:BTO_0000188 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colonic cell line
+obo:BTO_0000189 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # small cell lung cancer cell
+obo:BTO_0000191 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medullary carcinoma cell
+obo:BTO_0000192 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nasopharyngeal carcinoma cell
+obo:BTO_0000193 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rectal cancer cell
+obo:BTO_0000194 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endometrioid carcinoma cell
+obo:BTO_0000196 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thyroid cancer cell
+obo:BTO_0000197 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # carcinosarcoma cell
+obo:BTO_0000201 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pheochromocytoma cell line
+obo:BTO_0000218 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BALB/3T3 cell
+obo:BTO_0000223 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # teratocarcinoma cell
+obo:BTO_0000224 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # liver cell line
+obo:BTO_0000225 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CEM cell
+obo:BTO_0000228 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # C-1300 cell
+obo:BTO_0000250 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chondrosarcoma cell
+obo:BTO_0000256 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myoblast cell line
+obo:BTO_0000257 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine cancer cell
+obo:BTO_0000259 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chromaffin cell
+obo:BTO_0000264 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone marrow cell line
+obo:BTO_0000279 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # testicular cancer cell
+obo:BTO_0000306 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # teratocarcinoma cell line
+obo:BTO_0000308 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cytotoxic T-lymphocyte cell line
+obo:BTO_0000309 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bundle sheath cell
+obo:BTO_0000353 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung cell line
+obo:BTO_0000356 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # breast cancer cell line
+obo:BTO_0000362 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urinary bladder cancer cell
+obo:BTO_0000373 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Ehrlich ascites carcinoma cell
+obo:BTO_0000375 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # keratinocyte cell line
+obo:BTO_0000383 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal cell carcinoma cell line
+obo:BTO_0000392 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plasma cell
+obo:BTO_0000395 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolar cell
+obo:BTO_0000396 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # EAhy 926 cell
+obo:BTO_0000400 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sarcoma cell line
+obo:BTO_0000403 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mastocytoma cell line
+obo:BTO_0000407 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteosarcoma cell line
+obo:BTO_0000414 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epithelial cell
+obo:BTO_0000426 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # erythroleukemia cell
+obo:BTO_0000427 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pituitary gland cell line
+obo:BTO_0000433 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # exocrine acinar cell
+obo:BTO_0000453 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fibroblast cell line
+obo:BTO_0000456 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plasmacytoma cell line
+obo:BTO_0000459 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fibrosarcoma cell
+obo:BTO_0000460 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fibrosarcoma cell line
+obo:BTO_0000489 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intestinal cancer cell
+obo:BTO_0000492 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MST cell
+obo:BTO_0000498 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric cancer cell
+obo:BTO_0000526 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glioma cell
+obo:BTO_0000527 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glioblastoma cell
+obo:BTO_0000529 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # C6 glioma cell
+obo:BTO_0000535 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # germ cell
+obo:BTO_0000540 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pollen mother cell
+obo:BTO_0000542 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # granulosa cell
+obo:BTO_0000544 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # guard cell
+obo:BTO_0000551 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung cancer cell
+obo:BTO_0000552 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HaCaT cell
+obo:BTO_0000574 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hematopoietic cell
+obo:BTO_0000576 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-16 cell
+obo:BTO_0000577 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Morris hepatoma 3924A cell
+obo:BTO_0000578 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatoma cell line
+obo:BTO_0000579 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eye cancer cell
+obo:BTO_0000583 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone marrow cancer cell
+obo:BTO_0000584 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic cancer cell
+obo:BTO_0000585 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intraocular melanoma cell
+obo:BTO_0000586 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colonic cancer cell
+obo:BTO_0000592 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adrenal gland cancer cell
+obo:BTO_0000594 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # liver cancer cell
+obo:BTO_0000604 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adenocarcinoma cell
+obo:BTO_0000608 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatoma cell
+obo:BTO_0000610 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hybridoma cell
+obo:BTO_0000632 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # insulinoma cell
+obo:BTO_0000638 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # interrenal cell
+obo:BTO_0000658 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine adenocarcinoma cell
+obo:BTO_0000669 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic cell line
+obo:BTO_0000680 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # kidney cancer cell
+obo:BTO_0000681 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KM-3 cell
+obo:BTO_0000685 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Kupffer cell
+obo:BTO_0000686 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Kurloff cell
+obo:BTO_0000705 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Langerhans cell
+obo:BTO_0000711 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glioma cell line
+obo:BTO_0000716 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic beta cell line
+obo:BTO_0000725 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hematopoietic stem cell
+obo:BTO_0000727 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # multiple myeloma cell line
+obo:BTO_0000729 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # carcinoid cell
+obo:BTO_0000731 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # acute lymphoblastic leukemia cell
+obo:BTO_0000737 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leukemia cell line
+obo:BTO_0000741 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphocytic leukemia cell line
+obo:BTO_0000743 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pre-B-lymphocyte cell line
+obo:BTO_0000745 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Lewis lung carcinoma cell
+obo:BTO_0000746 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # preadipocyte cell line
+obo:BTO_0000755 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Leydig cell
+obo:BTO_0000760 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LLC-PK1 cell
+obo:BTO_0000762 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung cancer cell line
+obo:BTO_0000773 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphoblastoid cell line
+obo:BTO_0000774 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphoblastoma cell
+obo:BTO_0000783 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic beta cell
+obo:BTO_0000785 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphoma cell
+obo:BTO_0000787 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric cancer cell line
+obo:BTO_0000792 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urinary bladder cancer cell line
+obo:BTO_0000794 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic cancer cell line
+obo:BTO_0000795 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # L-5178-Y cell
+obo:BTO_0000797 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colonic cancer cell line
+obo:BTO_0000799 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphosarcoma cell
+obo:BTO_0000803 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic delta cell
+obo:BTO_0000811 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovary cancer cell line
+obo:BTO_0000830 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mast cell
+obo:BTO_0000832 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mastocytoma cell
+obo:BTO_0000845 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # meiotic cell
+obo:BTO_0000846 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # erythroleukemia cell line
+obo:BTO_0000848 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # melanoma cell
+obo:BTO_0000849 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # melanoma cell line
+obo:BTO_0000850 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amelanotic melanoma cell
+obo:BTO_0000851 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adrenal cortex cell line
+obo:BTO_0000853 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesangial cell
+obo:BTO_0000860 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CHRB-30 cell
+obo:BTO_0000872 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oligodendrocytic cell line
+obo:BTO_0000875 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # N20.1 cell
+obo:BTO_0000878 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mononuclear cell
+obo:BTO_0000885 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tongue cell line
+obo:BTO_0000889 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Burkitt lymphoma cell line
+obo:BTO_0000891 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NTERA-2 cell
+obo:BTO_0000898 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myeloma cell
+obo:BTO_0000899 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myeloma cell line
+obo:BTO_0000906 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myeloid cell line
+obo:BTO_0000908 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myrosin cell
+obo:BTO_0000914 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # natural killer cell
+obo:BTO_0000931 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuroblastoma cell
+obo:BTO_0000932 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuroblastoma cell line
+obo:BTO_0000939 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # basal cell
+obo:BTO_0000947 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuronal cell line
+obo:BTO_0000950 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Novikoff hepatoma cell
+obo:BTO_0000953 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nurse cell
+obo:BTO_0000955 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # laryngeal cell line
+obo:BTO_0000963 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oligodendroglioma cell
+obo:BTO_0000969 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteoclastoma cell
+obo:BTO_0000970 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteosarcoma cell
+obo:BTO_0000977 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovary cell line
+obo:BTO_0000986 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pachytene cell
+obo:BTO_0000990 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic alpha cell
+obo:BTO_0000993 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # paneth cell
+obo:BTO_0001003 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parotid acinar cell
+obo:BTO_0001005 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amnion epithelial cell
+obo:BTO_0001011 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebellar Purkinje cell
+obo:BTO_0001018 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # basophilic leukemia cell line
+obo:BTO_0001023 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovary cancer cell
+obo:BTO_0001025 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peripheral blood mononuclear cell
+obo:BTO_0001033 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostate cancer cell line
+obo:BTO_0001035 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hematopoietic cell line
+obo:BTO_0001037 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sensory cell
+obo:BTO_0001039 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peritubular cell
+obo:BTO_0001045 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T-lymphocyte cell line
+obo:BTO_0001054 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pheochromocytoma cell
+obo:BTO_0001055 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian epithelial cell
+obo:BTO_0001056 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myeloid leukemia cell
+obo:BTO_0001065 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Tsu-Pr1 cell
+obo:BTO_0001076 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pituitary gland tumor cell
+obo:BTO_0001080 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Morris hepatoma cell
+obo:BTO_0001082 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MM46 cell
+obo:BTO_0001086 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic stem cell
+obo:BTO_0001087 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plasmacytoma cell
+obo:BTO_0001094 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pre-B acute lymphoblastic leukemia cell
+obo:BTO_0001096 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphoid cell
+obo:BTO_0001100 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-cell acute lymphoblastic leukemia cell
+obo:BTO_0001106 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T-cell acute lymphoblastic leukemia cell
+obo:BTO_0001120 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epithelial cell line
+obo:BTO_0001130 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostate gland cancer cell
+obo:BTO_0001131 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BHK cell
+obo:BTO_0001155 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ray cell
+obo:BTO_0001169 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 3T3-F442A cell
+obo:BTO_0001170 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # resting cell
+obo:BTO_0001176 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endothelial cell
+obo:BTO_0001178 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinoblastoma cell
+obo:BTO_0001189 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # FAZA cell
+obo:BTO_0001197 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # S-180 cell
+obo:BTO_0001207 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sarcoma cell
+obo:BTO_0001211 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # breast epithelial cell
+obo:BTO_0001214 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Yoshida sarcoma cell
+obo:BTO_0001216 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Schwann cell line
+obo:BTO_0001220 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Schwann cell
+obo:BTO_0001238 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Sertoli cell
+obo:BTO_0001242 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fetal cell line
+obo:BTO_0001245 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchoalveolar stem cell
+obo:BTO_0001251 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # liver sinusoidal endothelial cell
+obo:BTO_0001263 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Friend erythroleukemia cell line
+obo:BTO_0001268 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # somatic cell
+obo:BTO_0001271 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leukemia cell
+obo:BTO_0001283 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mitral cell
+obo:BTO_0001286 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skin cancer cell
+obo:BTO_0001289 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # squamous cell carcinoma cell
+obo:BTO_0001294 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sporulating cell
+obo:BTO_0001298 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # basal cell carcinoma cell
+obo:BTO_0001326 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cholangiocarcinoma cell
+obo:BTO_0001329 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastrinoma cell
+obo:BTO_0001330 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatoma ascites cell
+obo:BTO_0001334 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # papilloma cell
+obo:BTO_0001341 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # S-49 cell
+obo:BTO_0001344 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adult T-cell lymphoma cell
+obo:BTO_0001359 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medulloblastoma cell line
+obo:BTO_0001405 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchial cancer cell
+obo:BTO_0001407 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuroendocrine tumor cell
+obo:BTO_0001434 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vegetative cell
+obo:BTO_0001437 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic carcinoma cell line
+obo:BTO_0001441 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # marrow cell
+obo:BTO_0001454 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymoma cell
+obo:BTO_0001455 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymic carcinoma cell
+obo:BTO_0001470 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epidermal cell
+obo:BTO_0001474 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # yolk sac erythroid cell
+obo:BTO_0001478 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # zygotene cell
+obo:BTO_0001514 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # biliary epithelial cell
+obo:BTO_0001518 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-lymphoma cell line
+obo:BTO_0001519 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endothelial cell line
+obo:BTO_0001521 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic adenocarcinoma cell line
+obo:BTO_0001522 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-lymphocyte cell line
+obo:BTO_0001523 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # WIL-2 cell
+obo:BTO_0001530 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glioblastoma cell line
+obo:BTO_0001531 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glial cell line
+obo:BTO_0001532 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rectal cancer cell line
+obo:BTO_0001537 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # small intestine cell line
+obo:BTO_0001540 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # goblet cell
+obo:BTO_0001544 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chronic myeloid leukemia cell
+obo:BTO_0001545 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # acute myeloid leukemia cell
+obo:BTO_0001546 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chronic lymphocytic leukemia cell
+obo:BTO_0001549 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # megakaryocytic cell line
+obo:BTO_0001550 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Dami cell
+obo:BTO_0001555 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endometrial cancer cell line
+obo:BTO_0001557 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SF-767 cell
+obo:BTO_0001565 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HT-29-MTX cell
+obo:BTO_0001566 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HT-29 G cell
+obo:BTO_0001567 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MDA-MB-435 cell
+obo:BTO_0001573 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brain cancer cell
+obo:BTO_0001574 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chondrosarcoma cell line
+obo:BTO_0001575 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # choriocarcinoma cell line
+obo:BTO_0001576 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # choriocarcinoma cell
+obo:BTO_0001577 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # esophageal cancer cell
+obo:BTO_0001581 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic stem cell line
+obo:BTO_0001586 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphoid cell line
+obo:BTO_0001610 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thyroid cancer cell line
+obo:BTO_0001614 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colorectal cell line
+obo:BTO_0001615 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colorectal cancer cell
+obo:BTO_0001617 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # DHL-9 cell
+obo:BTO_0001619 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skin fibroblast cell line
+obo:BTO_0001622 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fibroblastoma cell
+obo:BTO_0001623 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fibroma cell
+obo:BTO_0001625 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # laryngeal cancer cell
+obo:BTO_0001631 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leiomyosarcoma cell
+obo:BTO_0001664 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatoblastoma cell line
+obo:BTO_0001666 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatoblastoma cell
+obo:BTO_0001668 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mast cell line
+obo:BTO_0001669 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HMC-1 cell
+obo:BTO_0001674 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Mel Im cell
+obo:BTO_0001676 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PC-12D cell
+obo:BTO_0001677 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SCHNEIDER-2 cell
+obo:BTO_0001683 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adenohypophysis tumor cell
+obo:BTO_0001690 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-cell lymphoma cell
+obo:BTO_0001714 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # duodenal adenocarcinoma cell
+obo:BTO_0001731 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glucagonoma cell
+obo:BTO_0001736 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular cancer cell
+obo:BTO_0001737 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hemangioendothelioma cell
+obo:BTO_0001738 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # histiocytic lymphoma cell
+obo:BTO_0001756 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # meningioma cell
+obo:BTO_0001757 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medulloblastoma cell
+obo:BTO_0001767 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neurosecretory cell
+obo:BTO_0001774 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oral cancer cell
+obo:BTO_0001780 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oxyntic cell
+obo:BTO_0001781 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parathyroid gland cancer cell
+obo:BTO_0001797 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # promyelocytic leukemia cell
+obo:BTO_0001800 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinal ganglion cell
+obo:BTO_0001802 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rhabdomyosarcoma cell
+obo:BTO_0001824 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # synovial sarcoma cell
+obo:BTO_0001825 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T-cell lymphoma cell
+obo:BTO_0001854 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular endothelial cell
+obo:BTO_0001860 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # yolk sac cancer cell
+obo:BTO_0001870 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OVCA-5 cell
+obo:BTO_0001874 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lens epithelial cell line
+obo:BTO_0001876 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thyroid cell line
+obo:BTO_0001879 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # H9c2 cell
+obo:BTO_0001883 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # acute myeloid leukemia cell line
+obo:BTO_0001888 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # follicular thyroid cancer cell
+obo:BTO_0001895 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastrointestinal endocrine cell
+obo:BTO_0001897 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hemocyte cell line
+obo:BTO_0001898 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mbn-2 cell
+obo:BTO_0001907 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NS-1 cell
+obo:BTO_0001911 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung adenocarcinoma cell line
+obo:BTO_0001912 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # breast adenocarcinoma cell line
+obo:BTO_0001914 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colorectal adenocarcinoma cell line
+obo:BTO_0001916 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LIM1215 cell
+obo:BTO_0001918 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LIM1863 cell
+obo:BTO_0001926 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hybridoma cell line
+obo:BTO_0001928 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # AR4-2J cell
+obo:BTO_0001929 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ATDC-5 cell
+obo:BTO_0001931 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BJAB cell
+obo:BTO_0001933 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BRL cell
+obo:BTO_0001948 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # JURKAT E-6.1 cell
+obo:BTO_0001949 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HUVEC cell
+obo:BTO_0001955 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # REF-52 cell
+obo:BTO_0001964 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aorta smooth muscle cell line
+obo:BTO_0001966 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical cell line
+obo:BTO_0001967 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical cancer cell line
+obo:BTO_0001971 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant cell line
+obo:BTO_0001972 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TBY-2 cell
+obo:BTO_0001975 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # placental cell line
+obo:BTO_0001977 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Oc cell
+obo:BTO_0002008 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # culture condition:antigen-presenting cell
+obo:BTO_0002016 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # C81-61 cell
+obo:BTO_0002021 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostate adenocarcinoma cell
+obo:BTO_0002022 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchial epithelial cell line
+obo:BTO_0002023 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HBE-1 cell
+obo:BTO_0002024 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # squamous cell carcinoma cell line
+obo:BTO_0002026 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HSC-4 cell
+obo:BTO_0002027 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oral cancer cell line
+obo:BTO_0002029 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myoma cell
+obo:BTO_0002030 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # natural killer cell line
+obo:BTO_0002031 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RNK-16 cell
+obo:BTO_0002042 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dendritic cell
+obo:BTO_0002049 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Chang cell
+obo:BTO_0002050 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteogenic cell
+obo:BTO_0002052 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteogenic cell line
+obo:BTO_0002054 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Dunn cell
+obo:BTO_0002057 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung adenocarcinoma cell
+obo:BTO_0002058 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # non-small cell lung cancer cell
+obo:BTO_0002059 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # large cell carcinoma cell
+obo:BTO_0002060 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchioalveolar carcinoma cell
+obo:BTO_0002062 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-lymphoblastoid cell line
+obo:BTO_0002064 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stromal cell
+obo:BTO_0002088 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ependymoma cell
+obo:BTO_0002093 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ganglioneuroma cell
+obo:BTO_0002101 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # multiple myeloma cell
+obo:BTO_0002128 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TX3868 cell
+obo:BTO_0002135 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # INS-1 cell
+obo:BTO_0002137 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MiaPaCa-2 cell
+obo:BTO_0002138 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MiaPaCa cell
+obo:BTO_0002143 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CEM-VCR R cell
+obo:BTO_0002145 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # midgut cell line
+obo:BTO_0002170 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LOX cell
+obo:BTO_0002174 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parenchymal cell
+obo:BTO_0002177 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PR cell
+obo:BTO_0002178 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HMEpC cell
+obo:BTO_0002181 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEK-293T cell
+obo:BTO_0002182 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 95D cell
+obo:BTO_0002183 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 95C cell
+obo:BTO_0002193 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SCC-13 cell
+obo:BTO_0002194 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NHK cell
+obo:BTO_0002195 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular smooth muscle cell line
+obo:BTO_0002205 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # large cell lung cancer cell line
+obo:BTO_0002206 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # small cell lung cancer cell line
+obo:BTO_0002211 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oral squamous cell carcinoma cell line
+obo:BTO_0002214 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # A-1235 cell
+obo:BTO_0002215 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LN-319 cell
+obo:BTO_0002218 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chalazal cell
+obo:BTO_0002219 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adrenocortical carcinoma cell
+obo:BTO_0002221 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HLE-B3 cell
+obo:BTO_0002236 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian cumulus cell
+obo:BTO_0002242 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oral epithelial cell
+obo:BTO_0002245 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # foreskin fibroblast cell line
+obo:BTO_0002264 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dried cell
+obo:BTO_0002267 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rhabdomyosarcoma cell line
+obo:BTO_0002276 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # immobilized cell
+obo:BTO_0002278 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # macrophage cell line
+obo:BTO_0002279 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # J-774 cell
+obo:BTO_0002280 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lignifying cell
+obo:BTO_0002284 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MIN-6 cell
+obo:BTO_0002285 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # granulosa cell line
+obo:BTO_0002290 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primary cell line
+obo:BTO_0002306 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ARO cell
+obo:BTO_0002309 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myoepithelial cell
+obo:BTO_0002311 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mammary myoepithelial cell
+obo:BTO_0002312 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mature cell
+obo:BTO_0002313 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # immature cell
+obo:BTO_0002314 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # satellite cell
+obo:BTO_0002315 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # supporting cell
+obo:BTO_0002316 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stellate cell
+obo:BTO_0002332 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # monocytic leukemia cell line
+obo:BTO_0002334 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinal pigment epithelium cell line
+obo:BTO_0002361 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteochondroma cell
+obo:BTO_0002363 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic ductal carcinoma cell
+obo:BTO_0002372 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuroepithelioma cell
+obo:BTO_0002373 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glioblastoma multiforme cell
+obo:BTO_0002380 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric adenocarcinoma cell line
+obo:BTO_0002382 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MKN-7 cell
+obo:BTO_0002385 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GLC-4 cell
+obo:BTO_0002386 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GLC-4/ADR cell
+obo:BTO_0002389 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # U-1285 cell
+obo:BTO_0002391 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # U-1285dox cell
+obo:BTO_0002392 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SGC-7901 cell
+obo:BTO_0002393 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # N-27 cell
+obo:BTO_0002394 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # DC-3F cell
+obo:BTO_0002395 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # DC-3F/ADX cell
+obo:BTO_0002398 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostate epithelium cell line
+obo:BTO_0002403 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OS-RC-2 cell
+obo:BTO_0002406 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eosinophilic leukemia cell line
+obo:BTO_0002414 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PG-CL3 cell
+obo:BTO_0002420 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # monocytic leukemia cell
+obo:BTO_0002421 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eosinophilic leukemia cell
+obo:BTO_0002423 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesothelioma cell
+obo:BTO_0002424 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesothelioma cell line
+obo:BTO_0002426 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CHOP cell
+obo:BTO_0002428 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # esophageal squamous cell carcinoma cell line
+obo:BTO_0002429 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HA22T/VGH cell
+obo:BTO_0002478 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical epithelial cell
+obo:BTO_0002482 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gonadotrophic cell
+obo:BTO_0002484 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # columnar cell
+obo:BTO_0002489 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # promyelocytic leukemia cell line
+obo:BTO_0002499 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # companion cell
+obo:BTO_0002505 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anaplastic large cell lymphoma cell
+obo:BTO_0002509 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corticotropic cell
+obo:BTO_0002510 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myelomonocytic leukemia cell
+obo:BTO_0002513 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Ewing's sarcoma cell
+obo:BTO_0002515 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brain cortex cell line
+obo:BTO_0002517 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # follicular lymphoma cell line
+obo:BTO_0002521 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # diffuse large B-cell lymphoma cell
+obo:BTO_0002524 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEK-293A cell
+obo:BTO_0002534 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HBL-3 cell
+obo:BTO_0002546 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KBM-5 cell
+obo:BTO_0002555 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HOSE cell
+obo:BTO_0002564 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OVCA-429 cell
+obo:BTO_0002565 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OVCA-432 cell
+obo:BTO_0002572 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MEF cell
+obo:BTO_0002590 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEY cell
+obo:BTO_0002595 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leiomyosarcoma cell line
+obo:BTO_0002600 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # astrocyte cell line
+obo:BTO_0002606 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glial cell
+obo:BTO_0002625 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesenchymal cell
+obo:BTO_0002627 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T-lymphoblastoma cell
+obo:BTO_0002628 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-lymphoblastoma cell
+obo:BTO_0002629 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T-lymphoblastoid cell line
+obo:BTO_0002637 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # respiratory epithelium cell line
+obo:BTO_0002640 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CHO-EM9 cell
+obo:BTO_0002641 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CHO-AA8 cell
+obo:BTO_0002648 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ROS-17/2.8 cell
+obo:BTO_0002656 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sickle cell
+obo:BTO_0002658 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # collecting duct cell line
+obo:BTO_0002662 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skeletal muscle cell line
+obo:BTO_0002664 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HTAU cell
+obo:BTO_0002666 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adult stem cell
+obo:BTO_0002667 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cord blood stem cell
+obo:BTO_0002668 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone marrow stromal stem cell
+obo:BTO_0002669 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peripheral blood stem cell
+obo:BTO_0002687 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Leydig cell tumor cell
+obo:BTO_0002688 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular cell
+obo:BTO_0002691 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuroendocrine cell
+obo:BTO_0002692 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # enterochromaffin-like cell
+obo:BTO_0002694 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leiomyoma cell
+obo:BTO_0002695 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine leiomyoma cell
+obo:BTO_0002708 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GT1-7 cell
+obo:BTO_0002709 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # head and neck squamous cell carcinoma cell line
+obo:BTO_0002714 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # UM-SCC-22A cell
+obo:BTO_0002719 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primary effusion lymphoma cell line
+obo:BTO_0002727 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BCBL-1 cell
+obo:BTO_0002729 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian serous carcinoma cell
+obo:BTO_0002731 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # erythroid cell
+obo:BTO_0002741 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatic stellate cell
+obo:BTO_0002747 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PC-1 cell
+obo:BTO_0002748 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BL-2 cell
+obo:BTO_0002752 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PC-6 cell
+obo:BTO_0002768 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mammary epithelial cell line
+obo:BTO_0002769 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HME cell
+obo:BTO_0002770 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # decidual cell
+obo:BTO_0002771 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory ensheathing cell
+obo:BTO_0002773 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # salivary gland cancer cell
+obo:BTO_0002775 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ANA-1 cell
+obo:BTO_0002786 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cystadenoma cell
+obo:BTO_0002787 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # clear cell adenocarcinoma cell
+obo:BTO_0002788 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mucinous adenocarcinoma cell
+obo:BTO_0002790 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # phloem parenchyma cell
+obo:BTO_0002803 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BLM cell
+obo:BTO_0002805 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # M14 cell
+obo:BTO_0002808 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B16-BL6 cell
+obo:BTO_0002815 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # transitional cell carcinoma cell
+obo:BTO_0002817 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # esophageal cancer cell line
+obo:BTO_0002820 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oligodendroglioma cell line
+obo:BTO_0002821 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HOG cell
+obo:BTO_0002828 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HMEC-1 cell
+obo:BTO_0002836 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI-H460M cell
+obo:BTO_0002844 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # breast invasive ductal carcinoma cell
+obo:BTO_0002846 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # non-Hodgkin lymphoma cell
+obo:BTO_0002850 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # theca cell
+obo:BTO_0002861 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # esophageal squamous cell carcinoma cell
+obo:BTO_0002864 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T3M4 cell
+obo:BTO_0002865 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GER cell
+obo:BTO_0002869 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # transitional cell carcinoma cell line
+obo:BTO_0002870 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RT-4 cell
+obo:BTO_0002876 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CL1-5 cell
+obo:BTO_0002878 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-lymphoblastoid cell
+obo:BTO_0002881 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neural stem cell
+obo:BTO_0002886 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal epithelium cell line
+obo:BTO_0002888 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Th-1 cell line
+obo:BTO_0002889 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolar macrophage cell line
+obo:BTO_0002890 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CA-77 cell
+obo:BTO_0002891 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neural stem cell line
+obo:BTO_0002892 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GEO cell
+obo:BTO_0002899 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # K-1034 RPE cell
+obo:BTO_0002900 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # monocyte-derived dendritic cell
+obo:BTO_0002901 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neural crest cell line
+obo:BTO_0002904 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # non-Hodgkin lymphoma cell line
+obo:BTO_0002912 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuroepithelioma cell line
+obo:BTO_0002916 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # striated muscle cell
+obo:BTO_0002919 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinoblastoma cell line
+obo:BTO_0002921 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LS174T-HM7 cell
+obo:BTO_0002922 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchial epithelial cell
+obo:BTO_0002924 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NHBE cell
+obo:BTO_0002926 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tracheobronchial epithelial cell line
+obo:BTO_0002927 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tracheobronchial epithelial cell
+obo:BTO_0002928 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adult stem cell line
+obo:BTO_0002931 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # liver epithelial cell line
+obo:BTO_0002932 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cholangiocarcinoma cell line
+obo:BTO_0002936 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vaginal cell line
+obo:BTO_0002939 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # serous adenocarcinoma cell
+obo:BTO_0002946 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MNT-1 cell
+obo:BTO_0002951 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 624 cell
+obo:BTO_0002959 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TP17 cell
+obo:BTO_0002965 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # M10 cell
+obo:BTO_0002967 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SK-MEL-37 cell
+obo:BTO_0002971 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KJ29 cell
+obo:BTO_0002974 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEK-293-EBNA cell
+obo:BTO_0002980 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic alpha cell line
+obo:BTO_0002995 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CCL-39 cell
+obo:BTO_0002997 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LAPC4 cell
+obo:BTO_0003028 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI-N417 cell
+obo:BTO_0003031 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HCA-7 cell
+obo:BTO_0003032 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEK-293F cell
+obo:BTO_0003033 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEK-293H cell
+obo:BTO_0003036 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hippocampal cell line
+obo:BTO_0003037 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HT-22 cell
+obo:BTO_0003039 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hypodermal seam cell
+obo:BTO_0003046 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neurofibroma cell
+obo:BTO_0003047 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neurilemoma cell
+obo:BTO_0003050 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MA-10 cell
+obo:BTO_0003051 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MBA-15 cell
+obo:BTO_0003054 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OVCA-8 cell
+obo:BTO_0003056 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NB-2 cell
+obo:BTO_0003057 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NB2-Sp cell
+obo:BTO_0003058 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NB2a/d1 cell
+obo:BTO_0003059 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oviduct epithelial cell line
+obo:BTO_0003061 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinal cell line
+obo:BTO_0003072 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # human lens epithelial cell line
+obo:BTO_0003073 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medullary thyroid carcinoma cell line
+obo:BTO_0003085 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine anchor cell
+obo:BTO_0003103 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pro-B-lymphocyte cell line
+obo:BTO_0003107 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # foreign-body giant cell
+obo:BTO_0003108 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CL-1 prostate cancer cell
+obo:BTO_0003110 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CALO cell
+obo:BTO_0003124 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # microvascular endothelial cell line
+obo:BTO_0003125 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # human bladder microvascular endothelial cell
+obo:BTO_0003127 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # human bone marrow endothelial cell line
+obo:BTO_0003129 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # human brain microvascular endothelial cell
+obo:BTO_0003151 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HPAEC cell
+obo:BTO_0003152 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # papillary thyroid cancer cell
+obo:BTO_0003160 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PrEC cell
+obo:BTO_0003162 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PrSC cell
+obo:BTO_0003165 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical adenocarcinoma cell
+obo:BTO_0003166 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 10T1/2 cell
+obo:BTO_0003181 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # WEHI-7.2 cell
+obo:BTO_0003182 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NHEK cell
+obo:BTO_0003183 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # melanocyte cell line
+obo:BTO_0003185 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NHDF cell
+obo:BTO_0003192 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal cancer cell line
+obo:BTO_0003205 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # salivary gland cell line
+obo:BTO_0003208 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anaplastic thyroid cancer cell
+obo:BTO_0003210 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # papillary thyroid cancer cell line
+obo:BTO_0003212 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T-lymphoma cell line
+obo:BTO_0003213 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung epithelium cell line
+obo:BTO_0003216 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # melan-a cell
+obo:BTO_0003219 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TMK-1 cell
+obo:BTO_0003225 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neurilemoma cell line
+obo:BTO_0003227 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SMMC-7721 cell
+obo:BTO_0003231 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SHG-44 cell
+obo:BTO_0003232 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BT-325 cell
+obo:BTO_0003234 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # FTO-2B cell
+obo:BTO_0003236 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gall bladder cancer cell line
+obo:BTO_0003237 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gall bladder cancer cell
+obo:BTO_0003245 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aortic endothelial cell
+obo:BTO_0003249 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brain endothelium cell line
+obo:BTO_0003250 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colonic epithelium cell line
+obo:BTO_0003253 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ELT-3 cell
+obo:BTO_0003263 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEK-AD293 cell
+obo:BTO_0003264 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HL-1 cell
+obo:BTO_0003266 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HPAF-2 cell
+obo:BTO_0003270 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Me665/2 cell
+obo:BTO_0003280 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sessile cell
+obo:BTO_0003281 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # planktonic cell
+obo:BTO_0003283 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SC-M1 cell
+obo:BTO_0003290 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PanIN cell
+obo:BTO_0003291 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # P493-6 cell
+obo:BTO_0003293 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Rat-1 cell
+obo:BTO_0003296 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone marrow stromal cell line
+obo:BTO_0003298 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesenchymal stem cell
+obo:BTO_0003306 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Mat-Ly-Lu cell
+obo:BTO_0003310 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KMCH cell
+obo:BTO_0003312 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KM-12C cell
+obo:BTO_0003317 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # INS-1E cell
+obo:BTO_0003318 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # INS-1 823/13 cell
+obo:BTO_0003319 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Hepa-1 cell
+obo:BTO_0003321 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HCE cell
+obo:BTO_0003324 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cardiomyocyte cell line
+obo:BTO_0003326 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # FLK cell
+obo:BTO_0003336 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pulmonary artery smooth muscle cell
+obo:BTO_0003339 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HCMEC/D3 cell
+obo:BTO_0003344 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CL1-4 cell
+obo:BTO_0003347 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # C4-2 cell
+obo:BTO_0003349 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # microglial cell line
+obo:BTO_0003350 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BV-2 cell
+obo:BTO_0003352 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brain capillary endothelial cell line
+obo:BTO_0003354 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-cell chronic lymphocytic leukemia cell
+obo:BTO_0003357 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ARPE cell
+obo:BTO_0003393 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # granule cell
+obo:BTO_0003413 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # encysting cell
+obo:BTO_0003420 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trophoblast cell line
+obo:BTO_0003422 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # AF5 cell
+obo:BTO_0003423 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lacrimal gland acinar cell
+obo:BTO_0003429 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BIC-1 cell
+obo:BTO_0003431 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dermatofibroma cell
+obo:BTO_0003436 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # synovial cell line
+obo:BTO_0003438 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # WM-9 cell
+obo:BTO_0003452 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adipocyte cell line
+obo:BTO_0003457 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endometrioma cell
+obo:BTO_0003474 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # WM-239 cell
+obo:BTO_0003478 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SNU-638 cell
+obo:BTO_0003483 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sebaceous gland cell line
+obo:BTO_0003485 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RPAEC cell
+obo:BTO_0003492 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PLC-PRF-5 cell
+obo:BTO_0003494 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peripheral blood cell
+obo:BTO_0003505 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T-cell chronic lymphocytic leukemia cell
+obo:BTO_0003506 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SAF-1 cell
+obo:BTO_0003512 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolar epithelial cell line
+obo:BTO_0003513 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatic stellate cell line
+obo:BTO_0003516 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LX-2 cell
+obo:BTO_0003520 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HSC-T6 cell
+obo:BTO_0003525 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BSC cell
+obo:BTO_0003528 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GRX cell
+obo:BTO_0003539 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PNT2-C2 cell
+obo:BTO_0003540 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # P4E6 cell
+obo:BTO_0003544 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KU-7 cell
+obo:BTO_0003545 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KU-1 cell
+obo:BTO_0003548 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SMS-KCN cell
+obo:BTO_0003556 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SN-56 cell
+obo:BTO_0003560 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CCE cell
+obo:BTO_0003562 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MB-49 cell
+obo:BTO_0003566 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alphaT3-1 cell
+obo:BTO_0003568 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mammary gland cell line
+obo:BTO_0003569 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # C57MG cell
+obo:BTO_0003572 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HL60/ADR cell
+obo:BTO_0003578 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gingival cell line
+obo:BTO_0003581 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal glomerular cell line
+obo:BTO_0003583 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuroendocrine tumor cell line
+obo:BTO_0003586 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Hep-G2/C3A cell
+obo:BTO_0003588 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HeLa-MAGI cell
+obo:BTO_0003596 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine sarcoma cell
+obo:BTO_0003599 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # human lung microvascular endothelial cell
+obo:BTO_0003600 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # M cell
+obo:BTO_0003613 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung squamous cell carcinoma cell
+obo:BTO_0003614 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oral squamous cell carcinoma cell
+obo:BTO_0003620 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BMMC cell
+obo:BTO_0003621 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # serosal mast cell
+obo:BTO_0003622 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mucosal mast cell
+obo:BTO_0003630 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CT-26 cell
+obo:BTO_0003640 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # esophageal cell line
+obo:BTO_0003642 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Hca-F cell
+obo:BTO_0003643 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HD-11 cell
+obo:BTO_0003645 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # salivary gland tumor cell line
+obo:BTO_0003646 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pleomorphic adenoma cell
+obo:BTO_0003651 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spindle cell
+obo:BTO_0003652 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # synovial cell
+obo:BTO_0003659 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # secretory cell
+obo:BTO_0003666 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # outer hair cell
+obo:BTO_0003667 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inner hair cell
+obo:BTO_0003672 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # interdigitating reticulum cell
+obo:BTO_0003681 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hairy cell leukemia cell line
+obo:BTO_0003682 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hairy cell leukemia cell
+obo:BTO_0003689 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mucous cell
+obo:BTO_0003690 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mucous acinar cell
+obo:BTO_0003692 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostatic intraepithelial neoplasia cell
+obo:BTO_0003694 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CNS cell line
+obo:BTO_0003695 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CAD cell
+obo:BTO_0003696 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ATRkd cell
+obo:BTO_0003697 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endometrial stromal cell
+obo:BTO_0003704 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # H4 neuroglioma cell
+obo:BTO_0003713 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # WM-793 cell
+obo:BTO_0003714 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # VMRC-RCW cell
+obo:BTO_0003716 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ScN2a cell
+obo:BTO_0003736 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thyroid epithelial cell
+obo:BTO_0003744 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # liposarcoma cell line
+obo:BTO_0003745 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # liposarcoma cell
+obo:BTO_0003758 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # STAV-AB cell
+obo:BTO_0003764 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI cell
+obo:BTO_0003765 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dermatofibroma cell line
+obo:BTO_0003766 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # giant cell tumor cell line
+obo:BTO_0003771 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T2 cell
+obo:BTO_0003773 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oropharyngeal squamous cell carcinoma cell
+obo:BTO_0003779 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RN-46A cell
+obo:BTO_0003781 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RCC 786-O cell
+obo:BTO_0003782 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rectal adenocarcinoma cell
+obo:BTO_0003783 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rectal adenocarcinoma cell line
+obo:BTO_0003789 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PR-Mel cell
+obo:BTO_0003790 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MR-Mel cell
+obo:BTO_0003792 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OV-2008 cell
+obo:BTO_0003796 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # periglomerular cell
+obo:BTO_0003800 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PCCL-3 cell
+obo:BTO_0003804 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian serous adenocarcinoma cell line
+obo:BTO_0003845 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # A2780/CP70 cell
+obo:BTO_0003848 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adenoid cystic carcinoma cell
+obo:BTO_0003849 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adenosquamous carcinoma cell
+obo:BTO_0003856 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BON-1 cell
+obo:BTO_0003857 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone marrow-derived dendritic cell
+obo:BTO_0003858 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chondrocyte cell line
+obo:BTO_0003860 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T/C-28a2 cell
+obo:BTO_0003861 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inflammatory cell
+obo:BTO_0003865 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # enteroendocrine cell
+obo:BTO_0003871 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine endometrial cancer cell
+obo:BTO_0003872 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # foam cell
+obo:BTO_0003875 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # FTC-236 cell
+obo:BTO_0003877 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # G-292 cell
+obo:BTO_0003881 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HSC-2 cell
+obo:BTO_0003884 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HMT-3522 cell
+obo:BTO_0003894 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skin carcinoma cell line
+obo:BTO_0003898 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GT1 cell
+obo:BTO_0003907 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uroepithelial cell line
+obo:BTO_0003909 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bile duct cell line
+obo:BTO_0003912 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # IMCD cell
+obo:BTO_0003921 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KHOS cell
+obo:BTO_0003929 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MM1-R cell
+obo:BTO_0003932 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KMS-11 cell
+obo:BTO_0003936 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # laryngeal squamous cell carcinoma cell
+obo:BTO_0003944 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Mel-Ab cell
+obo:BTO_0003945 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MN-9D cell
+obo:BTO_0003946 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MMDD1 cell
+obo:BTO_0003952 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesenchymal stromal cell
+obo:BTO_0003955 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # N-11 cell
+obo:BTO_0003957 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # N-9 cell
+obo:BTO_0003960 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nasopharyngeal carcinoma cell line
+obo:BTO_0003964 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OECM-1 cell
+obo:BTO_0003967 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OSRGA cell
+obo:BTO_0003972 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostate gland stromal cell
+obo:BTO_0003981 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SAS cell
+obo:BTO_0003982 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinal stem cell
+obo:BTO_0003984 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # A-375P cell
+obo:BTO_0003998 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 41-M cell
+obo:BTO_0004002 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEMn cell
+obo:BTO_0004003 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NA cell
+obo:BTO_0004004 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 3-LL cell
+obo:BTO_0004007 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # porcine aortic endothelial cell
+obo:BTO_0004010 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HT-2 cell
+obo:BTO_0004012 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ROS cell
+obo:BTO_0004013 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Colon-26 cell
+obo:BTO_0004035 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 222 cell
+obo:BTO_0004044 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amacrine cell
+obo:BTO_0004049 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adult T-cell lymphoma cell line
+obo:BTO_0004050 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BEL-7402 cell
+obo:BTO_0004051 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bipolar cell
+obo:BTO_0004052 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone marrow stem cell
+obo:BTO_0004054 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # umbilical cord blood cell
+obo:BTO_0004055 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # COS cell
+obo:BTO_0004058 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # C3H10T1/2 cell
+obo:BTO_0004065 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CHO-MG cell
+obo:BTO_0004087 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mammary gland tumor cell
+obo:BTO_0004091 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic neural stem cell
+obo:BTO_0004093 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endothelial progenitor cell
+obo:BTO_0004094 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epithelial ovarian cancer cell
+obo:BTO_0004095 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # EONT cell
+obo:BTO_0004096 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # coronary artery endothelial cell
+obo:BTO_0004097 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epididymal clear cell
+obo:BTO_0004098 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal clear cell
+obo:BTO_0004105 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # FPMI-CF-203 cell
+obo:BTO_0004111 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastrointestinal stromal tumor cell
+obo:BTO_0004112 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GBC-SD cell
+obo:BTO_0004114 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adrenocortical carcinoma cell line
+obo:BTO_0004115 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HAC cell
+obo:BTO_0004116 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEP-3B2 cell
+obo:BTO_0004117 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HFK cell
+obo:BTO_0004120 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # horizontal cell
+obo:BTO_0004122 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone marrow stromal cell
+obo:BTO_0004126 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Huh-7.5 cell
+obo:BTO_0004139 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LAD-2 cell
+obo:BTO_0004160 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Ma-1 cell
+obo:BTO_0004166 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myofibroblast cell line
+obo:BTO_0004168 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MHCC-97 cell
+obo:BTO_0004169 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MHCC97-H cell
+obo:BTO_0004170 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MHCC97-L cell
+obo:BTO_0004178 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leukemic stem cell
+obo:BTO_0004181 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI/ADR-RES cell
+obo:BTO_0004190 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pacemaker cell
+obo:BTO_0004191 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PC-J cell
+obo:BTO_0004200 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RCSN-3 cell
+obo:BTO_0004201 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Ewing's sarcoma cell line
+obo:BTO_0004203 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RIE-1 cell
+obo:BTO_0004210 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seminoma cell
+obo:BTO_0004221 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SN-12C cell
+obo:BTO_0004223 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical squamous cell carcinoma cell
+obo:BTO_0004226 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TAMH cell
+obo:BTO_0004229 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # testicular cell line
+obo:BTO_0004232 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tsA-201 cell
+obo:BTO_0004236 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Y1-BS1 cell
+obo:BTO_0004237 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myometrial cell line
+obo:BTO_0004238 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # interstitial cell
+obo:BTO_0004243 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trypanosomoid cell line
+obo:BTO_0004248 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Xenopus A6 cell
+obo:BTO_0004254 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cancer stem cell
+obo:BTO_0004255 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Ewing's family tumor cell
+obo:BTO_0004257 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # extraosseus Ewing's sarcoma cell
+obo:BTO_0004258 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primitive neuroectodermal tumor cell
+obo:BTO_0004259 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primitive neuroectodermal tumor cell line
+obo:BTO_0004260 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Askin's tumor cell
+obo:BTO_0004261 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peripheral primitive neuroectodermal tumor cell
+obo:BTO_0004262 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral giant cell
+obo:BTO_0004265 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # EJ cell
+obo:BTO_0004266 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # H-10 cell
+obo:BTO_0004267 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # follicular dendritic cell
+obo:BTO_0004269 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # liver cancer stem cell
+obo:BTO_0004270 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adult liver stem cell
+obo:BTO_0004272 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hyalocyte cell line
+obo:BTO_0004278 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebellar granule cell
+obo:BTO_0004286 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # basophilic leukemia cell
+obo:BTO_0004296 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # umbilical vein endothelial cell
+obo:BTO_0004297 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colonic epithelial cell
+obo:BTO_0004298 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corneal epithelial cell
+obo:BTO_0004299 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung epithelial cell
+obo:BTO_0004300 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mammary epithelial cell
+obo:BTO_0004301 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuroepithelial cell
+obo:BTO_0004306 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCM-460 cell
+obo:BTO_0004324 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteoblast cell line
+obo:BTO_0004325 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 2T3 cell
+obo:BTO_0004333 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Do11.10 cell
+obo:BTO_0004339 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ScGT1 cell
+obo:BTO_0004360 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # angiomyolipoma cell
+obo:BTO_0004365 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastroesophageal cancer cell
+obo:BTO_0004384 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteoclast stem cell
+obo:BTO_0004389 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # angiomyolipoma cell line
+obo:BTO_0004392 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skeletal muscle cell
+obo:BTO_0004397 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-103 cell
+obo:BTO_0004398 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # meningioma cell line
+obo:BTO_0004402 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchial smooth muscle cell
+obo:BTO_0004405 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 3D5 cell
+obo:BTO_0004410 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # culture condition:CD8+ cell
+obo:BTO_0004416 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Daltons lymphoma cell
+obo:BTO_0004420 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # digestive cell
+obo:BTO_0004438 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HSCC cell
+obo:BTO_0004462 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # K-562R cell
+obo:BTO_0004467 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LbetaT2 cell
+obo:BTO_0004471 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Mahlavu cell
+obo:BTO_0004472 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mantle cell lymphoma cell
+obo:BTO_0004475 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MEL cell
+obo:BTO_0004476 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MES-23.5 cell
+obo:BTO_0004481 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neural crest-derived stem cell
+obo:BTO_0004482 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian surface epithelial cell line
+obo:BTO_0004484 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian surface epithelial cell
+obo:BTO_0004487 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OV-MZ-6 cell
+obo:BTO_0004488 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NSC-34 cell
+obo:BTO_0004492 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric epithelial cell
+obo:BTO_0004493 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric epithelium cell line
+obo:BTO_0004494 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RGM-1 cell
+obo:BTO_0004498 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # THCE cell
+obo:BTO_0004499 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostate gland intraepithelial neoplasia cell line
+obo:BTO_0004508 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endothelioma cell
+obo:BTO_0004509 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endothelioma cell line
+obo:BTO_0004513 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Sertoli cell line
+obo:BTO_0004519 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myometrial cell
+obo:BTO_0004522 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Leydig cell line
+obo:BTO_0004530 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # F5 meningioma cell
+obo:BTO_0004533 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # respiratory epithelium cell
+obo:BTO_0004535 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medullary collecting duct cell
+obo:BTO_0004537 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cortical collecting duct cell
+obo:BTO_0004541 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # connecting tubule cell
+obo:BTO_0004542 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # principal cell
+obo:BTO_0004543 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inner medullary collecting duct cell
+obo:BTO_0004561 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymic stromal cell
+obo:BTO_0004562 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymic cortical epithelial cell
+obo:BTO_0004563 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymic medullary epithelial cell
+obo:BTO_0004564 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymic dendritic cell
+obo:BTO_0004566 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Rb-1 cell
+obo:BTO_0004567 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sessile serrated adenoma cell
+obo:BTO_0004574 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dermal microvascular endothelial cell
+obo:BTO_0004575 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nephroblastoma cell
+obo:BTO_0004576 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # smooth muscle cell
+obo:BTO_0004577 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aortic smooth muscle cell
+obo:BTO_0004578 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular smooth muscle cell
+obo:BTO_0004585 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # acute promyelocytic leukemia cell
+obo:BTO_0004595 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # D-407 cell
+obo:BTO_0004599 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TE-13 cell
+obo:BTO_0004601 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TE-1 cell
+obo:BTO_0004602 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # human aortic endothelial cell
+obo:BTO_0004603 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HBE cell
+obo:BTO_0004606 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MDCK-1 cell
+obo:BTO_0004607 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MDCK-2 cell
+obo:BTO_0004609 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TALH cell
+obo:BTO_0004623 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OCI-M2 cell
+obo:BTO_0004624 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # YN-1 cell
+obo:BTO_0004625 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plasmacytoid dendritic cell
+obo:BTO_0004640 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # FD-2 cell
+obo:BTO_0004641 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tracheal cell line
+obo:BTO_0004656 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # follicular lymphoma cell
+obo:BTO_0004660 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # human amniotic epithelial cell
+obo:BTO_0004720 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mural cell
+obo:BTO_0004721 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myeloid dendritic cell
+obo:BTO_0004730 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myeloid progenitor cell
+obo:BTO_0004731 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphoid progenitor cell
+obo:BTO_0004744 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hair cell
+obo:BTO_0004752 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adipose-derived stromal cell
+obo:BTO_0004758 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # arterial endothelial cell
+obo:BTO_0004759 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # venous endothelial cell
+obo:BTO_0004770 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TAD-2 cell
+obo:BTO_0004771 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NPA cell
+obo:BTO_0004773 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trophoblast stem cell line
+obo:BTO_0004774 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trophoblast stem cell
+obo:BTO_0004779 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # soft tissue sarcoma cell
+obo:BTO_0004780 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # soft tissue sarcoma cell line
+obo:BTO_0004783 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SeAx cell
+obo:BTO_0004785 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Ewing's sarcoma family tumor cell line
+obo:BTO_0004787 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SK-N-LO cell
+obo:BTO_0004796 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 253J cell
+obo:BTO_0004799 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # AILNCaP cell
+obo:BTO_0004804 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # buccal epithelial cell
+obo:BTO_0004811 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Clara cell
+obo:BTO_0004812 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dermal dendritic cell
+obo:BTO_0004816 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ERpP cell
+obo:BTO_0004827 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hFOB cell
+obo:BTO_0004830 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epidermal cell line
+obo:BTO_0004831 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # JB6 cell
+obo:BTO_0004833 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # large cell neuroendocrine carcinoma cell
+obo:BTO_0004837 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MRC5-SV cell
+obo:BTO_0004845 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NHOst cell
+obo:BTO_0004850 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone marrow cell
+obo:BTO_0004851 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mammary ductal carcinoma cell
+obo:BTO_0004854 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PK-1 cell
+obo:BTO_0004862 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEI-OC1 cell
+obo:BTO_0004864 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HMC cell
+obo:BTO_0004868 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anaplastic large cell lymphoma cell line
+obo:BTO_0004877 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # distal tip cell
+obo:BTO_0004897 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CHO-LY-B cell
+obo:BTO_0004901 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # non-neuronal cell
+obo:BTO_0004910 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinal pigment epithelial cell
+obo:BTO_0004911 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # erythroid progenitor cell
+obo:BTO_0004919 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ZR-75 cell
+obo:BTO_0004921 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # swine testicular cell line
+obo:BTO_0004925 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HRA cell
+obo:BTO_0004953 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MGC-803 cell
+obo:BTO_0004958 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # F9-12 cell
+obo:BTO_0004959 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # C4-2B cell
+obo:BTO_0004961 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # acute megakaryoblastic leukemia cell line
+obo:BTO_0004963 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # acute megakaryoblastic leukemia cell
+obo:BTO_0004965 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TTA-1 cell
+obo:BTO_0004966 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Rat-1/BB16 cell
+obo:BTO_0004973 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Hodgkin lymphoma cell line
+obo:BTO_0004974 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Hodgkin lymphoma cell
+obo:BTO_0004975 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryogenic cell line
+obo:BTO_0004976 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tongue cancer cell
+obo:BTO_0004980 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uveal melanoma cell
+obo:BTO_0004996 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myelinating Schwann cell
+obo:BTO_0004997 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # non-myelinating Schwann cell
+obo:BTO_0005001 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinal microvascular endothelial cell
+obo:BTO_0005004 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # UROtsa cell
+obo:BTO_0005007 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # psammomatous meningioma cell
+obo:BTO_0005014 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-cell leukemia cell
+obo:BTO_0005023 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cEND cell
+obo:BTO_0005025 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEK-293-TrkB cell
+obo:BTO_0005029 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEK-293FT cell
+obo:BTO_0005034 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # DT-40 3KO cell
+obo:BTO_0005036 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Fanconi anemia lymphoid cell line
+obo:BTO_0005039 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HN-30 cell
+obo:BTO_0005040 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HN-12 cell
+obo:BTO_0005043 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # M1 melanoma cell
+obo:BTO_0005049 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostate adenocarcinoma cell line
+obo:BTO_0005054 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # macrophage foam cell
+obo:BTO_0005059 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TZM-bl cell
+obo:BTO_0005060 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # UACC-903 cell
+obo:BTO_0005067 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PAM212 cell
+obo:BTO_0005068 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SK-CO15 cell
+obo:BTO_0005071 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PC3-MM2 cell
+obo:BTO_0005083 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant mucous cell
+obo:BTO_0005092 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chondrogenic cell
+obo:BTO_0005093 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intercalated cell
+obo:BTO_0005096 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epithelial stem cell
+obo:BTO_0005097 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skin stem cell
+obo:BTO_0005098 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epidermal stem cell
+obo:BTO_0005099 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # follicular stem cell
+obo:BTO_0005101 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # coronary artery smooth muscle cell
+obo:BTO_0005103 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NB-1 cell
+obo:BTO_0005110 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ameloblastoma cell
+obo:BTO_0005117 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinal ganglion cell line
+obo:BTO_0005118 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RGC-5 cell
+obo:BTO_0005128 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # M12 prostate cancer cell
+obo:BTO_0005129 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # A2780/S cell
+obo:BTO_0005136 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ES-E14 cell
+obo:BTO_0005155 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CEM-VBL100 cell
+obo:BTO_0005158 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # juxtaglomerular cell
+obo:BTO_0005159 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # extraglomerular mesangial cell
+obo:BTO_0005161 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KAT-18 cell
+obo:BTO_0005167 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HSC-1 cell
+obo:BTO_0005191 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Patu-8988 cell
+obo:BTO_0005195 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # K-562/R7 cell
+obo:BTO_0005196 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KBv200 cell
+obo:BTO_0005198 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adipose-derived stem cell
+obo:BTO_0005201 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brain endothelial cell
+obo:BTO_0005204 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Ca9-22 cell
+obo:BTO_0005212 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical intraepithelial neoplasia cell
+obo:BTO_0005215 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KB-C2 cell
+obo:BTO_0005218 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MC57 cell
+obo:BTO_0005220 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PC-3M cell
+obo:BTO_0005238 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T-REx 293 cell
+obo:BTO_0005258 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oropharyngeal cancer cell
+obo:BTO_0005259 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oropharyngeal carcinoma cell line
+obo:BTO_0005261 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-lymphoblast cell line
+obo:BTO_0005262 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NEF cell
+obo:BTO_0005264 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mucoepidermoid carcinoma cell
+obo:BTO_0005283 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TS-20 cell
+obo:BTO_0005288 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CL-48 cell
+obo:BTO_0005300 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # muscle stem cell
+obo:BTO_0005301 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NPrEC cell
+obo:BTO_0005316 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # malignant peripheral nerve sheath cancer cell
+obo:BTO_0005319 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic germ cell
+obo:BTO_0005322 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chronic myelogenous leukemia progenitor cell
+obo:BTO_0005352 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 1-LN cell
+obo:BTO_0005362 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trophoblast giant cell
+obo:BTO_0005364 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # D-54MG cell
+obo:BTO_0005372 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SK-N-MC-IXC cell
+obo:BTO_0005375 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oral cell line
+obo:BTO_0005388 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SUM-149 cell
+obo:BTO_0005397 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SH-EP cell
+obo:BTO_0005399 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # POS cell
+obo:BTO_0005400 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BPH cell
+obo:BTO_0005403 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glycogen cell
+obo:BTO_0005453 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # culture condition:CD4+ cell
+obo:BTO_0005490 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MM-1 cell
+obo:CLO_0001056 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 1205Lu cell
+obo:CLO_0001088 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 143B cell
+obo:CLO_0001200 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 22Rv1 cell
+obo:CLO_0001230 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEK-293 cell
+obo:CLO_0001352 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 3T3-L1 cell
+obo:CLO_0001401 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # 4T1 cell
+obo:CLO_0001570 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # A-253 cell
+obo:CLO_0001571 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # A2780 cell
+obo:CLO_0001582 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # A-375 cell
+obo:CLO_0001590 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # A-427 cell
+obo:CLO_0001596 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # A-498 cell
+obo:CLO_0001606 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # A-673 cell
+obo:CLO_0001656 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ACT-1 cell
+obo:CLO_0001662 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ADF cell
+obo:CLO_0001745 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ARH-77 cell
+obo:CLO_0001756 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # AsPC-1 cell
+obo:CLO_0001766 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # AtT-20 cell
+obo:CLO_0001793 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B16-F1 cell
+obo:CLO_0001794 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B16-F10 cell
+obo:CLO_0001925 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BEAS-2B cell
+obo:CLO_0001933 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Beta-TC-6 cell
+obo:CLO_0001934 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BEWO cell
+obo:CLO_0001965 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BHK-21 cell
+obo:CLO_0002000 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Bm N cell
+obo:CLO_0002022 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BPH-1 cell
+obo:CLO_0002052 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BV-173 cell
+obo:CLO_0002057 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BW5147 cell
+obo:CLO_0002065 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BxPC-3 cell
+obo:CLO_0002086 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # C127I cell
+obo:CLO_0002168 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CA-46 cell
+obo:CLO_0002176 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Caki-1 cell
+obo:CLO_0002193 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Calu-6 cell
+obo:CLO_0002201 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CaSki cell
+obo:CLO_0002309 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CCD-18Co cell
+obo:CLO_0002360 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CESS cell
+obo:CLO_0002526 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CMK cell
+obo:CLO_0002532 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CMT-93 cell
+obo:CLO_0002571 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Colo-320 cell
+obo:CLO_0002574 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # COLO-699 cell
+obo:CLO_0002596 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # COS-1 cell
+obo:CLO_0002640 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CV-1 cell
+obo:CLO_0002650 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # CX-1 cell
+obo:CLO_0002699 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Daoy cell
+obo:CLO_0002708 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # DAUDI cell
+obo:CLO_0002767 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # DG-75 cell
+obo:CLO_0002807 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # DON cell
+obo:CLO_0002882 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ECV-304 cell
+obo:CLO_0002913 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # EL4 cell
+obo:CLO_0002988 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # F-9 cell
+obo:CLO_0003396 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # FRTL-5 cell
+obo:CLO_0003402 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # FTC-133 cell
+obo:CLO_0003413 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # G cell
+obo:CLO_0003450 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GAMG cell
+obo:CLO_0003487 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GH3 cell
+obo:CLO_0003490 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # GH4-C1 cell
+obo:CLO_0003612 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # H9 cell
+obo:CLO_0003663 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HCN-1A cell
+obo:CLO_0003664 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HCN-2 cell
+obo:CLO_0003667 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HCT-8 cell
+obo:CLO_0003679 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEL cell
+obo:CLO_0003682 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEL-92.1.7 cell
+obo:CLO_0003684 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HeLa cell
+obo:CLO_0003699 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HELA-S3 cell
+obo:CLO_0003706 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HEp-2 cell
+obo:CLO_0003734 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HFL-1 cell
+obo:CLO_0003740 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HGF cell
+obo:CLO_0003758 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HIT-T15 cell
+obo:CLO_0003771 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HK-2 cell
+obo:CLO_0003782 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HL-60/MX-2 cell
+obo:CLO_0003786 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HMV-II cell
+obo:CLO_0003814 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HPAC cell
+obo:CLO_0003817 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HPB-ALL cell
+obo:CLO_0003836 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HRT-18 cell
+obo:CLO_0004041 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Hs 68 cell
+obo:CLO_0004276 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HT-1080 cell
+obo:CLO_0004278 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HT-1197 cell
+obo:CLO_0004279 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HT-1376 cell
+obo:CLO_0004288 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HTC cell
+obo:CLO_0004304 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # HuT 78 cell
+obo:CLO_0004341 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # IEC-18 cell
+obo:CLO_0004342 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # IEC-6 cell
+obo:CLO_0006672 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # IGROV-1 cell
+obo:CLO_0006951 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # IMR-90 cell
+obo:CLO_0006954 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Intestine 407 cell
+obo:CLO_0007002 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # J558L cell
+obo:CLO_0007017 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # JEG-3 cell
+obo:CLO_0007059 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # K-562 cell
+obo:CLO_0007065 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KARPAS-299 cell
+obo:CLO_0007066 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KARPAS-422 cell
+obo:CLO_0007073 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KATO-III cell
+obo:CLO_0007074 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KB cell
+obo:CLO_0007079 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Kc cell
+obo:CLO_0007095 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KG-1A cell
+obo:CLO_0007104 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KLE cell
+obo:CLO_0007132 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # KYSE-30 cell
+obo:CLO_0007189 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # L-428 cell
+obo:CLO_0007335 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LLC-WRC 256 cell
+obo:CLO_0007378 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LoVo cell
+obo:CLO_0007393 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LS 174T cell
+obo:CLO_0007394 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LS 180 cell
+obo:CLO_0007484 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # M5076 cell
+obo:CLO_0007492 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MA 104 cell
+obo:CLO_0007529 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MALME-3M cell
+obo:CLO_0007600 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MCF-10F cell
+obo:CLO_0007606 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MCF-7 cell
+obo:CLO_0007636 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MDA-MB-361 cell
+obo:CLO_0007639 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MDA-MB-436 cell
+obo:CLO_0007641 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MDA-MB-468 cell
+obo:CLO_0007642 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MDBK cell
+obo:CLO_0007646 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MDCK cell
+obo:CLO_0007668 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MEG-01 cell
+obo:CLO_0007687 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MEWO cell
+obo:CLO_0007699 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MG-63 cell
+obo:CLO_0007709 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MH1C1 cell
+obo:CLO_0007735 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ML-1 cell
+obo:CLO_0007825 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MOLT-4 cell
+obo:CLO_0007827 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MONO-MAC-1 cell
+obo:CLO_0007828 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MONO-MAC-6 cell
+obo:CLO_0007854 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MPC-11 cell
+obo:CLO_0007880 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MSTO-211H cell
+obo:CLO_0007891 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MT-4 cell
+obo:CLO_0007950 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NBT-II cell
+obo:CLO_0007952 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NC-37 cell
+obo:CLO_0007986 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI-H1299 cell
+obo:CLO_0008035 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI-H1975 cell
+obo:CLO_0008085 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI-H358 cell
+obo:CLO_0008087 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI-H441 cell
+obo:CLO_0008121 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI-H838 cell
+obo:CLO_0008127 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI-H929 cell
+obo:CLO_0008129 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCI-N87 cell
+obo:CLO_0008132 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NCTC 2544 cell
+obo:CLO_0008154 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Neuro-2a cell
+obo:CLO_0008186 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NMuMG cell
+obo:CLO_0008205 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # NS20Y cell
+obo:CLO_0008235 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OCI-AML2 cell
+obo:CLO_0008236 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OCI-AML5 cell
+obo:CLO_0008240 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OE-33 cell
+obo:CLO_0008327 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # P388D1 cell
+obo:CLO_0008340 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # P-815 cell
+obo:CLO_0008395 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PC-3 cell
+obo:CLO_0008416 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PEER cell
+obo:CLO_0008426 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PG cell
+obo:CLO_0008447 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PK-15 cell
+obo:CLO_0008460 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PLHC-1 cell
+obo:CLO_0008475 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PNT-1A cell
+obo:CLO_0008476 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # PNT-2 cell
+obo:CLO_0008486 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Pro-5 cell
+obo:CLO_0008697 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # R1 cell
+obo:CLO_0008734 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RAJI cell
+obo:CLO_0008762 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RBL-1 cell
+obo:CLO_0008770 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RD cell
+obo:CLO_0008774 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RD-ES cell
+obo:CLO_0008781 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # REH cell
+obo:CLO_0008799 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RFL-6 cell
+obo:CLO_0008825 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RKO cell
+obo:CLO_0008828 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RL cell
+obo:CLO_0008873 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RPMI-8226 cell
+obo:CLO_0008876 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RPMI-2650 cell
+obo:CLO_0008987 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SF-21 cell
+obo:CLO_0008988 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SF-9 cell
+obo:CLO_0009019 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SIRC cell
+obo:CLO_0009039 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SK-LU-1 cell
+obo:CLO_0009043 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SK-MEL-28 cell
+obo:CLO_0009045 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SK-MEL-30 cell
+obo:CLO_0009051 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SK-N-AS cell
+obo:CLO_0009052 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SK-N-BE(2) cell
+obo:CLO_0009058 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SK-N-MC cell
+obo:CLO_0009097 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SNU-387 cell
+obo:CLO_0009126 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SR cell
+obo:CLO_0009183 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SW-1116 cell
+obo:CLO_0009196 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SW-620 cell
+obo:CLO_0009216 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SW-48 cell
+obo:CLO_0009217 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SW-480 cell
+obo:CLO_0009222 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SW626 cell
+obo:CLO_0009225 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SW-948 cell
+obo:CLO_0009237 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T/G HA-VSMC cell
+obo:CLO_0009245 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T24 cell
+obo:CLO_0009254 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T84 cell
+obo:CLO_0009320 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TE-8 cell
+obo:CLO_0009324 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Tera-2 cell
+obo:CLO_0009326 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TF-1 cell
+obo:CLO_0009357 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TK6 cell
+obo:CLO_0009368 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # TM-4 cell
+obo:CLO_0009452 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # U-138MG cell
+obo:CLO_0009456 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # U-251 MG cell
+obo:CLO_0009457 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # U-266 cell
+obo:CLO_0009459 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # U-343 MGa cell
+obo:CLO_0009461 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # U-373 MG cell
+obo:CLO_0009465 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # U-937 cell
+obo:CLO_0009500 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # V-79 cell
+obo:CLO_0009504 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # V79-4 cell
+obo:CLO_0009575 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # WEHI-231 cell
+obo:CLO_0009594 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # WI-38 cell
+obo:CLO_0009604 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # WIL2-NS cell
+obo:CLO_0009609 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # WISH cell
+obo:CLO_0009635 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # WSS-1 cell
+obo:CLO_0009709 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Y79 cell
+obo:CLO_0009727 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ZR-75-1 cell
+obo:CLO_0009728 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ZR-75-30 cell
+obo:CLO_0009833 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # BCWM.1 cell
+obo:CLO_0009848 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MOLM-13 cell
+obo:CLO_0009858 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # RPMI-8866 cell
+obo:CLO_0009902 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # SF-268 cell
+obo:CLO_0037097 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # OVISE cell
+obo:CLO_0037116 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # LNCaP cell
+obo:CLO_0037117 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # VCaP cell
+obo:CLO_0037142 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MKN-28 cell
+obo:CLO_0037180 rdfs:subClassOf bae:BrendaCell ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # MCF12A cell
 
 # reparenting tissues
 
-obo:BTO_0000000 rdfs:subClassOf bae:BrendaTissues . # tissues, cell types and enzyme sources
-obo:BTO_0000020 rdfs:subClassOf bae:BrendaTissues . # abdomen
-obo:BTO_0000022 rdfs:subClassOf bae:BrendaTissues . # abdominal ganglion
-obo:BTO_0000023 rdfs:subClassOf bae:BrendaTissues . # pectoral muscle
-obo:BTO_0000025 rdfs:subClassOf bae:BrendaTissues . # amniotic cavity
-obo:BTO_0000027 rdfs:subClassOf bae:BrendaTissues . # achene
-obo:BTO_0000029 rdfs:subClassOf bae:BrendaTissues . # adductor longus
-obo:BTO_0000030 rdfs:subClassOf bae:BrendaTissues . # adductor
-obo:BTO_0000031 rdfs:subClassOf bae:BrendaTissues . # fruit peduncle
-obo:BTO_0000034 rdfs:subClassOf bae:BrendaTissues . # apical meristem
-obo:BTO_0000039 rdfs:subClassOf bae:BrendaTissues . # root cap
-obo:BTO_0000040 rdfs:subClassOf bae:BrendaTissues . # adenohypophysis
-obo:BTO_0000041 rdfs:subClassOf bae:BrendaTissues . # medulla oblongata
-obo:BTO_0000043 rdfs:subClassOf bae:BrendaTissues . # cerebellar cortex
-obo:BTO_0000044 rdfs:subClassOf bae:BrendaTissues . # tear gland
-obo:BTO_0000045 rdfs:subClassOf bae:BrendaTissues . # adrenal cortex
-obo:BTO_0000047 rdfs:subClassOf bae:BrendaTissues . # adrenal gland
-obo:BTO_0000048 rdfs:subClassOf bae:BrendaTissues . # zona glomerulosa
-obo:BTO_0000049 rdfs:subClassOf bae:BrendaTissues . # adrenal medulla
-obo:BTO_0000050 rdfs:subClassOf bae:BrendaTissues . # zona fasciculata
-obo:BTO_0000051 rdfs:subClassOf bae:BrendaTissues . # tendon sheath
-obo:BTO_0000052 rdfs:subClassOf bae:BrendaTissues . # stoma
-obo:BTO_0000053 rdfs:subClassOf bae:BrendaTissues . # albedo
-obo:BTO_0000054 rdfs:subClassOf bae:BrendaTissues . # albumen gland
-obo:BTO_0000055 rdfs:subClassOf bae:BrendaTissues . # pars recta
-obo:BTO_0000057 rdfs:subClassOf bae:BrendaTissues . # aleurone layer
-obo:BTO_0000058 rdfs:subClassOf bae:BrendaTissues . # alimentary canal
-obo:BTO_0000059 rdfs:subClassOf bae:BrendaTissues . # renal epithelium
-obo:BTO_0000060 rdfs:subClassOf bae:BrendaTissues . # alveolus
-obo:BTO_0000061 rdfs:subClassOf bae:BrendaTissues . # alveolar sac
-obo:BTO_0000062 rdfs:subClassOf bae:BrendaTissues . # amastigote
-obo:BTO_0000065 rdfs:subClassOf bae:BrendaTissues . # amnion
-obo:BTO_0000066 rdfs:subClassOf bae:BrendaTissues . # amniocyte
-obo:BTO_0000068 rdfs:subClassOf bae:BrendaTissues . # amniotic fluid
-obo:BTO_0000071 rdfs:subClassOf bae:BrendaTissues . # amoebocyte
-obo:BTO_0000072 rdfs:subClassOf bae:BrendaTissues . # carpel
-obo:BTO_0000074 rdfs:subClassOf bae:BrendaTissues . # antenna
-obo:BTO_0000075 rdfs:subClassOf bae:BrendaTissues . # antennal gland
-obo:BTO_0000076 rdfs:subClassOf bae:BrendaTissues . # anterior midgut
-obo:BTO_0000077 rdfs:subClassOf bae:BrendaTissues . # posterior midgut
-obo:BTO_0000078 rdfs:subClassOf bae:BrendaTissues . # microglia
-obo:BTO_0000079 rdfs:subClassOf bae:BrendaTissues . # anther
-obo:BTO_0000081 rdfs:subClassOf bae:BrendaTissues . # reproductive system
-obo:BTO_0000083 rdfs:subClassOf bae:BrendaTissues . # female reproductive system
-obo:BTO_0000084 rdfs:subClassOf bae:BrendaTissues . # vermiform appendix
-obo:BTO_0000087 rdfs:subClassOf bae:BrendaTissues . # arterial smooth muscle
-obo:BTO_0000088 rdfs:subClassOf bae:BrendaTissues . # cardiovascular system
-obo:BTO_0000089 rdfs:subClassOf bae:BrendaTissues . # blood
-obo:BTO_0000090 rdfs:subClassOf bae:BrendaTissues . # ascidian
-obo:BTO_0000091 rdfs:subClassOf bae:BrendaTissues . # ascites
-obo:BTO_0000092 rdfs:subClassOf bae:BrendaTissues . # trypanosomoid form
-obo:BTO_0000099 rdfs:subClassOf bae:BrendaTissues . # astrocyte
-obo:BTO_0000102 rdfs:subClassOf bae:BrendaTissues . # blood clot
-obo:BTO_0000105 rdfs:subClassOf bae:BrendaTissues . # upper epidermis
-obo:BTO_0000108 rdfs:subClassOf bae:BrendaTissues . # olfactory epithelium
-obo:BTO_0000109 rdfs:subClassOf bae:BrendaTissues . # bacteroid
-obo:BTO_0000119 rdfs:subClassOf bae:BrendaTissues . # berry
-obo:BTO_0000121 rdfs:subClassOf bae:BrendaTissues . # bile
-obo:BTO_0000122 rdfs:subClassOf bae:BrendaTissues . # bile duct
-obo:BTO_0000123 rdfs:subClassOf bae:BrendaTissues . # bladder
-obo:BTO_0000124 rdfs:subClassOf bae:BrendaTissues . # microspore
-obo:BTO_0000126 rdfs:subClassOf bae:BrendaTissues . # blastoderm
-obo:BTO_0000128 rdfs:subClassOf bae:BrendaTissues . # blastula
-obo:BTO_0000129 rdfs:subClassOf bae:BrendaTissues . # basophil
-obo:BTO_0000130 rdfs:subClassOf bae:BrendaTissues . # neutrophil
-obo:BTO_0000131 rdfs:subClassOf bae:BrendaTissues . # blood plasma
-obo:BTO_0000132 rdfs:subClassOf bae:BrendaTissues . # blood platelet
-obo:BTO_0000134 rdfs:subClassOf bae:BrendaTissues . # bloodstream form
-obo:BTO_0000135 rdfs:subClassOf bae:BrendaTissues . # aorta
-obo:BTO_0000136 rdfs:subClassOf bae:BrendaTissues . # bronchoalveolar system
-obo:BTO_0000138 rdfs:subClassOf bae:BrendaTissues . # midbrain
-obo:BTO_0000139 rdfs:subClassOf bae:BrendaTissues . # body wall
-obo:BTO_0000140 rdfs:subClassOf bae:BrendaTissues . # bone
-obo:BTO_0000141 rdfs:subClassOf bae:BrendaTissues . # bone marrow
-obo:BTO_0000142 rdfs:subClassOf bae:BrendaTissues . # brain
-obo:BTO_0000143 rdfs:subClassOf bae:BrendaTissues . # substantia nigra
-obo:BTO_0000144 rdfs:subClassOf bae:BrendaTissues . # meninx
-obo:BTO_0000145 rdfs:subClassOf bae:BrendaTissues . # brain myelin
-obo:BTO_0000146 rdfs:subClassOf bae:BrendaTissues . # brain stem
-obo:BTO_0000147 rdfs:subClassOf bae:BrendaTissues . # microgametophyte
-obo:BTO_0000148 rdfs:subClassOf bae:BrendaTissues . # branch
-obo:BTO_0000149 rdfs:subClassOf bae:BrendaTissues . # breast
-obo:BTO_0000151 rdfs:subClassOf bae:BrendaTissues . # extensor
-obo:BTO_0000155 rdfs:subClassOf bae:BrendaTissues . # bronchoalveolar lavage
-obo:BTO_0000156 rdfs:subClassOf bae:BrendaTissues . # brown adipose tissue
-obo:BTO_0000159 rdfs:subClassOf bae:BrendaTissues . # bulb
-obo:BTO_0000160 rdfs:subClassOf bae:BrendaTissues . # bundle sheath
-obo:BTO_0000163 rdfs:subClassOf bae:BrendaTissues . # corolla
-obo:BTO_0000166 rdfs:subClassOf bae:BrendaTissues . # cecum
-obo:BTO_0000168 rdfs:subClassOf bae:BrendaTissues . # carotid artery
-obo:BTO_0000169 rdfs:subClassOf bae:BrendaTissues . # calyx
-obo:BTO_0000170 rdfs:subClassOf bae:BrendaTissues . # cambium
-obo:BTO_0000171 rdfs:subClassOf bae:BrendaTissues . # L-cell
-obo:BTO_0000175 rdfs:subClassOf bae:BrendaTissues . # epithalamus
-obo:BTO_0000187 rdfs:subClassOf bae:BrendaTissues . # myeloblast
-obo:BTO_0000198 rdfs:subClassOf bae:BrendaTissues . # cardia
-obo:BTO_0000199 rdfs:subClassOf bae:BrendaTissues . # cardiac muscle
-obo:BTO_0000202 rdfs:subClassOf bae:BrendaTissues . # sense organ
-obo:BTO_0000203 rdfs:subClassOf bae:BrendaTissues . # respiratory system
-obo:BTO_0000204 rdfs:subClassOf bae:BrendaTissues . # carotid body
-obo:BTO_0000205 rdfs:subClassOf bae:BrendaTissues . # nerve plexus
-obo:BTO_0000206 rdfs:subClassOf bae:BrendaTissues . # cartilage
-obo:BTO_0000207 rdfs:subClassOf bae:BrendaTissues . # tibial cartilage
-obo:BTO_0000208 rdfs:subClassOf bae:BrendaTissues . # caryopsis
-obo:BTO_0000209 rdfs:subClassOf bae:BrendaTissues . # corpus epididymis
-obo:BTO_0000210 rdfs:subClassOf bae:BrendaTissues . # cauda epididymis
-obo:BTO_0000211 rdfs:subClassOf bae:BrendaTissues . # caudate nucleus
-obo:BTO_0000212 rdfs:subClassOf bae:BrendaTissues . # caudate putamen
-obo:BTO_0000214 rdfs:subClassOf bae:BrendaTissues . # cell culture
-obo:BTO_0000216 rdfs:subClassOf bae:BrendaTissues . # culture condition
-obo:BTO_0000221 rdfs:subClassOf bae:BrendaTissues . # cell suspension culture
-obo:BTO_0000222 rdfs:subClassOf bae:BrendaTissues . # myoblast
-obo:BTO_0000227 rdfs:subClassOf bae:BrendaTissues . # central nervous system
-obo:BTO_0000229 rdfs:subClassOf bae:BrendaTissues . # centrum semiovale
-obo:BTO_0000230 rdfs:subClassOf bae:BrendaTissues . # subarachnoid space
-obo:BTO_0000231 rdfs:subClassOf bae:BrendaTissues . # cerebral hemisphere
-obo:BTO_0000232 rdfs:subClassOf bae:BrendaTissues . # cerebellum
-obo:BTO_0000233 rdfs:subClassOf bae:BrendaTissues . # cerebral cortex
-obo:BTO_0000234 rdfs:subClassOf bae:BrendaTissues . # vein
-obo:BTO_0000236 rdfs:subClassOf bae:BrendaTissues . # cerebral white matter
-obo:BTO_0000237 rdfs:subClassOf bae:BrendaTissues . # cerebrospinal fluid
-obo:BTO_0000239 rdfs:subClassOf bae:BrendaTissues . # telencephalon
-obo:BTO_0000240 rdfs:subClassOf bae:BrendaTissues . # inferior cervical ganglion
-obo:BTO_0000241 rdfs:subClassOf bae:BrendaTissues . # cervical epithelium
-obo:BTO_0000242 rdfs:subClassOf bae:BrendaTissues . # cervical mucus
-obo:BTO_0000243 rdfs:subClassOf bae:BrendaTissues . # vagina
-obo:BTO_0000247 rdfs:subClassOf bae:BrendaTissues . # shoot tip
-obo:BTO_0000249 rdfs:subClassOf bae:BrendaTissues . # chondrocyte
-obo:BTO_0000251 rdfs:subClassOf bae:BrendaTissues . # chorioallantois
-obo:BTO_0000258 rdfs:subClassOf bae:BrendaTissues . # choroid plexus
-obo:BTO_0000260 rdfs:subClassOf bae:BrendaTissues . # ciliary body
-obo:BTO_0000262 rdfs:subClassOf bae:BrendaTissues . # clove
-obo:BTO_0000265 rdfs:subClassOf bae:BrendaTissues . # coagulating gland
-obo:BTO_0000266 rdfs:subClassOf bae:BrendaTissues . # cob
-obo:BTO_0000267 rdfs:subClassOf bae:BrendaTissues . # cochlea
-obo:BTO_0000268 rdfs:subClassOf bae:BrendaTissues . # coleoptile
-obo:BTO_0000269 rdfs:subClassOf bae:BrendaTissues . # colon
-obo:BTO_0000271 rdfs:subClassOf bae:BrendaTissues . # colonic mucosa
-obo:BTO_0000272 rdfs:subClassOf bae:BrendaTissues . # colon transversum
-obo:BTO_0000273 rdfs:subClassOf bae:BrendaTissues . # ink gland
-obo:BTO_0000274 rdfs:subClassOf bae:BrendaTissues . # apical bud
-obo:BTO_0000275 rdfs:subClassOf bae:BrendaTissues . # colonocyte
-obo:BTO_0000278 rdfs:subClassOf bae:BrendaTissues . # commercial preparation
-obo:BTO_0000280 rdfs:subClassOf bae:BrendaTissues . # cone
-obo:BTO_0000282 rdfs:subClassOf bae:BrendaTissues . # head
-obo:BTO_0000284 rdfs:subClassOf bae:BrendaTissues . # organism form
-obo:BTO_0000285 rdfs:subClassOf bae:BrendaTissues . # corm
-obo:BTO_0000286 rdfs:subClassOf bae:BrendaTissues . # cornea
-obo:BTO_0000287 rdfs:subClassOf bae:BrendaTissues . # corneal epithelium
-obo:BTO_0000289 rdfs:subClassOf bae:BrendaTissues . # cytotoxic T-lymphocyte
-obo:BTO_0000290 rdfs:subClassOf bae:BrendaTissues . # coronary artery
-obo:BTO_0000291 rdfs:subClassOf bae:BrendaTissues . # corpus allatum
-obo:BTO_0000292 rdfs:subClassOf bae:BrendaTissues . # corpus luteum
-obo:BTO_0000293 rdfs:subClassOf bae:BrendaTissues . # occipital lobe
-obo:BTO_0000294 rdfs:subClassOf bae:BrendaTissues . # dermis
-obo:BTO_0000299 rdfs:subClassOf bae:BrendaTissues . # cotton fibre
-obo:BTO_0000300 rdfs:subClassOf bae:BrendaTissues . # cotyledon
-obo:BTO_0000303 rdfs:subClassOf bae:BrendaTissues . # crown gall
-obo:BTO_0000305 rdfs:subClassOf bae:BrendaTissues . # crypt
-obo:BTO_0000307 rdfs:subClassOf bae:BrendaTissues . # crystalline style
-obo:BTO_0000310 rdfs:subClassOf bae:BrendaTissues . # protophloem
-obo:BTO_0000311 rdfs:subClassOf bae:BrendaTissues . # culture filtrate
-obo:BTO_0000312 rdfs:subClassOf bae:BrendaTissues . # motoneuron
-obo:BTO_0000313 rdfs:subClassOf bae:BrendaTissues . # hypodermis
-obo:BTO_0000314 rdfs:subClassOf bae:BrendaTissues . # neuroepithelium
-obo:BTO_0000315 rdfs:subClassOf bae:BrendaTissues . # ectoderm
-obo:BTO_0000316 rdfs:subClassOf bae:BrendaTissues . # culture medium
-obo:BTO_0000317 rdfs:subClassOf bae:BrendaTissues . # caulonema
-obo:BTO_0000320 rdfs:subClassOf bae:BrendaTissues . # cyst
-obo:BTO_0000321 rdfs:subClassOf bae:BrendaTissues . # plant cuticle
-obo:BTO_0000322 rdfs:subClassOf bae:BrendaTissues . # cytotrophoblast
-obo:BTO_0000333 rdfs:subClassOf bae:BrendaTissues . # renal corpuscle
-obo:BTO_0000334 rdfs:subClassOf bae:BrendaTissues . # decidua parietalis
-obo:BTO_0000336 rdfs:subClassOf bae:BrendaTissues . # caput epididymis
-obo:BTO_0000337 rdfs:subClassOf bae:BrendaTissues . # dental follicle
-obo:BTO_0000338 rdfs:subClassOf bae:BrendaTissues . # dental plaque
-obo:BTO_0000339 rdfs:subClassOf bae:BrendaTissues . # dental pulp
-obo:BTO_0000341 rdfs:subClassOf bae:BrendaTissues . # diaphragm
-obo:BTO_0000342 rdfs:subClassOf bae:BrendaTissues . # diencephalon
-obo:BTO_0000343 rdfs:subClassOf bae:BrendaTissues . # renal tubule
-obo:BTO_0000344 rdfs:subClassOf bae:BrendaTissues . # stratum corneum
-obo:BTO_0000345 rdfs:subClassOf bae:BrendaTissues . # digestive gland
-obo:BTO_0000347 rdfs:subClassOf bae:BrendaTissues . # reticulum
-obo:BTO_0000348 rdfs:subClassOf bae:BrendaTissues . # omasum
-obo:BTO_0000349 rdfs:subClassOf bae:BrendaTissues . # gut cavity
-obo:BTO_0000351 rdfs:subClassOf bae:BrendaTissues . # disc
-obo:BTO_0000357 rdfs:subClassOf bae:BrendaTissues . # nectary
-obo:BTO_0000359 rdfs:subClassOf bae:BrendaTissues . # middle cervical ganglion
-obo:BTO_0000361 rdfs:subClassOf bae:BrendaTissues . # stratum granulosum
-obo:BTO_0000364 rdfs:subClassOf bae:BrendaTissues . # stratum lucidum
-obo:BTO_0000365 rdfs:subClassOf bae:BrendaTissues . # duodenum
-obo:BTO_0000366 rdfs:subClassOf bae:BrendaTissues . # duodenal juice
-obo:BTO_0000367 rdfs:subClassOf bae:BrendaTissues . # duodenal mucosa
-obo:BTO_0000368 rdfs:subClassOf bae:BrendaTissues . # ear
-obo:BTO_0000369 rdfs:subClassOf bae:BrendaTissues . # egg
-obo:BTO_0000370 rdfs:subClassOf bae:BrendaTissues . # egg white
-obo:BTO_0000371 rdfs:subClassOf bae:BrendaTissues . # egg yolk
-obo:BTO_0000376 rdfs:subClassOf bae:BrendaTissues . # electric organ
-obo:BTO_0000377 rdfs:subClassOf bae:BrendaTissues . # elementary body
-obo:BTO_0000378 rdfs:subClassOf bae:BrendaTissues . # elytron
-obo:BTO_0000379 rdfs:subClassOf bae:BrendaTissues . # embryo
-obo:BTO_0000380 rdfs:subClassOf bae:BrendaTissues . # embryonic axis
-obo:BTO_0000381 rdfs:subClassOf bae:BrendaTissues . # embryonic blood
-obo:BTO_0000387 rdfs:subClassOf bae:BrendaTissues . # endocardium
-obo:BTO_0000388 rdfs:subClassOf bae:BrendaTissues . # endodermis
-obo:BTO_0000389 rdfs:subClassOf bae:BrendaTissues . # mature ovarian follicle
-obo:BTO_0000390 rdfs:subClassOf bae:BrendaTissues . # endosperm
-obo:BTO_0000393 rdfs:subClassOf bae:BrendaTissues . # endothelium
-obo:BTO_0000394 rdfs:subClassOf bae:BrendaTissues . # aorta endothelium
-obo:BTO_0000397 rdfs:subClassOf bae:BrendaTissues . # tooth
-obo:BTO_0000398 rdfs:subClassOf bae:BrendaTissues . # enterocyte
-obo:BTO_0000399 rdfs:subClassOf bae:BrendaTissues . # eosinophil
-obo:BTO_0000401 rdfs:subClassOf bae:BrendaTissues . # ependymal epithelium
-obo:BTO_0000402 rdfs:subClassOf bae:BrendaTissues . # epicotyl
-obo:BTO_0000404 rdfs:subClassOf bae:BrendaTissues . # epidermis
-obo:BTO_0000405 rdfs:subClassOf bae:BrendaTissues . # penis
-obo:BTO_0000408 rdfs:subClassOf bae:BrendaTissues . # epididymis
-obo:BTO_0000409 rdfs:subClassOf bae:BrendaTissues . # epimastigote
-obo:BTO_0000410 rdfs:subClassOf bae:BrendaTissues . # immature ovarian follicle
-obo:BTO_0000411 rdfs:subClassOf bae:BrendaTissues . # cervical mucosa
-obo:BTO_0000412 rdfs:subClassOf bae:BrendaTissues . # epiphyseal growth plate
-obo:BTO_0000413 rdfs:subClassOf bae:BrendaTissues . # epiphysis
-obo:BTO_0000416 rdfs:subClassOf bae:BrendaTissues . # epithelium
-obo:BTO_0000417 rdfs:subClassOf bae:BrendaTissues . # bile duct epithelium
-obo:BTO_0000418 rdfs:subClassOf bae:BrendaTissues . # neostriatum
-obo:BTO_0000419 rdfs:subClassOf bae:BrendaTissues . # respiratory epithelium
-obo:BTO_0000420 rdfs:subClassOf bae:BrendaTissues . # neck
-obo:BTO_0000421 rdfs:subClassOf bae:BrendaTissues . # connective tissue
-obo:BTO_0000422 rdfs:subClassOf bae:BrendaTissues . # vaginal epithelium
-obo:BTO_0000424 rdfs:subClassOf bae:BrendaTissues . # erythrocyte
-obo:BTO_0000425 rdfs:subClassOf bae:BrendaTissues . # erythrocytic stage
-obo:BTO_0000431 rdfs:subClassOf bae:BrendaTissues . # excretory gland
-obo:BTO_0000432 rdfs:subClassOf bae:BrendaTissues . # corpus cardiacum
-obo:BTO_0000434 rdfs:subClassOf bae:BrendaTissues . # exocrine pancreas
-obo:BTO_0000435 rdfs:subClassOf bae:BrendaTissues . # stratum spinosum
-obo:BTO_0000436 rdfs:subClassOf bae:BrendaTissues . # extensor digitorum longus
-obo:BTO_0000438 rdfs:subClassOf bae:BrendaTissues . # stratum germinativum
-obo:BTO_0000439 rdfs:subClassOf bae:BrendaTissues . # eye
-obo:BTO_0000442 rdfs:subClassOf bae:BrendaTissues . # fat body
-obo:BTO_0000443 rdfs:subClassOf bae:BrendaTissues . # adipocyte
-obo:BTO_0000445 rdfs:subClassOf bae:BrendaTissues . # cerebral lobe
-obo:BTO_0000447 rdfs:subClassOf bae:BrendaTissues . # feather
-obo:BTO_0000449 rdfs:subClassOf bae:BrendaTissues . # fetus
-obo:BTO_0000450 rdfs:subClassOf bae:BrendaTissues . # fiber
-obo:BTO_0000452 rdfs:subClassOf bae:BrendaTissues . # fibroblast
-obo:BTO_0000463 rdfs:subClassOf bae:BrendaTissues . # filament
-obo:BTO_0000464 rdfs:subClassOf bae:BrendaTissues . # flagellate
-obo:BTO_0000465 rdfs:subClassOf bae:BrendaTissues . # flavedo
-obo:BTO_0000466 rdfs:subClassOf bae:BrendaTissues . # flexor digitorum longus
-obo:BTO_0000467 rdfs:subClassOf bae:BrendaTissues . # flight muscle
-obo:BTO_0000468 rdfs:subClassOf bae:BrendaTissues . # floret
-obo:BTO_0000469 rdfs:subClassOf bae:BrendaTissues . # flower
-obo:BTO_0000470 rdfs:subClassOf bae:BrendaTissues . # flower bud
-obo:BTO_0000473 rdfs:subClassOf bae:BrendaTissues . # fetal membrane
-obo:BTO_0000474 rdfs:subClassOf bae:BrendaTissues . # allantois
-obo:BTO_0000475 rdfs:subClassOf bae:BrendaTissues . # ovarian follicle
-obo:BTO_0000476 rdfs:subClassOf bae:BrendaTissues . # foot
-obo:BTO_0000477 rdfs:subClassOf bae:BrendaTissues . # foot muscle
-obo:BTO_0000478 rdfs:subClassOf bae:BrendaTissues . # forebrain
-obo:BTO_0000479 rdfs:subClassOf bae:BrendaTissues . # forelimb muscle
-obo:BTO_0000482 rdfs:subClassOf bae:BrendaTissues . # renal distal tubule
-obo:BTO_0000483 rdfs:subClassOf bae:BrendaTissues . # frond
-obo:BTO_0000484 rdfs:subClassOf bae:BrendaTissues . # frontal lobe
-obo:BTO_0000486 rdfs:subClassOf bae:BrendaTissues . # fruit
-obo:BTO_0000487 rdfs:subClassOf bae:BrendaTissues . # fruit body
-obo:BTO_0000488 rdfs:subClassOf bae:BrendaTissues . # lower epidermis
-obo:BTO_0000493 rdfs:subClassOf bae:BrendaTissues . # gall bladder
-obo:BTO_0000494 rdfs:subClassOf bae:BrendaTissues . # germinal disc
-obo:BTO_0000495 rdfs:subClassOf bae:BrendaTissues . # gametophyte
-obo:BTO_0000496 rdfs:subClassOf bae:BrendaTissues . # anterior lobe
-obo:BTO_0000497 rdfs:subClassOf bae:BrendaTissues . # ganglion
-obo:BTO_0000500 rdfs:subClassOf bae:BrendaTissues . # gastric epithelium
-obo:BTO_0000501 rdfs:subClassOf bae:BrendaTissues . # gastric juice
-obo:BTO_0000503 rdfs:subClassOf bae:BrendaTissues . # gastric gland
-obo:BTO_0000504 rdfs:subClassOf bae:BrendaTissues . # pancreatic juice
-obo:BTO_0000506 rdfs:subClassOf bae:BrendaTissues . # gastrocnemius
-obo:BTO_0000507 rdfs:subClassOf bae:BrendaTissues . # foregut
-obo:BTO_0000509 rdfs:subClassOf bae:BrendaTissues . # gastrodermis
-obo:BTO_0000510 rdfs:subClassOf bae:BrendaTissues . # hindgut
-obo:BTO_0000511 rdfs:subClassOf bae:BrendaTissues . # gastrointestinal tract
-obo:BTO_0000512 rdfs:subClassOf bae:BrendaTissues . # primary oocyte
-obo:BTO_0000514 rdfs:subClassOf bae:BrendaTissues . # germ
-obo:BTO_0000516 rdfs:subClassOf bae:BrendaTissues . # ghost
-obo:BTO_0000518 rdfs:subClassOf bae:BrendaTissues . # gill
-obo:BTO_0000519 rdfs:subClassOf bae:BrendaTissues . # gingiva
-obo:BTO_0000520 rdfs:subClassOf bae:BrendaTissues . # gizzard
-obo:BTO_0000524 rdfs:subClassOf bae:BrendaTissues . # glia
-obo:BTO_0000530 rdfs:subClassOf bae:BrendaTissues . # renal glomerulus
-obo:BTO_0000531 rdfs:subClassOf bae:BrendaTissues . # gluteal muscle
-obo:BTO_0000534 rdfs:subClassOf bae:BrendaTissues . # gonad
-obo:BTO_0000536 rdfs:subClassOf bae:BrendaTissues . # gracilis muscle
-obo:BTO_0000537 rdfs:subClassOf bae:BrendaTissues . # nectar
-obo:BTO_0000538 rdfs:subClassOf bae:BrendaTissues . # alveolar cell type II
-obo:BTO_0000539 rdfs:subClassOf bae:BrendaTissues . # granulocyte
-obo:BTO_0000545 rdfs:subClassOf bae:BrendaTissues . # gut
-obo:BTO_0000546 rdfs:subClassOf bae:BrendaTissues . # gut mucosa
-obo:BTO_0000547 rdfs:subClassOf bae:BrendaTissues . # gut wall
-obo:BTO_0000553 rdfs:subClassOf bae:BrendaTissues . # peripheral blood
-obo:BTO_0000554 rdfs:subClassOf bae:BrendaTissues . # hair follicle
-obo:BTO_0000555 rdfs:subClassOf bae:BrendaTissues . # hair root
-obo:BTO_0000556 rdfs:subClassOf bae:BrendaTissues . # germ layer
-obo:BTO_0000557 rdfs:subClassOf bae:BrendaTissues . # harderian gland
-obo:BTO_0000558 rdfs:subClassOf bae:BrendaTissues . # hatching gland
-obo:BTO_0000561 rdfs:subClassOf bae:BrendaTissues . # posterior lobe
-obo:BTO_0000562 rdfs:subClassOf bae:BrendaTissues . # heart
-obo:BTO_0000564 rdfs:subClassOf bae:BrendaTissues . # heart valve
-obo:BTO_0000569 rdfs:subClassOf bae:BrendaTissues . # exoerythrocytic stage
-obo:BTO_0000570 rdfs:subClassOf bae:BrendaTissues . # hematopoietic system
-obo:BTO_0000571 rdfs:subClassOf bae:BrendaTissues . # hemocyte
-obo:BTO_0000572 rdfs:subClassOf bae:BrendaTissues . # hemolymph
-obo:BTO_0000573 rdfs:subClassOf bae:BrendaTissues . # artery
-obo:BTO_0000575 rdfs:subClassOf bae:BrendaTissues . # hepatocyte
-obo:BTO_0000589 rdfs:subClassOf bae:BrendaTissues . # primary meristem
-obo:BTO_0000597 rdfs:subClassOf bae:BrendaTissues . # hepatopancreas
-obo:BTO_0000601 rdfs:subClassOf bae:BrendaTissues . # hippocampus
-obo:BTO_0000602 rdfs:subClassOf bae:BrendaTissues . # histiocyte
-obo:BTO_0000605 rdfs:subClassOf bae:BrendaTissues . # honey
-obo:BTO_0000609 rdfs:subClassOf bae:BrendaTissues . # husk
-obo:BTO_0000613 rdfs:subClassOf bae:BrendaTissues . # hypocotyl
-obo:BTO_0000614 rdfs:subClassOf bae:BrendaTissues . # hypothalamus
-obo:BTO_0000615 rdfs:subClassOf bae:BrendaTissues . # corpus callosum
-obo:BTO_0000616 rdfs:subClassOf bae:BrendaTissues . # I-cell
-obo:BTO_0000619 rdfs:subClassOf bae:BrendaTissues . # ileal mucosa
-obo:BTO_0000620 rdfs:subClassOf bae:BrendaTissues . # ileum
-obo:BTO_0000621 rdfs:subClassOf bae:BrendaTissues . # iliopsoas muscle
-obo:BTO_0000628 rdfs:subClassOf bae:BrendaTissues . # inflorescence
-obo:BTO_0000629 rdfs:subClassOf bae:BrendaTissues . # ink
-obo:BTO_0000630 rdfs:subClassOf bae:BrendaTissues . # inner ear
-obo:BTO_0000634 rdfs:subClassOf bae:BrendaTissues . # integument
-obo:BTO_0000635 rdfs:subClassOf bae:BrendaTissues . # yellow bone marrow
-obo:BTO_0000639 rdfs:subClassOf bae:BrendaTissues . # intersegmental muscle
-obo:BTO_0000640 rdfs:subClassOf bae:BrendaTissues . # intestinal gland
-obo:BTO_0000641 rdfs:subClassOf bae:BrendaTissues . # colon descendens
-obo:BTO_0000642 rdfs:subClassOf bae:BrendaTissues . # intestinal mucosa
-obo:BTO_0000643 rdfs:subClassOf bae:BrendaTissues . # intestinal muscle
-obo:BTO_0000644 rdfs:subClassOf bae:BrendaTissues . # intestinal juice
-obo:BTO_0000645 rdfs:subClassOf bae:BrendaTissues . # colon sigmoideum
-obo:BTO_0000646 rdfs:subClassOf bae:BrendaTissues . # left colon
-obo:BTO_0000647 rdfs:subClassOf bae:BrendaTissues . # intestinal wall
-obo:BTO_0000648 rdfs:subClassOf bae:BrendaTissues . # intestine
-obo:BTO_0000649 rdfs:subClassOf bae:BrendaTissues . # right colon
-obo:BTO_0000650 rdfs:subClassOf bae:BrendaTissues . # endocrine pancreas
-obo:BTO_0000651 rdfs:subClassOf bae:BrendaTissues . # small intestine
-obo:BTO_0000653 rdfs:subClassOf bae:BrendaTissues . # iris
-obo:BTO_0000654 rdfs:subClassOf bae:BrendaTissues . # ciliary muscle
-obo:BTO_0000656 rdfs:subClassOf bae:BrendaTissues . # iris sphincter muscle
-obo:BTO_0000657 rdfs:subClassOf bae:BrendaTissues . # jejunum
-obo:BTO_0000659 rdfs:subClassOf bae:BrendaTissues . # juice
-obo:BTO_0000662 rdfs:subClassOf bae:BrendaTissues . # nasopharynx
-obo:BTO_0000667 rdfs:subClassOf bae:BrendaTissues . # keratinocyte
-obo:BTO_0000668 rdfs:subClassOf bae:BrendaTissues . # kernel
-obo:BTO_0000671 rdfs:subClassOf bae:BrendaTissues . # kidney
-obo:BTO_0000672 rdfs:subClassOf bae:BrendaTissues . # hindbrain
-obo:BTO_0000673 rdfs:subClassOf bae:BrendaTissues . # metencephalon
-obo:BTO_0000703 rdfs:subClassOf bae:BrendaTissues . # lacquer
-obo:BTO_0000706 rdfs:subClassOf bae:BrendaTissues . # large intestine
-obo:BTO_0000707 rdfs:subClassOf bae:BrendaTissues . # larva
-obo:BTO_0000708 rdfs:subClassOf bae:BrendaTissues . # larval integument
-obo:BTO_0000709 rdfs:subClassOf bae:BrendaTissues . # secondary spermatocyte
-obo:BTO_0000710 rdfs:subClassOf bae:BrendaTissues . # latex
-obo:BTO_0000712 rdfs:subClassOf bae:BrendaTissues . # laticifer
-obo:BTO_0000713 rdfs:subClassOf bae:BrendaTissues . # leaf
-obo:BTO_0000714 rdfs:subClassOf bae:BrendaTissues . # leaf axil
-obo:BTO_0000715 rdfs:subClassOf bae:BrendaTissues . # leaf base
-obo:BTO_0000717 rdfs:subClassOf bae:BrendaTissues . # pericardium
-obo:BTO_0000718 rdfs:subClassOf bae:BrendaTissues . # leaf epidermis
-obo:BTO_0000719 rdfs:subClassOf bae:BrendaTissues . # leaf lamina
-obo:BTO_0000722 rdfs:subClassOf bae:BrendaTissues . # leg muscle
-obo:BTO_0000723 rdfs:subClassOf bae:BrendaTissues . # lens
-obo:BTO_0000724 rdfs:subClassOf bae:BrendaTissues . # lens fiber
-obo:BTO_0000730 rdfs:subClassOf bae:BrendaTissues . # endocarp
-obo:BTO_0000733 rdfs:subClassOf bae:BrendaTissues . # exocarp
-obo:BTO_0000734 rdfs:subClassOf bae:BrendaTissues . # myelocyte
-obo:BTO_0000735 rdfs:subClassOf bae:BrendaTissues . # sporophyte
-obo:BTO_0000742 rdfs:subClassOf bae:BrendaTissues . # myotome
-obo:BTO_0000747 rdfs:subClassOf bae:BrendaTissues . # sporangiospore
-obo:BTO_0000750 rdfs:subClassOf bae:BrendaTissues . # plant ovary
-obo:BTO_0000751 rdfs:subClassOf bae:BrendaTissues . # leukocyte
-obo:BTO_0000752 rdfs:subClassOf bae:BrendaTissues . # lymph vessel
-obo:BTO_0000753 rdfs:subClassOf bae:BrendaTissues . # lymphoid tissue
-obo:BTO_0000758 rdfs:subClassOf bae:BrendaTissues . # myelencephalon
-obo:BTO_0000759 rdfs:subClassOf bae:BrendaTissues . # liver
-obo:BTO_0000761 rdfs:subClassOf bae:BrendaTissues . # collecting duct
-obo:BTO_0000763 rdfs:subClassOf bae:BrendaTissues . # lung
-obo:BTO_0000764 rdfs:subClassOf bae:BrendaTissues . # lung fibroblast
-obo:BTO_0000765 rdfs:subClassOf bae:BrendaTissues . # exocrine gland
-obo:BTO_0000766 rdfs:subClassOf bae:BrendaTissues . # blood vessel endothelium
-obo:BTO_0000767 rdfs:subClassOf bae:BrendaTissues . # mesenteric lymph node
-obo:BTO_0000768 rdfs:subClassOf bae:BrendaTissues . # infundibulum
-obo:BTO_0000770 rdfs:subClassOf bae:BrendaTissues . # oligodendroglia
-obo:BTO_0000772 rdfs:subClassOf bae:BrendaTissues . # lymphoblast
-obo:BTO_0000775 rdfs:subClassOf bae:BrendaTissues . # lymphocyte
-obo:BTO_0000776 rdfs:subClassOf bae:BrendaTissues . # B-lymphocyte
-obo:BTO_0000777 rdfs:subClassOf bae:BrendaTissues . # adenoid
-obo:BTO_0000778 rdfs:subClassOf bae:BrendaTissues . # pulmonary artery
-obo:BTO_0000780 rdfs:subClassOf bae:BrendaTissues . # alveolar cell type I
-obo:BTO_0000781 rdfs:subClassOf bae:BrendaTissues . # intestinal epithelium
-obo:BTO_0000782 rdfs:subClassOf bae:BrendaTissues . # T-lymphocyte
-obo:BTO_0000784 rdfs:subClassOf bae:BrendaTissues . # lymph node
-obo:BTO_0000800 rdfs:subClassOf bae:BrendaTissues . # endoderm
-obo:BTO_0000801 rdfs:subClassOf bae:BrendaTissues . # macrophage
-obo:BTO_0000802 rdfs:subClassOf bae:BrendaTissues . # alveolar macrophage
-obo:BTO_0000808 rdfs:subClassOf bae:BrendaTissues . # interrenal gland
-obo:BTO_0000810 rdfs:subClassOf bae:BrendaTissues . # malpighian tubule
-obo:BTO_0000817 rdfs:subClassOf bae:BrendaTissues . # mammary gland
-obo:BTO_0000818 rdfs:subClassOf bae:BrendaTissues . # spinal column
-obo:BTO_0000821 rdfs:subClassOf bae:BrendaTissues . # nipple
-obo:BTO_0000823 rdfs:subClassOf bae:BrendaTissues . # cerebral gray matter
-obo:BTO_0000825 rdfs:subClassOf bae:BrendaTissues . # mantle
-obo:BTO_0000826 rdfs:subClassOf bae:BrendaTissues . # mantle cavity
-obo:BTO_0000827 rdfs:subClassOf bae:BrendaTissues . # mantle muscle
-obo:BTO_0000828 rdfs:subClassOf bae:BrendaTissues . # throat
-obo:BTO_0000829 rdfs:subClassOf bae:BrendaTissues . # marrow
-obo:BTO_0000838 rdfs:subClassOf bae:BrendaTissues . # meconium
-obo:BTO_0000839 rdfs:subClassOf bae:BrendaTissues . # mesoderm
-obo:BTO_0000840 rdfs:subClassOf bae:BrendaTissues . # nose
-obo:BTO_0000841 rdfs:subClassOf bae:BrendaTissues . # umbilical artery
-obo:BTO_0000842 rdfs:subClassOf bae:BrendaTissues . # megagametophyte
-obo:BTO_0000843 rdfs:subClassOf bae:BrendaTissues . # megakaryocyte
-obo:BTO_0000847 rdfs:subClassOf bae:BrendaTissues . # melanocyte
-obo:BTO_0000852 rdfs:subClassOf bae:BrendaTissues . # meristem
-obo:BTO_0000854 rdfs:subClassOf bae:BrendaTissues . # zygote
-obo:BTO_0000855 rdfs:subClassOf bae:BrendaTissues . # lymph
-obo:BTO_0000856 rdfs:subClassOf bae:BrendaTissues . # mesocarp
-obo:BTO_0000858 rdfs:subClassOf bae:BrendaTissues . # mesophyll
-obo:BTO_0000859 rdfs:subClassOf bae:BrendaTissues . # metacestode
-obo:BTO_0000862 rdfs:subClassOf bae:BrendaTissues . # heart ventricle
-obo:BTO_0000863 rdfs:subClassOf bae:BrendaTissues . # midgut
-obo:BTO_0000865 rdfs:subClassOf bae:BrendaTissues . # anterior spinal root
-obo:BTO_0000866 rdfs:subClassOf bae:BrendaTissues . # midgut secretion
-obo:BTO_0000867 rdfs:subClassOf bae:BrendaTissues . # tibialis posterior
-obo:BTO_0000868 rdfs:subClassOf bae:BrendaTissues . # milk
-obo:BTO_0000870 rdfs:subClassOf bae:BrendaTissues . # spinal nerve
-obo:BTO_0000874 rdfs:subClassOf bae:BrendaTissues . # molting gland
-obo:BTO_0000876 rdfs:subClassOf bae:BrendaTissues . # monocyte
-obo:BTO_0000879 rdfs:subClassOf bae:BrendaTissues . # lateral ventricle
-obo:BTO_0000883 rdfs:subClassOf bae:BrendaTissues . # spinal root
-obo:BTO_0000884 rdfs:subClassOf bae:BrendaTissues . # molting fluid
-obo:BTO_0000886 rdfs:subClassOf bae:BrendaTissues . # mucosa
-obo:BTO_0000887 rdfs:subClassOf bae:BrendaTissues . # muscle
-obo:BTO_0000888 rdfs:subClassOf bae:BrendaTissues . # muscle fibre
-obo:BTO_0000897 rdfs:subClassOf bae:BrendaTissues . # amnion epithelium
-obo:BTO_0000901 rdfs:subClassOf bae:BrendaTissues . # myocardium
-obo:BTO_0000902 rdfs:subClassOf bae:BrendaTissues . # plant vessel
-obo:BTO_0000903 rdfs:subClassOf bae:BrendaTissues . # atrium
-obo:BTO_0000907 rdfs:subClassOf bae:BrendaTissues . # myometrium
-obo:BTO_0000912 rdfs:subClassOf bae:BrendaTissues . # nasal mucosa
-obo:BTO_0000913 rdfs:subClassOf bae:BrendaTissues . # nasal polyp
-obo:BTO_0000915 rdfs:subClassOf bae:BrendaTissues . # nauplius
-obo:BTO_0000917 rdfs:subClassOf bae:BrendaTissues . # needle
-obo:BTO_0000920 rdfs:subClassOf bae:BrendaTissues . # neocortex
-obo:BTO_0000923 rdfs:subClassOf bae:BrendaTissues . # nephridium
-obo:BTO_0000924 rdfs:subClassOf bae:BrendaTissues . # nephron
-obo:BTO_0000925 rdfs:subClassOf bae:BrendaTissues . # nerve
-obo:BTO_0000926 rdfs:subClassOf bae:BrendaTissues . # ophthalmic nerve
-obo:BTO_0000927 rdfs:subClassOf bae:BrendaTissues . # nerve trunk
-obo:BTO_0000928 rdfs:subClassOf bae:BrendaTissues . # limbic system
-obo:BTO_0000929 rdfs:subClassOf bae:BrendaTissues . # neural retina
-obo:BTO_0000930 rdfs:subClassOf bae:BrendaTissues . # neuroblast
-obo:BTO_0000937 rdfs:subClassOf bae:BrendaTissues . # neurohypophysis
-obo:BTO_0000938 rdfs:subClassOf bae:BrendaTissues . # neuron
-obo:BTO_0000952 rdfs:subClassOf bae:BrendaTissues . # nuchal ligament
-obo:BTO_0000954 rdfs:subClassOf bae:BrendaTissues . # nymph
-obo:BTO_0000956 rdfs:subClassOf bae:BrendaTissues . # gut epithelium
-obo:BTO_0000957 rdfs:subClassOf bae:BrendaTissues . # nape
-obo:BTO_0000958 rdfs:subClassOf bae:BrendaTissues . # spermatogonium
-obo:BTO_0000959 rdfs:subClassOf bae:BrendaTissues . # esophagus
-obo:BTO_0000961 rdfs:subClassOf bae:BrendaTissues . # olfactory bulb
-obo:BTO_0000962 rdfs:subClassOf bae:BrendaTissues . # oligodendrocyte
-obo:BTO_0000964 rdfs:subClassOf bae:BrendaTissues . # oocyte
-obo:BTO_0000965 rdfs:subClassOf bae:BrendaTissues . # optic lobe
-obo:BTO_0000966 rdfs:subClassOf bae:BrendaTissues . # optic nerve
-obo:BTO_0000967 rdfs:subClassOf bae:BrendaTissues . # osseous plate
-obo:BTO_0000968 rdfs:subClassOf bae:BrendaTissues . # osteoclast
-obo:BTO_0000973 rdfs:subClassOf bae:BrendaTissues . # respiratory mucosa
-obo:BTO_0000975 rdfs:subClassOf bae:BrendaTissues . # ovary
-obo:BTO_0000980 rdfs:subClassOf bae:BrendaTissues . # oviduct
-obo:BTO_0000981 rdfs:subClassOf bae:BrendaTissues . # ovotestis
-obo:BTO_0000987 rdfs:subClassOf bae:BrendaTissues . # palisade parenchyma
-obo:BTO_0000988 rdfs:subClassOf bae:BrendaTissues . # pancreas
-obo:BTO_0000989 rdfs:subClassOf bae:BrendaTissues . # taste bud
-obo:BTO_0000991 rdfs:subClassOf bae:BrendaTissues . # pancreatic islet
-obo:BTO_0000992 rdfs:subClassOf bae:BrendaTissues . # tongue epithelium
-obo:BTO_0000995 rdfs:subClassOf bae:BrendaTissues . # paramyeloblast
-obo:BTO_0000996 rdfs:subClassOf bae:BrendaTissues . # gametocyte
-obo:BTO_0000997 rdfs:subClassOf bae:BrendaTissues . # parathyroid gland
-obo:BTO_0000999 rdfs:subClassOf bae:BrendaTissues . # plant parenchyma
-obo:BTO_0001001 rdfs:subClassOf bae:BrendaTissues . # parietal lobe
-obo:BTO_0001002 rdfs:subClassOf bae:BrendaTissues . # schizont
-obo:BTO_0001004 rdfs:subClassOf bae:BrendaTissues . # parotid gland
-obo:BTO_0001006 rdfs:subClassOf bae:BrendaTissues . # pelvis
-obo:BTO_0001010 rdfs:subClassOf bae:BrendaTissues . # callus
-obo:BTO_0001012 rdfs:subClassOf bae:BrendaTissues . # pedal ganglion
-obo:BTO_0001016 rdfs:subClassOf bae:BrendaTissues . # pericardial fluid
-obo:BTO_0001017 rdfs:subClassOf bae:BrendaTissues . # pericarp
-obo:BTO_0001020 rdfs:subClassOf bae:BrendaTissues . # periodontal ligament
-obo:BTO_0001022 rdfs:subClassOf bae:BrendaTissues . # periosteum
-obo:BTO_0001024 rdfs:subClassOf bae:BrendaTissues . # retinal rod
-obo:BTO_0001027 rdfs:subClassOf bae:BrendaTissues . # peripheral nerve
-obo:BTO_0001028 rdfs:subClassOf bae:BrendaTissues . # peripheral nervous system
-obo:BTO_0001029 rdfs:subClassOf bae:BrendaTissues . # perisperm
-obo:BTO_0001031 rdfs:subClassOf bae:BrendaTissues . # peritoneal fluid
-obo:BTO_0001036 rdfs:subClassOf bae:BrendaTissues . # retinal cone
-obo:BTO_0001038 rdfs:subClassOf bae:BrendaTissues . # peritrophic membrane
-obo:BTO_0001040 rdfs:subClassOf bae:BrendaTissues . # petal
-obo:BTO_0001041 rdfs:subClassOf bae:BrendaTissues . # petiole
-obo:BTO_0001042 rdfs:subClassOf bae:BrendaTissues . # amygdala
-obo:BTO_0001043 rdfs:subClassOf bae:BrendaTissues . # adult
-obo:BTO_0001044 rdfs:subClassOf bae:BrendaTissues . # phagocyte
-obo:BTO_0001046 rdfs:subClassOf bae:BrendaTissues . # pharate pupa
-obo:BTO_0001048 rdfs:subClassOf bae:BrendaTissues . # pharyngeal muscle
-obo:BTO_0001049 rdfs:subClassOf bae:BrendaTissues . # pharynx
-obo:BTO_0001057 rdfs:subClassOf bae:BrendaTissues . # neural tube
-obo:BTO_0001058 rdfs:subClassOf bae:BrendaTissues . # phloem
-obo:BTO_0001060 rdfs:subClassOf bae:BrendaTissues . # photoreceptor
-obo:BTO_0001063 rdfs:subClassOf bae:BrendaTissues . # phrenic nerve
-obo:BTO_0001064 rdfs:subClassOf bae:BrendaTissues . # phycobiont
-obo:BTO_0001066 rdfs:subClassOf bae:BrendaTissues . # hippocampal pyramidal layer
-obo:BTO_0001067 rdfs:subClassOf bae:BrendaTissues . # pineal gland
-obo:BTO_0001068 rdfs:subClassOf bae:BrendaTissues . # pinealocyte
-obo:BTO_0001069 rdfs:subClassOf bae:BrendaTissues . # pitcher
-obo:BTO_0001071 rdfs:subClassOf bae:BrendaTissues . # pith
-obo:BTO_0001072 rdfs:subClassOf bae:BrendaTissues . # trigeminal nerve
-obo:BTO_0001073 rdfs:subClassOf bae:BrendaTissues . # hypophysis
-obo:BTO_0001075 rdfs:subClassOf bae:BrendaTissues . # motor trigeminal nucleus
-obo:BTO_0001078 rdfs:subClassOf bae:BrendaTissues . # placenta
-obo:BTO_0001079 rdfs:subClassOf bae:BrendaTissues . # trophoblast
-obo:BTO_0001084 rdfs:subClassOf bae:BrendaTissues . # plantlet
-obo:BTO_0001085 rdfs:subClassOf bae:BrendaTissues . # vascular system
-obo:BTO_0001090 rdfs:subClassOf bae:BrendaTissues . # mouth
-obo:BTO_0001091 rdfs:subClassOf bae:BrendaTissues . # axenic culture
-obo:BTO_0001097 rdfs:subClassOf bae:BrendaTissues . # pollen
-obo:BTO_0001099 rdfs:subClassOf bae:BrendaTissues . # blastocyst
-obo:BTO_0001101 rdfs:subClassOf bae:BrendaTissues . # pons
-obo:BTO_0001102 rdfs:subClassOf bae:BrendaTissues . # blood vessel
-obo:BTO_0001103 rdfs:subClassOf bae:BrendaTissues . # skeletal muscle
-obo:BTO_0001104 rdfs:subClassOf bae:BrendaTissues . # cranial nerve
-obo:BTO_0001105 rdfs:subClassOf bae:BrendaTissues . # insular cortex
-obo:BTO_0001107 rdfs:subClassOf bae:BrendaTissues . # preadipocyte
-obo:BTO_0001108 rdfs:subClassOf bae:BrendaTissues . # mitral cell layer
-obo:BTO_0001110 rdfs:subClassOf bae:BrendaTissues . # prepupa
-obo:BTO_0001111 rdfs:subClassOf bae:BrendaTissues . # preputial gland
-obo:BTO_0001113 rdfs:subClassOf bae:BrendaTissues . # prepuce
-obo:BTO_0001114 rdfs:subClassOf bae:BrendaTissues . # primary leaf
-obo:BTO_0001115 rdfs:subClassOf bae:BrendaTissues . # primary spermatocyte
-obo:BTO_0001116 rdfs:subClassOf bae:BrendaTissues . # floral primordium
-obo:BTO_0001117 rdfs:subClassOf bae:BrendaTissues . # proboscis
-obo:BTO_0001119 rdfs:subClassOf bae:BrendaTissues . # procambium
-obo:BTO_0001121 rdfs:subClassOf bae:BrendaTissues . # cauline leaf
-obo:BTO_0001122 rdfs:subClassOf bae:BrendaTissues . # procyclic form
-obo:BTO_0001124 rdfs:subClassOf bae:BrendaTissues . # promastigote
-obo:BTO_0001127 rdfs:subClassOf bae:BrendaTissues . # primary culture
-obo:BTO_0001128 rdfs:subClassOf bae:BrendaTissues . # prostasome
-obo:BTO_0001129 rdfs:subClassOf bae:BrendaTissues . # prostate gland
-obo:BTO_0001133 rdfs:subClassOf bae:BrendaTissues . # pre-B-lymphocyte
-obo:BTO_0001134 rdfs:subClassOf bae:BrendaTissues . # protonema
-obo:BTO_0001135 rdfs:subClassOf bae:BrendaTissues . # protoxylem
-obo:BTO_0001136 rdfs:subClassOf bae:BrendaTissues . # proventriculus
-obo:BTO_0001138 rdfs:subClassOf bae:BrendaTissues . # somatic embryo
-obo:BTO_0001140 rdfs:subClassOf bae:BrendaTissues . # psoas
-obo:BTO_0001142 rdfs:subClassOf bae:BrendaTissues . # pulp
-obo:BTO_0001146 rdfs:subClassOf bae:BrendaTissues . # pyloric region
-obo:BTO_0001149 rdfs:subClassOf bae:BrendaTissues . # quadriceps
-obo:BTO_0001152 rdfs:subClassOf bae:BrendaTissues . # radicle
-obo:BTO_0001153 rdfs:subClassOf bae:BrendaTissues . # radular muscle
-obo:BTO_0001156 rdfs:subClassOf bae:BrendaTissues . # node
-obo:BTO_0001157 rdfs:subClassOf bae:BrendaTissues . # rectal gland
-obo:BTO_0001158 rdfs:subClassOf bae:BrendaTissues . # rectum
-obo:BTO_0001160 rdfs:subClassOf bae:BrendaTissues . # red bone marrow
-obo:BTO_0001161 rdfs:subClassOf bae:BrendaTissues . # chorionic villus
-obo:BTO_0001162 rdfs:subClassOf bae:BrendaTissues . # apocrine gland
-obo:BTO_0001164 rdfs:subClassOf bae:BrendaTissues . # megakaryoblast
-obo:BTO_0001165 rdfs:subClassOf bae:BrendaTissues . # renal artery
-obo:BTO_0001166 rdfs:subClassOf bae:BrendaTissues . # renal cortex
-obo:BTO_0001167 rdfs:subClassOf bae:BrendaTissues . # renal medulla
-obo:BTO_0001168 rdfs:subClassOf bae:BrendaTissues . # rennet
-obo:BTO_0001172 rdfs:subClassOf bae:BrendaTissues . # reticulate body
-obo:BTO_0001173 rdfs:subClassOf bae:BrendaTissues . # reticulocyte
-obo:BTO_0001174 rdfs:subClassOf bae:BrendaTissues . # reticuloendothelial system
-obo:BTO_0001175 rdfs:subClassOf bae:BrendaTissues . # retina
-obo:BTO_0001177 rdfs:subClassOf bae:BrendaTissues . # retinal pigment epithelium
-obo:BTO_0001179 rdfs:subClassOf bae:BrendaTissues . # rhizophore
-obo:BTO_0001180 rdfs:subClassOf bae:BrendaTissues . # idioblast
-obo:BTO_0001181 rdfs:subClassOf bae:BrendaTissues . # rhizome
-obo:BTO_0001182 rdfs:subClassOf bae:BrendaTissues . # primary root
-obo:BTO_0001183 rdfs:subClassOf bae:BrendaTissues . # secondary root
-obo:BTO_0001184 rdfs:subClassOf bae:BrendaTissues . # rind
-obo:BTO_0001187 rdfs:subClassOf bae:BrendaTissues . # roe
-obo:BTO_0001188 rdfs:subClassOf bae:BrendaTissues . # root
-obo:BTO_0001190 rdfs:subClassOf bae:BrendaTissues . # root nodule
-obo:BTO_0001191 rdfs:subClassOf bae:BrendaTissues . # root tip
-obo:BTO_0001192 rdfs:subClassOf bae:BrendaTissues . # rootlet
-obo:BTO_0001194 rdfs:subClassOf bae:BrendaTissues . # rumen
-obo:BTO_0001195 rdfs:subClassOf bae:BrendaTissues . # rumen epithelium
-obo:BTO_0001198 rdfs:subClassOf bae:BrendaTissues . # atrial gland
-obo:BTO_0001201 rdfs:subClassOf bae:BrendaTissues . # rosette
-obo:BTO_0001202 rdfs:subClassOf bae:BrendaTissues . # saliva
-obo:BTO_0001203 rdfs:subClassOf bae:BrendaTissues . # salivary gland
-obo:BTO_0001204 rdfs:subClassOf bae:BrendaTissues . # salt gland
-obo:BTO_0001206 rdfs:subClassOf bae:BrendaTissues . # sarcocarp
-obo:BTO_0001208 rdfs:subClassOf bae:BrendaTissues . # larynx
-obo:BTO_0001215 rdfs:subClassOf bae:BrendaTissues . # sartorius
-obo:BTO_0001217 rdfs:subClassOf bae:BrendaTissues . # scape
-obo:BTO_0001218 rdfs:subClassOf bae:BrendaTissues . # scapula
-obo:BTO_0001221 rdfs:subClassOf bae:BrendaTissues . # sciatic nerve
-obo:BTO_0001222 rdfs:subClassOf bae:BrendaTissues . # sclerenchyma
-obo:BTO_0001223 rdfs:subClassOf bae:BrendaTissues . # scutellum
-obo:BTO_0001226 rdfs:subClassOf bae:BrendaTissues . # seed
-obo:BTO_0001227 rdfs:subClassOf bae:BrendaTissues . # seed coat
-obo:BTO_0001228 rdfs:subClassOf bae:BrendaTissues . # seedling
-obo:BTO_0001230 rdfs:subClassOf bae:BrendaTissues . # semen
-obo:BTO_0001231 rdfs:subClassOf bae:BrendaTissues . # trigeminal ganglion
-obo:BTO_0001232 rdfs:subClassOf bae:BrendaTissues . # seminal plasma
-obo:BTO_0001233 rdfs:subClassOf bae:BrendaTissues . # plant embryo
-obo:BTO_0001234 rdfs:subClassOf bae:BrendaTissues . # seminal vesicle
-obo:BTO_0001235 rdfs:subClassOf bae:BrendaTissues . # seminiferous tubule
-obo:BTO_0001236 rdfs:subClassOf bae:BrendaTissues . # semitendinosus
-obo:BTO_0001237 rdfs:subClassOf bae:BrendaTissues . # sensillum
-obo:BTO_0001239 rdfs:subClassOf bae:BrendaTissues . # serum
-obo:BTO_0001241 rdfs:subClassOf bae:BrendaTissues . # shell gland
-obo:BTO_0001243 rdfs:subClassOf bae:BrendaTissues . # shoot
-obo:BTO_0001244 rdfs:subClassOf bae:BrendaTissues . # urinary tract
-obo:BTO_0001246 rdfs:subClassOf bae:BrendaTissues . # flexor digitorum profundus
-obo:BTO_0001247 rdfs:subClassOf bae:BrendaTissues . # sieve tube
-obo:BTO_0001249 rdfs:subClassOf bae:BrendaTissues . # silique
-obo:BTO_0001250 rdfs:subClassOf bae:BrendaTissues . # silk gland
-obo:BTO_0001252 rdfs:subClassOf bae:BrendaTissues . # tibia
-obo:BTO_0001253 rdfs:subClassOf bae:BrendaTissues . # skin
-obo:BTO_0001254 rdfs:subClassOf bae:BrendaTissues . # sweat
-obo:BTO_0001255 rdfs:subClassOf bae:BrendaTissues . # skin fibroblast
-obo:BTO_0001257 rdfs:subClassOf bae:BrendaTissues . # flexor
-obo:BTO_0001259 rdfs:subClassOf bae:BrendaTissues . # small intestine mucosa
-obo:BTO_0001260 rdfs:subClassOf bae:BrendaTissues . # smooth muscle
-obo:BTO_0001261 rdfs:subClassOf bae:BrendaTissues . # abdominal muscle
-obo:BTO_0001262 rdfs:subClassOf bae:BrendaTissues . # soft body part
-obo:BTO_0001264 rdfs:subClassOf bae:BrendaTissues . # spinal ganglion
-obo:BTO_0001265 rdfs:subClassOf bae:BrendaTissues . # soleus
-obo:BTO_0001266 rdfs:subClassOf bae:BrendaTissues . # invertebrate muscular system
-obo:BTO_0001269 rdfs:subClassOf bae:BrendaTissues . # spadix
-obo:BTO_0001270 rdfs:subClassOf bae:BrendaTissues . # spear
-obo:BTO_0001273 rdfs:subClassOf bae:BrendaTissues . # spermatheca
-obo:BTO_0001274 rdfs:subClassOf bae:BrendaTissues . # spermatid
-obo:BTO_0001275 rdfs:subClassOf bae:BrendaTissues . # spermatocyte
-obo:BTO_0001277 rdfs:subClassOf bae:BrendaTissues . # spermatozoon
-obo:BTO_0001278 rdfs:subClassOf bae:BrendaTissues . # spike
-obo:BTO_0001279 rdfs:subClassOf bae:BrendaTissues . # spinal cord
-obo:BTO_0001281 rdfs:subClassOf bae:BrendaTissues . # spleen
-obo:BTO_0001284 rdfs:subClassOf bae:BrendaTissues . # femur
-obo:BTO_0001287 rdfs:subClassOf bae:BrendaTissues . # sporangium
-obo:BTO_0001290 rdfs:subClassOf bae:BrendaTissues . # sporocarp
-obo:BTO_0001292 rdfs:subClassOf bae:BrendaTissues . # sporozoite
-obo:BTO_0001293 rdfs:subClassOf bae:BrendaTissues . # sporulated oocyst
-obo:BTO_0001295 rdfs:subClassOf bae:BrendaTissues . # cranium
-obo:BTO_0001296 rdfs:subClassOf bae:BrendaTissues . # sprout
-obo:BTO_0001297 rdfs:subClassOf bae:BrendaTissues . # sputum
-obo:BTO_0001299 rdfs:subClassOf bae:BrendaTissues . # stele
-obo:BTO_0001300 rdfs:subClassOf bae:BrendaTissues . # stem
-obo:BTO_0001301 rdfs:subClassOf bae:BrendaTissues . # bark
-obo:BTO_0001302 rdfs:subClassOf bae:BrendaTissues . # sternum
-obo:BTO_0001303 rdfs:subClassOf bae:BrendaTissues . # stigma
-obo:BTO_0001304 rdfs:subClassOf bae:BrendaTissues . # stipe
-obo:BTO_0001305 rdfs:subClassOf bae:BrendaTissues . # stipule
-obo:BTO_0001306 rdfs:subClassOf bae:BrendaTissues . # stolon
-obo:BTO_0001307 rdfs:subClassOf bae:BrendaTissues . # stomach
-obo:BTO_0001308 rdfs:subClassOf bae:BrendaTissues . # gastric mucosa
-obo:BTO_0001309 rdfs:subClassOf bae:BrendaTissues . # tuberous root
-obo:BTO_0001310 rdfs:subClassOf bae:BrendaTissues . # storage tissue
-obo:BTO_0001311 rdfs:subClassOf bae:BrendaTissues . # corpus striatum
-obo:BTO_0001312 rdfs:subClassOf bae:BrendaTissues . # adductor magnus
-obo:BTO_0001313 rdfs:subClassOf bae:BrendaTissues . # style
-obo:BTO_0001314 rdfs:subClassOf bae:BrendaTissues . # subcutis
-obo:BTO_0001315 rdfs:subClassOf bae:BrendaTissues . # sublingual gland
-obo:BTO_0001316 rdfs:subClassOf bae:BrendaTissues . # submandibular gland
-obo:BTO_0001317 rdfs:subClassOf bae:BrendaTissues . # glomerular layer
-obo:BTO_0001318 rdfs:subClassOf bae:BrendaTissues . # submandibular ganglion
-obo:BTO_0001319 rdfs:subClassOf bae:BrendaTissues . # external plexiform layer
-obo:BTO_0001320 rdfs:subClassOf bae:BrendaTissues . # internal plexiform layer
-obo:BTO_0001325 rdfs:subClassOf bae:BrendaTissues . # superior cervical ganglion
-obo:BTO_0001327 rdfs:subClassOf bae:BrendaTissues . # granule cell layer
-obo:BTO_0001328 rdfs:subClassOf bae:BrendaTissues . # calvarium
-obo:BTO_0001331 rdfs:subClassOf bae:BrendaTissues . # sweat gland
-obo:BTO_0001335 rdfs:subClassOf bae:BrendaTissues . # syncytiotrophoblast
-obo:BTO_0001336 rdfs:subClassOf bae:BrendaTissues . # synovial fibroblast
-obo:BTO_0001337 rdfs:subClassOf bae:BrendaTissues . # extensor digitorum brevis
-obo:BTO_0001338 rdfs:subClassOf bae:BrendaTissues . # synovial tissue
-obo:BTO_0001339 rdfs:subClassOf bae:BrendaTissues . # synovia
-obo:BTO_0001340 rdfs:subClassOf bae:BrendaTissues . # bronchus
-obo:BTO_0001343 rdfs:subClassOf bae:BrendaTissues . # extensor digitorum communis
-obo:BTO_0001346 rdfs:subClassOf bae:BrendaTissues . # tachyzoite
-obo:BTO_0001347 rdfs:subClassOf bae:BrendaTissues . # tadpole
-obo:BTO_0001348 rdfs:subClassOf bae:BrendaTissues . # tail
-obo:BTO_0001350 rdfs:subClassOf bae:BrendaTissues . # tapetum
-obo:BTO_0001351 rdfs:subClassOf bae:BrendaTissues . # vomeronasal nerve
-obo:BTO_0001353 rdfs:subClassOf bae:BrendaTissues . # telson
-obo:BTO_0001355 rdfs:subClassOf bae:BrendaTissues . # temporal lobe
-obo:BTO_0001356 rdfs:subClassOf bae:BrendaTissues . # tendon
-obo:BTO_0001357 rdfs:subClassOf bae:BrendaTissues . # tentacle
-obo:BTO_0001360 rdfs:subClassOf bae:BrendaTissues . # decidua
-obo:BTO_0001362 rdfs:subClassOf bae:BrendaTissues . # olfactory lobe
-obo:BTO_0001363 rdfs:subClassOf bae:BrendaTissues . # testis
-obo:BTO_0001365 rdfs:subClassOf bae:BrendaTissues . # thalamus
-obo:BTO_0001366 rdfs:subClassOf bae:BrendaTissues . # thallus
-obo:BTO_0001367 rdfs:subClassOf bae:BrendaTissues . # thigh muscle
-obo:BTO_0001368 rdfs:subClassOf bae:BrendaTissues . # thorax
-obo:BTO_0001369 rdfs:subClassOf bae:BrendaTissues . # vertebrate muscular system
-obo:BTO_0001372 rdfs:subClassOf bae:BrendaTissues . # thymocyte
-obo:BTO_0001374 rdfs:subClassOf bae:BrendaTissues . # thymus
-obo:BTO_0001376 rdfs:subClassOf bae:BrendaTissues . # thigh
-obo:BTO_0001379 rdfs:subClassOf bae:BrendaTissues . # thyroid gland
-obo:BTO_0001380 rdfs:subClassOf bae:BrendaTissues . # mesentery
-obo:BTO_0001382 rdfs:subClassOf bae:BrendaTissues . # tibialis anterior
-obo:BTO_0001383 rdfs:subClassOf bae:BrendaTissues . # alveolar bone
-obo:BTO_0001384 rdfs:subClassOf bae:BrendaTissues . # tissue culture
-obo:BTO_0001385 rdfs:subClassOf bae:BrendaTissues . # tongue
-obo:BTO_0001386 rdfs:subClassOf bae:BrendaTissues . # tongue muscle
-obo:BTO_0001387 rdfs:subClassOf bae:BrendaTissues . # tonsil
-obo:BTO_0001388 rdfs:subClassOf bae:BrendaTissues . # trachea
-obo:BTO_0001389 rdfs:subClassOf bae:BrendaTissues . # tracheal epithelium
-obo:BTO_0001391 rdfs:subClassOf bae:BrendaTissues . # tracheal smooth muscle
-obo:BTO_0001393 rdfs:subClassOf bae:BrendaTissues . # mesenchyme
-obo:BTO_0001395 rdfs:subClassOf bae:BrendaTissues . # trichome
-obo:BTO_0001396 rdfs:subClassOf bae:BrendaTissues . # trophosome tissue
-obo:BTO_0001397 rdfs:subClassOf bae:BrendaTissues . # trophozoite
-obo:BTO_0001398 rdfs:subClassOf bae:BrendaTissues . # trypomastigote
-obo:BTO_0001399 rdfs:subClassOf bae:BrendaTissues . # Tay-Sachs disease specific cell type
-obo:BTO_0001400 rdfs:subClassOf bae:BrendaTissues . # tuber
-obo:BTO_0001401 rdfs:subClassOf bae:BrendaTissues . # tuber cortex
-obo:BTO_0001402 rdfs:subClassOf bae:BrendaTissues . # urogenital ridge
-obo:BTO_0001403 rdfs:subClassOf bae:BrendaTissues . # gastrula
-obo:BTO_0001408 rdfs:subClassOf bae:BrendaTissues . # locus ceruleus
-obo:BTO_0001409 rdfs:subClassOf bae:BrendaTissues . # ureter
-obo:BTO_0001411 rdfs:subClassOf bae:BrendaTissues . # twig
-obo:BTO_0001415 rdfs:subClassOf bae:BrendaTissues . # umbilical cord
-obo:BTO_0001418 rdfs:subClassOf bae:BrendaTissues . # urinary bladder
-obo:BTO_0001419 rdfs:subClassOf bae:BrendaTissues . # urine
-obo:BTO_0001420 rdfs:subClassOf bae:BrendaTissues . # uropygial gland
-obo:BTO_0001421 rdfs:subClassOf bae:BrendaTissues . # uterine cervix
-obo:BTO_0001422 rdfs:subClassOf bae:BrendaTissues . # uterine endometrium
-obo:BTO_0001423 rdfs:subClassOf bae:BrendaTissues . # uterine lavage
-obo:BTO_0001424 rdfs:subClassOf bae:BrendaTissues . # uterus
-obo:BTO_0001426 rdfs:subClassOf bae:BrendaTissues . # urethra
-obo:BTO_0001427 rdfs:subClassOf bae:BrendaTissues . # vas deferens
-obo:BTO_0001428 rdfs:subClassOf bae:BrendaTissues . # breast epithelium
-obo:BTO_0001429 rdfs:subClassOf bae:BrendaTissues . # vascular bundle
-obo:BTO_0001431 rdfs:subClassOf bae:BrendaTissues . # vascular smooth muscle
-obo:BTO_0001432 rdfs:subClassOf bae:BrendaTissues . # vascular tissue
-obo:BTO_0001438 rdfs:subClassOf bae:BrendaTissues . # vena cava
-obo:BTO_0001439 rdfs:subClassOf bae:BrendaTissues . # venom
-obo:BTO_0001440 rdfs:subClassOf bae:BrendaTissues . # venom gland
-obo:BTO_0001442 rdfs:subClassOf bae:BrendaTissues . # brain ventricle
-obo:BTO_0001445 rdfs:subClassOf bae:BrendaTissues . # tail bud
-obo:BTO_0001446 rdfs:subClassOf bae:BrendaTissues . # olfactory cortex
-obo:BTO_0001447 rdfs:subClassOf bae:BrendaTissues . # forearm
-obo:BTO_0001448 rdfs:subClassOf bae:BrendaTissues . # visceral hump
-obo:BTO_0001450 rdfs:subClassOf bae:BrendaTissues . # vitelline membrane
-obo:BTO_0001451 rdfs:subClassOf bae:BrendaTissues . # vitreous humor
-obo:BTO_0001452 rdfs:subClassOf bae:BrendaTissues . # nasal nerve
-obo:BTO_0001453 rdfs:subClassOf bae:BrendaTissues . # detrusor
-obo:BTO_0001456 rdfs:subClassOf bae:BrendaTissues . # white adipose tissue
-obo:BTO_0001457 rdfs:subClassOf bae:BrendaTissues . # hip
-obo:BTO_0001458 rdfs:subClassOf bae:BrendaTissues . # apocrine sweat gland
-obo:BTO_0001461 rdfs:subClassOf bae:BrendaTissues . # whole plant
-obo:BTO_0001462 rdfs:subClassOf bae:BrendaTissues . # bladder wall
-obo:BTO_0001463 rdfs:subClassOf bae:BrendaTissues . # wing
-obo:BTO_0001464 rdfs:subClassOf bae:BrendaTissues . # wing disc
-obo:BTO_0001465 rdfs:subClassOf bae:BrendaTissues . # pericycle
-obo:BTO_0001467 rdfs:subClassOf bae:BrendaTissues . # mesocotyl
-obo:BTO_0001468 rdfs:subClassOf bae:BrendaTissues . # xylem
-obo:BTO_0001471 rdfs:subClassOf bae:BrendaTissues . # yolk sac
-obo:BTO_0001472 rdfs:subClassOf bae:BrendaTissues . # peritoneum
-obo:BTO_0001473 rdfs:subClassOf bae:BrendaTissues . # blastomere
-obo:BTO_0001477 rdfs:subClassOf bae:BrendaTissues . # photophore
-obo:BTO_0001484 rdfs:subClassOf bae:BrendaTissues . # nervous system
-obo:BTO_0001485 rdfs:subClassOf bae:BrendaTissues . # muscular system
-obo:BTO_0001486 rdfs:subClassOf bae:BrendaTissues . # skeletal system
-obo:BTO_0001487 rdfs:subClassOf bae:BrendaTissues . # adipose tissue
-obo:BTO_0001488 rdfs:subClassOf bae:BrendaTissues . # endocrine gland
-obo:BTO_0001491 rdfs:subClassOf bae:BrendaTissues . # viscus
-obo:BTO_0001492 rdfs:subClassOf bae:BrendaTissues . # limb
-obo:BTO_0001493 rdfs:subClassOf bae:BrendaTissues . # trunk
-obo:BTO_0001494 rdfs:subClassOf bae:BrendaTissues . # fungus
-obo:BTO_0001495 rdfs:subClassOf bae:BrendaTissues . # plumule
-obo:BTO_0001496 rdfs:subClassOf bae:BrendaTissues . # perivascular astrocyte
-obo:BTO_0001498 rdfs:subClassOf bae:BrendaTissues . # renal proximal tubule
-obo:BTO_0001499 rdfs:subClassOf bae:BrendaTissues . # tear
-obo:BTO_0001500 rdfs:subClassOf bae:BrendaTissues . # tendril
-obo:BTO_0001501 rdfs:subClassOf bae:BrendaTissues . # hair
-obo:BTO_0001502 rdfs:subClassOf bae:BrendaTissues . # hip joint
-obo:BTO_0001504 rdfs:subClassOf bae:BrendaTissues . # blastodisc
-obo:BTO_0001505 rdfs:subClassOf bae:BrendaTissues . # loin
-obo:BTO_0001506 rdfs:subClassOf bae:BrendaTissues . # radula
-obo:BTO_0001508 rdfs:subClassOf bae:BrendaTissues . # morula
-obo:BTO_0001509 rdfs:subClassOf bae:BrendaTissues . # umbilical vein
-obo:BTO_0001511 rdfs:subClassOf bae:BrendaTissues . # tooth germ
-obo:BTO_0001512 rdfs:subClassOf bae:BrendaTissues . # imago
-obo:BTO_0001513 rdfs:subClassOf bae:BrendaTissues . # biliary epithelium
-obo:BTO_0001528 rdfs:subClassOf bae:BrendaTissues . # B-lymphoblast
-obo:BTO_0001539 rdfs:subClassOf bae:BrendaTissues . # parenchyma
-obo:BTO_0001541 rdfs:subClassOf bae:BrendaTissues . # pronephros
-obo:BTO_0001542 rdfs:subClassOf bae:BrendaTissues . # mesonephron
-obo:BTO_0001543 rdfs:subClassOf bae:BrendaTissues . # metanephron
-obo:BTO_0001547 rdfs:subClassOf bae:BrendaTissues . # sepal
-obo:BTO_0001548 rdfs:subClassOf bae:BrendaTissues . # labial gland
-obo:BTO_0001551 rdfs:subClassOf bae:BrendaTissues . # free-living state
-obo:BTO_0001558 rdfs:subClassOf bae:BrendaTissues . # somite
-obo:BTO_0001559 rdfs:subClassOf bae:BrendaTissues . # stamen
-obo:BTO_0001564 rdfs:subClassOf bae:BrendaTissues . # rectus femoris
-obo:BTO_0001571 rdfs:subClassOf bae:BrendaTissues . # erythroblast
-obo:BTO_0001572 rdfs:subClassOf bae:BrendaTissues . # articular cartilage
-obo:BTO_0001578 rdfs:subClassOf bae:BrendaTissues . # esophageal epithelium
-obo:BTO_0001579 rdfs:subClassOf bae:BrendaTissues . # extraocular muscle
-obo:BTO_0001580 rdfs:subClassOf bae:BrendaTissues . # ejaculatory duct
-obo:BTO_0001592 rdfs:subClassOf bae:BrendaTissues . # meniscus
-obo:BTO_0001593 rdfs:subClassOf bae:BrendaTissues . # osteoblast
-obo:BTO_0001597 rdfs:subClassOf bae:BrendaTissues . # sapling
-obo:BTO_0001601 rdfs:subClassOf bae:BrendaTissues . # epicuticle
-obo:BTO_0001602 rdfs:subClassOf bae:BrendaTissues . # exocuticle
-obo:BTO_0001603 rdfs:subClassOf bae:BrendaTissues . # endocuticle
-obo:BTO_0001604 rdfs:subClassOf bae:BrendaTissues . # eyestalk
-obo:BTO_0001605 rdfs:subClassOf bae:BrendaTissues . # reticulum trabeculare
-obo:BTO_0001606 rdfs:subClassOf bae:BrendaTissues . # sclera
-obo:BTO_0001607 rdfs:subClassOf bae:BrendaTissues . # swim bladder
-obo:BTO_0001608 rdfs:subClassOf bae:BrendaTissues . # feather calamus
-obo:BTO_0001613 rdfs:subClassOf bae:BrendaTissues . # colorectum
-obo:BTO_0001624 rdfs:subClassOf bae:BrendaTissues . # femoral artery
-obo:BTO_0001626 rdfs:subClassOf bae:BrendaTissues . # laryngeal muscle
-obo:BTO_0001627 rdfs:subClassOf bae:BrendaTissues . # glottis
-obo:BTO_0001628 rdfs:subClassOf bae:BrendaTissues . # epiglottis
-obo:BTO_0001629 rdfs:subClassOf bae:BrendaTissues . # left ventricle
-obo:BTO_0001630 rdfs:subClassOf bae:BrendaTissues . # right ventricle
-obo:BTO_0001632 rdfs:subClassOf bae:BrendaTissues . # lens cortex
-obo:BTO_0001633 rdfs:subClassOf bae:BrendaTissues . # lens nucleus
-obo:BTO_0001634 rdfs:subClassOf bae:BrendaTissues . # leptomeninx
-obo:BTO_0001635 rdfs:subClassOf bae:BrendaTissues . # pia mater
-obo:BTO_0001636 rdfs:subClassOf bae:BrendaTissues . # arachnoid mater
-obo:BTO_0001638 rdfs:subClassOf bae:BrendaTissues . # blastema
-obo:BTO_0001640 rdfs:subClassOf bae:BrendaTissues . # limb bud
-obo:BTO_0001642 rdfs:subClassOf bae:BrendaTissues . # liver bud
-obo:BTO_0001643 rdfs:subClassOf bae:BrendaTissues . # lung bud
-obo:BTO_0001645 rdfs:subClassOf bae:BrendaTissues . # wing bud
-obo:BTO_0001646 rdfs:subClassOf bae:BrendaTissues . # ureteric bud
-obo:BTO_0001647 rdfs:subClassOf bae:BrendaTissues . # lip
-obo:BTO_0001648 rdfs:subClassOf bae:BrendaTissues . # longissimus
-obo:BTO_0001651 rdfs:subClassOf bae:BrendaTissues . # longissimus thoracis
-obo:BTO_0001652 rdfs:subClassOf bae:BrendaTissues . # sacrospinalis
-obo:BTO_0001653 rdfs:subClassOf bae:BrendaTissues . # lung epithelium
-obo:BTO_0001654 rdfs:subClassOf bae:BrendaTissues . # female cone
-obo:BTO_0001655 rdfs:subClassOf bae:BrendaTissues . # male cone
-obo:BTO_0001656 rdfs:subClassOf bae:BrendaTissues . # nerve cord
-obo:BTO_0001657 rdfs:subClassOf bae:BrendaTissues . # abscission zone
-obo:BTO_0001658 rdfs:subClassOf bae:BrendaTissues . # aerial part
-obo:BTO_0001659 rdfs:subClassOf bae:BrendaTissues . # aerial root
-obo:BTO_0001660 rdfs:subClassOf bae:BrendaTissues . # respiratory smooth muscle
-obo:BTO_0001662 rdfs:subClassOf bae:BrendaTissues . # allantoic fluid
-obo:BTO_0001663 rdfs:subClassOf bae:BrendaTissues . # ameloblast
-obo:BTO_0001679 rdfs:subClassOf bae:BrendaTissues . # Th2-cell
-obo:BTO_0001680 rdfs:subClassOf bae:BrendaTissues . # anus
-obo:BTO_0001681 rdfs:subClassOf bae:BrendaTissues . # anal sac
-obo:BTO_0001682 rdfs:subClassOf bae:BrendaTissues . # byssus
-obo:BTO_0001684 rdfs:subClassOf bae:BrendaTissues . # antler
-obo:BTO_0001685 rdfs:subClassOf bae:BrendaTissues . # aortic smooth muscle
-obo:BTO_0001686 rdfs:subClassOf bae:BrendaTissues . # joint
-obo:BTO_0001687 rdfs:subClassOf bae:BrendaTissues . # asynchronous muscle
-obo:BTO_0001688 rdfs:subClassOf bae:BrendaTissues . # cochlear ganglion
-obo:BTO_0001689 rdfs:subClassOf bae:BrendaTissues . # axillary bud
-obo:BTO_0001691 rdfs:subClassOf bae:BrendaTissues . # spiral organ
-obo:BTO_0001692 rdfs:subClassOf bae:BrendaTissues . # cochlear duct
-obo:BTO_0001693 rdfs:subClassOf bae:BrendaTissues . # modiolus
-obo:BTO_0001694 rdfs:subClassOf bae:BrendaTissues . # urinary bladder epithelium
-obo:BTO_0001695 rdfs:subClassOf bae:BrendaTissues . # blastopore
-obo:BTO_0001696 rdfs:subClassOf bae:BrendaTissues . # archenteron
-obo:BTO_0001697 rdfs:subClassOf bae:BrendaTissues . # olfactory gland
-obo:BTO_0001698 rdfs:subClassOf bae:BrendaTissues . # bulbourethral gland
-obo:BTO_0001699 rdfs:subClassOf bae:BrendaTissues . # bursa of Fabricius
-obo:BTO_0001700 rdfs:subClassOf bae:BrendaTissues . # cancellous bone
-obo:BTO_0001701 rdfs:subClassOf bae:BrendaTissues . # carapace
-obo:BTO_0001702 rdfs:subClassOf bae:BrendaTissues . # left atrium
-obo:BTO_0001703 rdfs:subClassOf bae:BrendaTissues . # right atrium
-obo:BTO_0001704 rdfs:subClassOf bae:BrendaTissues . # twitch muscle
-obo:BTO_0001705 rdfs:subClassOf bae:BrendaTissues . # vallate papilla
-obo:BTO_0001706 rdfs:subClassOf bae:BrendaTissues . # cnidoblast
-obo:BTO_0001707 rdfs:subClassOf bae:BrendaTissues . # coelom
-obo:BTO_0001708 rdfs:subClassOf bae:BrendaTissues . # coelomic fluid
-obo:BTO_0001709 rdfs:subClassOf bae:BrendaTissues . # colonic epithelium
-obo:BTO_0001711 rdfs:subClassOf bae:BrendaTissues . # melanophore
-obo:BTO_0001713 rdfs:subClassOf bae:BrendaTissues . # dorsum
-obo:BTO_0001715 rdfs:subClassOf bae:BrendaTissues . # ectoplacental cone
-obo:BTO_0001716 rdfs:subClassOf bae:BrendaTissues . # eggshell
-obo:BTO_0001718 rdfs:subClassOf bae:BrendaTissues . # embryoid body
-obo:BTO_0001719 rdfs:subClassOf bae:BrendaTissues . # claw
-obo:BTO_0001720 rdfs:subClassOf bae:BrendaTissues . # floor plate
-obo:BTO_0001721 rdfs:subClassOf bae:BrendaTissues . # sternal cartilage
-obo:BTO_0001722 rdfs:subClassOf bae:BrendaTissues . # enamel organ
-obo:BTO_0001724 rdfs:subClassOf bae:BrendaTissues . # ependymocyte
-obo:BTO_0001725 rdfs:subClassOf bae:BrendaTissues . # floral meristem
-obo:BTO_0001726 rdfs:subClassOf bae:BrendaTissues . # inflorescence meristem
-obo:BTO_0001727 rdfs:subClassOf bae:BrendaTissues . # perianth
-obo:BTO_0001728 rdfs:subClassOf bae:BrendaTissues . # tepal
-obo:BTO_0001729 rdfs:subClassOf bae:BrendaTissues . # forelimb
-obo:BTO_0001732 rdfs:subClassOf bae:BrendaTissues . # gastric antrum
-obo:BTO_0001733 rdfs:subClassOf bae:BrendaTissues . # gynoecium
-obo:BTO_0001734 rdfs:subClassOf bae:BrendaTissues . # gut juice
-obo:BTO_0001735 rdfs:subClassOf bae:BrendaTissues . # cardiac Purkinje fiber
-obo:BTO_0001739 rdfs:subClassOf bae:BrendaTissues . # pars tuberalis
-obo:BTO_0001740 rdfs:subClassOf bae:BrendaTissues . # hypopharynx
-obo:BTO_0001741 rdfs:subClassOf bae:BrendaTissues . # incisor
-obo:BTO_0001742 rdfs:subClassOf bae:BrendaTissues . # jejunal mucosa
-obo:BTO_0001743 rdfs:subClassOf bae:BrendaTissues . # jejunal epithelium
-obo:BTO_0001744 rdfs:subClassOf bae:BrendaTissues . # jugular vein
-obo:BTO_0001745 rdfs:subClassOf bae:BrendaTissues . # renal inner medulla
-obo:BTO_0001746 rdfs:subClassOf bae:BrendaTissues . # renal outer medulla
-obo:BTO_0001747 rdfs:subClassOf bae:BrendaTissues . # palpus
-obo:BTO_0001748 rdfs:subClassOf bae:BrendaTissues . # mandible
-obo:BTO_0001749 rdfs:subClassOf bae:BrendaTissues . # jaw
-obo:BTO_0001752 rdfs:subClassOf bae:BrendaTissues . # invertebrate mandible
-obo:BTO_0001753 rdfs:subClassOf bae:BrendaTissues . # mandibular organ
-obo:BTO_0001754 rdfs:subClassOf bae:BrendaTissues . # cheek
-obo:BTO_0001755 rdfs:subClassOf bae:BrendaTissues . # masseter
-obo:BTO_0001758 rdfs:subClassOf bae:BrendaTissues . # ocellus
-obo:BTO_0001759 rdfs:subClassOf bae:BrendaTissues . # molaris
-obo:BTO_0001760 rdfs:subClassOf bae:BrendaTissues . # myotube
-obo:BTO_0001761 rdfs:subClassOf bae:BrendaTissues . # nasal vestibule
-obo:BTO_0001762 rdfs:subClassOf bae:BrendaTissues . # neonate
-obo:BTO_0001763 rdfs:subClassOf bae:BrendaTissues . # neural arch
-obo:BTO_0001764 rdfs:subClassOf bae:BrendaTissues . # neural crest
-obo:BTO_0001765 rdfs:subClassOf bae:BrendaTissues . # neural plate
-obo:BTO_0001766 rdfs:subClassOf bae:BrendaTissues . # neurula
-obo:BTO_0001768 rdfs:subClassOf bae:BrendaTissues . # notochord
-obo:BTO_0001769 rdfs:subClassOf bae:BrendaTissues . # odontoblast
-obo:BTO_0001770 rdfs:subClassOf bae:BrendaTissues . # ciliary epithelium
-obo:BTO_0001772 rdfs:subClassOf bae:BrendaTissues . # olfactory organ
-obo:BTO_0001773 rdfs:subClassOf bae:BrendaTissues . # oocyst
-obo:BTO_0001775 rdfs:subClassOf bae:BrendaTissues . # oral epithelium
-obo:BTO_0001776 rdfs:subClassOf bae:BrendaTissues . # plant ovule
-obo:BTO_0001777 rdfs:subClassOf bae:BrendaTissues . # megasporangium
-obo:BTO_0001778 rdfs:subClassOf bae:BrendaTissues . # microsporangium
-obo:BTO_0001779 rdfs:subClassOf bae:BrendaTissues . # palate
-obo:BTO_0001782 rdfs:subClassOf bae:BrendaTissues . # peritoneal cavity
-obo:BTO_0001783 rdfs:subClassOf bae:BrendaTissues . # pulvinus
-obo:BTO_0001784 rdfs:subClassOf bae:BrendaTissues . # Peyer's gland
-obo:BTO_0001785 rdfs:subClassOf bae:BrendaTissues . # branchial arch
-obo:BTO_0001786 rdfs:subClassOf bae:BrendaTissues . # pheromone gland
-obo:BTO_0001787 rdfs:subClassOf bae:BrendaTissues . # pars distalis
-obo:BTO_0001788 rdfs:subClassOf bae:BrendaTissues . # pars intermedia
-obo:BTO_0001790 rdfs:subClassOf bae:BrendaTissues . # pleopod
-obo:BTO_0001791 rdfs:subClassOf bae:BrendaTissues . # pleura
-obo:BTO_0001792 rdfs:subClassOf bae:BrendaTissues . # portal vein
-obo:BTO_0001793 rdfs:subClassOf bae:BrendaTissues . # tectum mesencephali
-obo:BTO_0001794 rdfs:subClassOf bae:BrendaTissues . # posterior silk gland
-obo:BTO_0001795 rdfs:subClassOf bae:BrendaTissues . # anterior silk gland
-obo:BTO_0001796 rdfs:subClassOf bae:BrendaTissues . # preoptic area
-obo:BTO_0001798 rdfs:subClassOf bae:BrendaTissues . # prothallium
-obo:BTO_0001799 rdfs:subClassOf bae:BrendaTissues . # pulmonary vein
-obo:BTO_0001805 rdfs:subClassOf bae:BrendaTissues . # saccule
-obo:BTO_0001807 rdfs:subClassOf bae:BrendaTissues . # utricle
-obo:BTO_0001808 rdfs:subClassOf bae:BrendaTissues . # saphenous vein
-obo:BTO_0001809 rdfs:subClassOf bae:BrendaTissues . # scalp
-obo:BTO_0001811 rdfs:subClassOf bae:BrendaTissues . # seminiferous epithelium
-obo:BTO_0001813 rdfs:subClassOf bae:BrendaTissues . # fast twitch muscle fiber
-obo:BTO_0001814 rdfs:subClassOf bae:BrendaTissues . # leaf tip
-obo:BTO_0001815 rdfs:subClassOf bae:BrendaTissues . # stellate ganglion
-obo:BTO_0001816 rdfs:subClassOf bae:BrendaTissues . # stem nodule
-obo:BTO_0001818 rdfs:subClassOf bae:BrendaTissues . # stomach smooth muscle
-obo:BTO_0001819 rdfs:subClassOf bae:BrendaTissues . # stria vascularis
-obo:BTO_0001820 rdfs:subClassOf bae:BrendaTissues . # subcommissural organ
-obo:BTO_0001821 rdfs:subClassOf bae:BrendaTissues . # subesophageal ganglion
-obo:BTO_0001822 rdfs:subClassOf bae:BrendaTissues . # suprachiasmatic nucleus
-obo:BTO_0001823 rdfs:subClassOf bae:BrendaTissues . # synovium
-obo:BTO_0001826 rdfs:subClassOf bae:BrendaTissues . # T-lymphoblast
-obo:BTO_0001827 rdfs:subClassOf bae:BrendaTissues . # tail fin
-obo:BTO_0001828 rdfs:subClassOf bae:BrendaTissues . # tapetum lucidum
-obo:BTO_0001829 rdfs:subClassOf bae:BrendaTissues . # choroid
-obo:BTO_0001830 rdfs:subClassOf bae:BrendaTissues . # tassel
-obo:BTO_0001831 rdfs:subClassOf bae:BrendaTissues . # thoracic ganglion
-obo:BTO_0001832 rdfs:subClassOf bae:BrendaTissues . # sympathetic nervous system
-obo:BTO_0001833 rdfs:subClassOf bae:BrendaTissues . # parasympathetic nervous system
-obo:BTO_0001834 rdfs:subClassOf bae:BrendaTissues . # sympathetic chain
-obo:BTO_0001835 rdfs:subClassOf bae:BrendaTissues . # vertebral ganglion
-obo:BTO_0001836 rdfs:subClassOf bae:BrendaTissues . # thymic epithelium
-obo:BTO_0001837 rdfs:subClassOf bae:BrendaTissues . # serous gland
-obo:BTO_0001838 rdfs:subClassOf bae:BrendaTissues . # tooth bud
-obo:BTO_0001839 rdfs:subClassOf bae:BrendaTissues . # dental papilla
-obo:BTO_0001840 rdfs:subClassOf bae:BrendaTissues . # trophectoderm
-obo:BTO_0001841 rdfs:subClassOf bae:BrendaTissues . # parietal ganglion
-obo:BTO_0001842 rdfs:subClassOf bae:BrendaTissues . # pleural ganglion
-obo:BTO_0001843 rdfs:subClassOf bae:BrendaTissues . # cerebral ganglion
-obo:BTO_0001844 rdfs:subClassOf bae:BrendaTissues . # tooth enamel
-obo:BTO_0001845 rdfs:subClassOf bae:BrendaTissues . # bronchial epithelium
-obo:BTO_0001846 rdfs:subClassOf bae:BrendaTissues . # bronchial mucosa
-obo:BTO_0001847 rdfs:subClassOf bae:BrendaTissues . # umbilical smooth muscle
-obo:BTO_0001848 rdfs:subClassOf bae:BrendaTissues . # urophysis
-obo:BTO_0001849 rdfs:subClassOf bae:BrendaTissues . # urinary bladder smooth muscle
-obo:BTO_0001850 rdfs:subClassOf bae:BrendaTissues . # portio vaginalis cervicis
-obo:BTO_0001852 rdfs:subClassOf bae:BrendaTissues . # cerebrovascular endothelium
-obo:BTO_0001853 rdfs:subClassOf bae:BrendaTissues . # vascular endothelium
-obo:BTO_0001855 rdfs:subClassOf bae:BrendaTissues . # venom duct
-obo:BTO_0001856 rdfs:subClassOf bae:BrendaTissues . # vestibular labyrinth
-obo:BTO_0001857 rdfs:subClassOf bae:BrendaTissues . # visual cortex
-obo:BTO_0001858 rdfs:subClassOf bae:BrendaTissues . # dermal papilla
-obo:BTO_0001859 rdfs:subClassOf bae:BrendaTissues . # wart
-obo:BTO_0001862 rdfs:subClassOf bae:BrendaTissues . # nucleus accumbens
-obo:BTO_0001863 rdfs:subClassOf bae:BrendaTissues . # body wall muscle
-obo:BTO_0001866 rdfs:subClassOf bae:BrendaTissues . # bronchiolar epithelium
-obo:BTO_0001868 rdfs:subClassOf bae:BrendaTissues . # occipital pole
-obo:BTO_0001871 rdfs:subClassOf bae:BrendaTissues . # synganglion
-obo:BTO_0001873 rdfs:subClassOf bae:BrendaTissues . # lens epithelium
-obo:BTO_0001886 rdfs:subClassOf bae:BrendaTissues . # primordium
-obo:BTO_0001887 rdfs:subClassOf bae:BrendaTissues . # heart primordium
-obo:BTO_0001893 rdfs:subClassOf bae:BrendaTissues . # ring stage
-obo:BTO_0001899 rdfs:subClassOf bae:BrendaTissues . # stationary phase culture
-obo:BTO_0001901 rdfs:subClassOf bae:BrendaTissues . # death phase culture
-obo:BTO_0001902 rdfs:subClassOf bae:BrendaTissues . # lag phase culture
-obo:BTO_0001903 rdfs:subClassOf bae:BrendaTissues . # logarithmic phase culture
-obo:BTO_0001905 rdfs:subClassOf bae:BrendaTissues . # tail muscle
-obo:BTO_0001906 rdfs:subClassOf bae:BrendaTissues . # cephalothorax
-obo:BTO_0001919 rdfs:subClassOf bae:BrendaTissues . # tube foot
-obo:BTO_0001921 rdfs:subClassOf bae:BrendaTissues . # compound eye
-obo:BTO_0001922 rdfs:subClassOf bae:BrendaTissues . # ommatidium
-obo:BTO_0001925 rdfs:subClassOf bae:BrendaTissues . # longissimus lumborum
-obo:BTO_0001940 rdfs:subClassOf bae:BrendaTissues . # cardiomyoblast
-obo:BTO_0001942 rdfs:subClassOf bae:BrendaTissues . # mandibular incisor
-obo:BTO_0001943 rdfs:subClassOf bae:BrendaTissues . # corneocyte
-obo:BTO_0001946 rdfs:subClassOf bae:BrendaTissues . # myofibroblast
-obo:BTO_0001953 rdfs:subClassOf bae:BrendaTissues . # tanycyte
-obo:BTO_0001954 rdfs:subClassOf bae:BrendaTissues . # median eminence
-obo:BTO_0001965 rdfs:subClassOf bae:BrendaTissues . # carcass
-obo:BTO_0001978 rdfs:subClassOf bae:BrendaTissues . # anal canal
-obo:BTO_0001979 rdfs:subClassOf bae:BrendaTissues . # mucous gland
-obo:BTO_0001980 rdfs:subClassOf bae:BrendaTissues . # sebaceous gland
-obo:BTO_0001981 rdfs:subClassOf bae:BrendaTissues . # sebum
-obo:BTO_0001982 rdfs:subClassOf bae:BrendaTissues . # chemostat culture
-obo:BTO_0001997 rdfs:subClassOf bae:BrendaTissues . # arteriole
-obo:BTO_0002009 rdfs:subClassOf bae:BrendaTissues . # artery wall
-obo:BTO_0002012 rdfs:subClassOf bae:BrendaTissues . # tunica intima vasorum
-obo:BTO_0002017 rdfs:subClassOf bae:BrendaTissues . # plant reproductive system
-obo:BTO_0002018 rdfs:subClassOf bae:BrendaTissues . # corpus cavernosum clitoridis
-obo:BTO_0002019 rdfs:subClassOf bae:BrendaTissues . # corpus cavernosum penis
-obo:BTO_0002020 rdfs:subClassOf bae:BrendaTissues . # clitoris
-obo:BTO_0002038 rdfs:subClassOf bae:BrendaTissues . # osteocyte
-obo:BTO_0002045 rdfs:subClassOf bae:BrendaTissues . # capillary
-obo:BTO_0002046 rdfs:subClassOf bae:BrendaTissues . # spermatozoid
-obo:BTO_0002051 rdfs:subClassOf bae:BrendaTissues . # preosteoblast
-obo:BTO_0002053 rdfs:subClassOf bae:BrendaTissues . # seminal vesicle fluid
-obo:BTO_0002056 rdfs:subClassOf bae:BrendaTissues . # siphon
-obo:BTO_0002065 rdfs:subClassOf bae:BrendaTissues . # venom apparatus
-obo:BTO_0002066 rdfs:subClassOf bae:BrendaTissues . # venom sac
-obo:BTO_0002067 rdfs:subClassOf bae:BrendaTissues . # stinger
-obo:BTO_0002068 rdfs:subClassOf bae:BrendaTissues . # scent gland
-obo:BTO_0002069 rdfs:subClassOf bae:BrendaTissues . # wax gland
-obo:BTO_0002072 rdfs:subClassOf bae:BrendaTissues . # squamous epithelium
-obo:BTO_0002073 rdfs:subClassOf bae:BrendaTissues . # pavement epithelium
-obo:BTO_0002074 rdfs:subClassOf bae:BrendaTissues . # stratified epithelium
-obo:BTO_0002075 rdfs:subClassOf bae:BrendaTissues . # mesenchymal epithelium
-obo:BTO_0002082 rdfs:subClassOf bae:BrendaTissues . # subdural space
-obo:BTO_0002083 rdfs:subClassOf bae:BrendaTissues . # perilymphatic space
-obo:BTO_0002084 rdfs:subClassOf bae:BrendaTissues . # anterior chamber of the eye
-obo:BTO_0002085 rdfs:subClassOf bae:BrendaTissues . # chamber of the eye
-obo:BTO_0002086 rdfs:subClassOf bae:BrendaTissues . # posterior chamber of the eye
-obo:BTO_0002087 rdfs:subClassOf bae:BrendaTissues . # vitreous chamber of the eye
-obo:BTO_0002096 rdfs:subClassOf bae:BrendaTissues . # nasal cavity
-obo:BTO_0002097 rdfs:subClassOf bae:BrendaTissues . # pharyngeal cavity
-obo:BTO_0002098 rdfs:subClassOf bae:BrendaTissues . # tympanum
-obo:BTO_0002099 rdfs:subClassOf bae:BrendaTissues . # middle ear
-obo:BTO_0002100 rdfs:subClassOf bae:BrendaTissues . # outer ear
-obo:BTO_0002105 rdfs:subClassOf bae:BrendaTissues . # perisympathetic organ
-obo:BTO_0002106 rdfs:subClassOf bae:BrendaTissues . # neurohemal organ
-obo:BTO_0002107 rdfs:subClassOf bae:BrendaTissues . # submucosa
-obo:BTO_0002119 rdfs:subClassOf bae:BrendaTissues . # spikelet
-obo:BTO_0002120 rdfs:subClassOf bae:BrendaTissues . # pyloric cecum
-obo:BTO_0002121 rdfs:subClassOf bae:BrendaTissues . # pyloric stomach
-obo:BTO_0002122 rdfs:subClassOf bae:BrendaTissues . # cardiac stomach
-obo:BTO_0002123 rdfs:subClassOf bae:BrendaTissues . # primitive endoderm
-obo:BTO_0002124 rdfs:subClassOf bae:BrendaTissues . # ampulla
-obo:BTO_0002125 rdfs:subClassOf bae:BrendaTissues . # water vascular system
-obo:BTO_0002149 rdfs:subClassOf bae:BrendaTissues . # gill raker
-obo:BTO_0002150 rdfs:subClassOf bae:BrendaTissues . # gill filament
-obo:BTO_0002152 rdfs:subClassOf bae:BrendaTissues . # gill arch
-obo:BTO_0002155 rdfs:subClassOf bae:BrendaTissues . # ceratobranchial
-obo:BTO_0002156 rdfs:subClassOf bae:BrendaTissues . # hypobranchial
-obo:BTO_0002157 rdfs:subClassOf bae:BrendaTissues . # endochondral bone
-obo:BTO_0002168 rdfs:subClassOf bae:BrendaTissues . # juvenile
-obo:BTO_0002169 rdfs:subClassOf bae:BrendaTissues . # anterior commissure
-obo:BTO_0002173 rdfs:subClassOf bae:BrendaTissues . # tubercle
-obo:BTO_0002191 rdfs:subClassOf bae:BrendaTissues . # fibre tract
-obo:BTO_0002217 rdfs:subClassOf bae:BrendaTissues . # culture supernatant
-obo:BTO_0002222 rdfs:subClassOf bae:BrendaTissues . # bract
-obo:BTO_0002224 rdfs:subClassOf bae:BrendaTissues . # cheek pouch
-obo:BTO_0002233 rdfs:subClassOf bae:BrendaTissues . # culture fluid
-obo:BTO_0002240 rdfs:subClassOf bae:BrendaTissues . # exodermis
-obo:BTO_0002241 rdfs:subClassOf bae:BrendaTissues . # eyelid
-obo:BTO_0002243 rdfs:subClassOf bae:BrendaTissues . # hypanthium
-obo:BTO_0002244 rdfs:subClassOf bae:BrendaTissues . # flower stalk
-obo:BTO_0002246 rdfs:subClassOf bae:BrendaTissues . # globus pallidus
-obo:BTO_0002249 rdfs:subClassOf bae:BrendaTissues . # cervical canal
-obo:BTO_0002250 rdfs:subClassOf bae:BrendaTissues . # nucleus lentiformis
-obo:BTO_0002252 rdfs:subClassOf bae:BrendaTissues . # subthalamic nucleus
-obo:BTO_0002254 rdfs:subClassOf bae:BrendaTissues . # vas efferens
-obo:BTO_0002272 rdfs:subClassOf bae:BrendaTissues . # merozoite
-obo:BTO_0002273 rdfs:subClassOf bae:BrendaTissues . # ileocecum
-obo:BTO_0002275 rdfs:subClassOf bae:BrendaTissues . # lateral hypodermal chord
-obo:BTO_0002277 rdfs:subClassOf bae:BrendaTissues . # melanotroph
-obo:BTO_0002294 rdfs:subClassOf bae:BrendaTissues . # solid substrate culture
-obo:BTO_0002295 rdfs:subClassOf bae:BrendaTissues . # podocyte
-obo:BTO_0002297 rdfs:subClassOf bae:BrendaTissues . # renal glomerular capsule
-obo:BTO_0002298 rdfs:subClassOf bae:BrendaTissues . # inferior olivary complex
-obo:BTO_0002299 rdfs:subClassOf bae:BrendaTissues . # oliva
-obo:BTO_0002302 rdfs:subClassOf bae:BrendaTissues . # inferior mesenteric artery
-obo:BTO_0002303 rdfs:subClassOf bae:BrendaTissues . # superior mesenteric artery
-obo:BTO_0002304 rdfs:subClassOf bae:BrendaTissues . # protoscolex
-obo:BTO_0002305 rdfs:subClassOf bae:BrendaTissues . # scolex
-obo:BTO_0002308 rdfs:subClassOf bae:BrendaTissues . # myoepithelium
-obo:BTO_0002310 rdfs:subClassOf bae:BrendaTissues . # mammary myoepithelium
-obo:BTO_0002317 rdfs:subClassOf bae:BrendaTissues . # slow muscle
-obo:BTO_0002318 rdfs:subClassOf bae:BrendaTissues . # fast muscle
-obo:BTO_0002319 rdfs:subClassOf bae:BrendaTissues . # skeletal muscle fiber
-obo:BTO_0002323 rdfs:subClassOf bae:BrendaTissues . # eccrine sweat gland
-obo:BTO_0002324 rdfs:subClassOf bae:BrendaTissues . # merocrine gland
-obo:BTO_0002325 rdfs:subClassOf bae:BrendaTissues . # holocrine gland
-obo:BTO_0002328 rdfs:subClassOf bae:BrendaTissues . # ventral nerve cord
-obo:BTO_0002329 rdfs:subClassOf bae:BrendaTissues . # dorsal nerve cord
-obo:BTO_0002330 rdfs:subClassOf bae:BrendaTissues . # lamina propria
-obo:BTO_0002340 rdfs:subClassOf bae:BrendaTissues . # plant collar
-obo:BTO_0002342 rdfs:subClassOf bae:BrendaTissues . # bradyzoite
-obo:BTO_0002343 rdfs:subClassOf bae:BrendaTissues . # tarsal bone
-obo:BTO_0002344 rdfs:subClassOf bae:BrendaTissues . # electrocyte
-obo:BTO_0002345 rdfs:subClassOf bae:BrendaTissues . # hindlimb
-obo:BTO_0002346 rdfs:subClassOf bae:BrendaTissues . # fibula
-obo:BTO_0002347 rdfs:subClassOf bae:BrendaTissues . # metatarsal bone
-obo:BTO_0002348 rdfs:subClassOf bae:BrendaTissues . # toe
-obo:BTO_0002349 rdfs:subClassOf bae:BrendaTissues . # hallux
-obo:BTO_0002354 rdfs:subClassOf bae:BrendaTissues . # talus
-obo:BTO_0002355 rdfs:subClassOf bae:BrendaTissues . # calcaneal bone
-obo:BTO_0002356 rdfs:subClassOf bae:BrendaTissues . # navicular bone
-obo:BTO_0002357 rdfs:subClassOf bae:BrendaTissues . # cuboid bone
-obo:BTO_0002360 rdfs:subClassOf bae:BrendaTissues . # medial cuneiform bone
-obo:BTO_0002362 rdfs:subClassOf bae:BrendaTissues . # pancreatic duct
-obo:BTO_0002364 rdfs:subClassOf bae:BrendaTissues . # gastric pit
-obo:BTO_0002366 rdfs:subClassOf bae:BrendaTissues . # extravillous trophoblast
-obo:BTO_0002370 rdfs:subClassOf bae:BrendaTissues . # colleterial gland
-obo:BTO_0002375 rdfs:subClassOf bae:BrendaTissues . # bronchiole
-obo:BTO_0002376 rdfs:subClassOf bae:BrendaTissues . # duodenal gland
-obo:BTO_0002397 rdfs:subClassOf bae:BrendaTissues . # prostate gland epithelium
-obo:BTO_0002407 rdfs:subClassOf bae:BrendaTissues . # spermary
-obo:BTO_0002417 rdfs:subClassOf bae:BrendaTissues . # helper T-lymphocyte
-obo:BTO_0002422 rdfs:subClassOf bae:BrendaTissues . # mesothelium
-obo:BTO_0002433 rdfs:subClassOf bae:BrendaTissues . # genital primordium
-obo:BTO_0002434 rdfs:subClassOf bae:BrendaTissues . # dorsal raphe nucleus
-obo:BTO_0002435 rdfs:subClassOf bae:BrendaTissues . # colorectal mucosa
-obo:BTO_0002436 rdfs:subClassOf bae:BrendaTissues . # myenteric plexus
-obo:BTO_0002437 rdfs:subClassOf bae:BrendaTissues . # enteric plexus
-obo:BTO_0002441 rdfs:subClassOf bae:BrendaTissues . # pericyte
-obo:BTO_0002444 rdfs:subClassOf bae:BrendaTissues . # basal forebrain
-obo:BTO_0002445 rdfs:subClassOf bae:BrendaTissues . # diagonal band
-obo:BTO_0002446 rdfs:subClassOf bae:BrendaTissues . # medial septum
-obo:BTO_0002448 rdfs:subClassOf bae:BrendaTissues . # basal telencephalon
-obo:BTO_0002450 rdfs:subClassOf bae:BrendaTissues . # anterior hypothalamic nucleus
-obo:BTO_0002451 rdfs:subClassOf bae:BrendaTissues . # dorsal hypothalamic nucleus
-obo:BTO_0002452 rdfs:subClassOf bae:BrendaTissues . # thalamic nucleus
-obo:BTO_0002459 rdfs:subClassOf bae:BrendaTissues . # nucleus reuniens
-obo:BTO_0002462 rdfs:subClassOf bae:BrendaTissues . # posterior nuclear complex of thalamus
-obo:BTO_0002473 rdfs:subClassOf bae:BrendaTissues . # infundibular nucleus
-obo:BTO_0002477 rdfs:subClassOf bae:BrendaTissues . # cecal epithelium
-obo:BTO_0002480 rdfs:subClassOf bae:BrendaTissues . # plume
-obo:BTO_0002483 rdfs:subClassOf bae:BrendaTissues . # interventricular septum
-obo:BTO_0002485 rdfs:subClassOf bae:BrendaTissues . # atrial appendage
-obo:BTO_0002486 rdfs:subClassOf bae:BrendaTissues . # lupulin gland
-obo:BTO_0002487 rdfs:subClassOf bae:BrendaTissues . # metacyclic form
-obo:BTO_0002492 rdfs:subClassOf bae:BrendaTissues . # vestimentum
-obo:BTO_0002494 rdfs:subClassOf bae:BrendaTissues . # mesangium
-obo:BTO_0002495 rdfs:subClassOf bae:BrendaTissues . # cerebral gyrus
-obo:BTO_0002501 rdfs:subClassOf bae:BrendaTissues . # trabecula
-obo:BTO_0002502 rdfs:subClassOf bae:BrendaTissues . # kinetoplastid
-obo:BTO_0002503 rdfs:subClassOf bae:BrendaTissues . # protozoan form
-obo:BTO_0002506 rdfs:subClassOf bae:BrendaTissues . # enteric nervous system
-obo:BTO_0002507 rdfs:subClassOf bae:BrendaTissues . # autonomic nervous system
-obo:BTO_0002516 rdfs:subClassOf bae:BrendaTissues . # odontoclast
-obo:BTO_0002525 rdfs:subClassOf bae:BrendaTissues . # cementum
-obo:BTO_0002536 rdfs:subClassOf bae:BrendaTissues . # feather vane
-obo:BTO_0002543 rdfs:subClassOf bae:BrendaTissues . # alveolar wall
-obo:BTO_0002608 rdfs:subClassOf bae:BrendaTissues . # vomeronasal organ
-obo:BTO_0002611 rdfs:subClassOf bae:BrendaTissues . # axopodium
-obo:BTO_0002613 rdfs:subClassOf bae:BrendaTissues . # lobopodium
-obo:BTO_0002614 rdfs:subClassOf bae:BrendaTissues . # reticulopodium
-obo:BTO_0002616 rdfs:subClassOf bae:BrendaTissues . # turion
-obo:BTO_0002617 rdfs:subClassOf bae:BrendaTissues . # thyroid nodule
-obo:BTO_0002619 rdfs:subClassOf bae:BrendaTissues . # posterior adductor muscle
-obo:BTO_0002621 rdfs:subClassOf bae:BrendaTissues . # spinal muscle
-obo:BTO_0002626 rdfs:subClassOf bae:BrendaTissues . # venule
-obo:BTO_0002631 rdfs:subClassOf bae:BrendaTissues . # glume
-obo:BTO_0002643 rdfs:subClassOf bae:BrendaTissues . # cortical collecting duct
-obo:BTO_0002651 rdfs:subClassOf bae:BrendaTissues . # piriform area
-obo:BTO_0002655 rdfs:subClassOf bae:BrendaTissues . # postlarva
-obo:BTO_0002660 rdfs:subClassOf bae:BrendaTissues . # inflorescence stalk
-obo:BTO_0002661 rdfs:subClassOf bae:BrendaTissues . # auditory vesicle
-obo:BTO_0002670 rdfs:subClassOf bae:BrendaTissues . # medial geniculate nucleus
-obo:BTO_0002674 rdfs:subClassOf bae:BrendaTissues . # medial geniculate body
-obo:BTO_0002675 rdfs:subClassOf bae:BrendaTissues . # mushroom body
-obo:BTO_0002678 rdfs:subClassOf bae:BrendaTissues . # testicular vein
-obo:BTO_0002681 rdfs:subClassOf bae:BrendaTissues . # renal vein
-obo:BTO_0002682 rdfs:subClassOf bae:BrendaTissues . # inferior vena cava
-obo:BTO_0002683 rdfs:subClassOf bae:BrendaTissues . # superior vena cava
-obo:BTO_0002684 rdfs:subClassOf bae:BrendaTissues . # lymphoid follicle
-obo:BTO_0002689 rdfs:subClassOf bae:BrendaTissues . # oviductal fluid
-obo:BTO_0002690 rdfs:subClassOf bae:BrendaTissues . # biofilm
-obo:BTO_0002697 rdfs:subClassOf bae:BrendaTissues . # supraoptic nucleus
-obo:BTO_0002698 rdfs:subClassOf bae:BrendaTissues . # bed nucleus of stria terminalis
-obo:BTO_0002699 rdfs:subClassOf bae:BrendaTissues . # lateral habenular nucleus
-obo:BTO_0002702 rdfs:subClassOf bae:BrendaTissues . # medial amygdaloid nucleus
-obo:BTO_0002704 rdfs:subClassOf bae:BrendaTissues . # lateral amygdaloid nucleus
-obo:BTO_0002705 rdfs:subClassOf bae:BrendaTissues . # septal area
-obo:BTO_0002738 rdfs:subClassOf bae:BrendaTissues . # cement gland
-obo:BTO_0002742 rdfs:subClassOf bae:BrendaTissues . # gynecophoral canal
-obo:BTO_0002743 rdfs:subClassOf bae:BrendaTissues . # schistosomulum
-obo:BTO_0002774 rdfs:subClassOf bae:BrendaTissues . # amyloid plaque
-obo:BTO_0002776 rdfs:subClassOf bae:BrendaTissues . # inflorescence apex
-obo:BTO_0002778 rdfs:subClassOf bae:BrendaTissues . # rostral ventrolateral medulla
-obo:BTO_0002780 rdfs:subClassOf bae:BrendaTissues . # visceral muscle
-obo:BTO_0002784 rdfs:subClassOf bae:BrendaTissues . # corpus albicans
-obo:BTO_0002807 rdfs:subClassOf bae:BrendaTissues . # prefrontal cortex
-obo:BTO_0002811 rdfs:subClassOf bae:BrendaTissues . # flag leaf
-obo:BTO_0002819 rdfs:subClassOf bae:BrendaTissues . # decidua basalis
-obo:BTO_0002840 rdfs:subClassOf bae:BrendaTissues . # bile ductule
-obo:BTO_0002841 rdfs:subClassOf bae:BrendaTissues . # bile canaliculus
-obo:BTO_0002845 rdfs:subClassOf bae:BrendaTissues . # mammary duct
-obo:BTO_0002851 rdfs:subClassOf bae:BrendaTissues . # theca interna
-obo:BTO_0002852 rdfs:subClassOf bae:BrendaTissues . # theca externa
-obo:BTO_0002854 rdfs:subClassOf bae:BrendaTissues . # corn silk
-obo:BTO_0002855 rdfs:subClassOf bae:BrendaTissues . # hepatic cecum
-obo:BTO_0002856 rdfs:subClassOf bae:BrendaTissues . # coelomocyte
-obo:BTO_0002857 rdfs:subClassOf bae:BrendaTissues . # eleocyte
-obo:BTO_0002858 rdfs:subClassOf bae:BrendaTissues . # cerebral subcortex
-obo:BTO_0002859 rdfs:subClassOf bae:BrendaTissues . # esophageal mucosa
-obo:BTO_0002860 rdfs:subClassOf bae:BrendaTissues . # oral mucosa
-obo:BTO_0002879 rdfs:subClassOf bae:BrendaTissues . # chorionic plate
-obo:BTO_0002925 rdfs:subClassOf bae:BrendaTissues . # tracheobronchial epithelium
-obo:BTO_0002930 rdfs:subClassOf bae:BrendaTissues . # fascia
-obo:BTO_0002934 rdfs:subClassOf bae:BrendaTissues . # thymic cortex
-obo:BTO_0002977 rdfs:subClassOf bae:BrendaTissues . # exocrine glandular secretion
-obo:BTO_0002978 rdfs:subClassOf bae:BrendaTissues . # internal secretion
-obo:BTO_0002984 rdfs:subClassOf bae:BrendaTissues . # antropyloric mucosa
-obo:BTO_0002990 rdfs:subClassOf bae:BrendaTissues . # gastric ulcer
-obo:BTO_0002991 rdfs:subClassOf bae:BrendaTissues . # glandular epithelium
-obo:BTO_0002994 rdfs:subClassOf bae:BrendaTissues . # lacteal cyst
-obo:BTO_0002996 rdfs:subClassOf bae:BrendaTissues . # cavernous artery
-obo:BTO_0003002 rdfs:subClassOf bae:BrendaTissues . # endocervix
-obo:BTO_0003003 rdfs:subClassOf bae:BrendaTissues . # epididymal fluid
-obo:BTO_0003015 rdfs:subClassOf bae:BrendaTissues . # macula lutea
-obo:BTO_0003048 rdfs:subClassOf bae:BrendaTissues . # neurolemma
-obo:BTO_0003080 rdfs:subClassOf bae:BrendaTissues . # pleural fluid
-obo:BTO_0003082 rdfs:subClassOf bae:BrendaTissues . # uterine epithelium
-obo:BTO_0003083 rdfs:subClassOf bae:BrendaTissues . # uterine wall
-obo:BTO_0003084 rdfs:subClassOf bae:BrendaTissues . # vaginal fluid
-obo:BTO_0003086 rdfs:subClassOf bae:BrendaTissues . # rosette leaf
-obo:BTO_0003087 rdfs:subClassOf bae:BrendaTissues . # subiculum
-obo:BTO_0003090 rdfs:subClassOf bae:BrendaTissues . # subventricular zone
-obo:BTO_0003091 rdfs:subClassOf bae:BrendaTissues . # urogenital system
-obo:BTO_0003092 rdfs:subClassOf bae:BrendaTissues . # urinary system
-obo:BTO_0003093 rdfs:subClassOf bae:BrendaTissues . # cardiofibroblast
-obo:BTO_0003094 rdfs:subClassOf bae:BrendaTissues . # secondary oocyte
-obo:BTO_0003095 rdfs:subClassOf bae:BrendaTissues . # normoblast
-obo:BTO_0003096 rdfs:subClassOf bae:BrendaTissues . # internal male genital organ
-obo:BTO_0003098 rdfs:subClassOf bae:BrendaTissues . # scrotum
-obo:BTO_0003101 rdfs:subClassOf bae:BrendaTissues . # female pudendum
-obo:BTO_0003102 rdfs:subClassOf bae:BrendaTissues . # pyramidal neuron
-obo:BTO_0003104 rdfs:subClassOf bae:BrendaTissues . # pro-B-lymphocyte
-obo:BTO_0003114 rdfs:subClassOf bae:BrendaTissues . # wound fluid
-obo:BTO_0003115 rdfs:subClassOf bae:BrendaTissues . # major vestibular gland
-obo:BTO_0003116 rdfs:subClassOf bae:BrendaTissues . # minor vestibular gland
-obo:BTO_0003118 rdfs:subClassOf bae:BrendaTissues . # glans penis
-obo:BTO_0003120 rdfs:subClassOf bae:BrendaTissues . # atherosclerotic plaque
-obo:BTO_0003121 rdfs:subClassOf bae:BrendaTissues . # villus
-obo:BTO_0003132 rdfs:subClassOf bae:BrendaTissues . # microsporidian
-obo:BTO_0003135 rdfs:subClassOf bae:BrendaTissues . # zona pellucida
-obo:BTO_0003141 rdfs:subClassOf bae:BrendaTissues . # true leaf
-obo:BTO_0003143 rdfs:subClassOf bae:BrendaTissues . # coculture
-obo:BTO_0003144 rdfs:subClassOf bae:BrendaTissues . # neuron-oligodendrocyte coculture
-obo:BTO_0003145 rdfs:subClassOf bae:BrendaTissues . # vestibulum vaginae
-obo:BTO_0003146 rdfs:subClassOf bae:BrendaTissues . # zona incerta
-obo:BTO_0003149 rdfs:subClassOf bae:BrendaTissues . # interalveolar septum
-obo:BTO_0003153 rdfs:subClassOf bae:BrendaTissues . # perineurium
-obo:BTO_0003155 rdfs:subClassOf bae:BrendaTissues . # pleural mesothelium
-obo:BTO_0003156 rdfs:subClassOf bae:BrendaTissues . # peritoneal mesothelium
-obo:BTO_0003163 rdfs:subClassOf bae:BrendaTissues . # prostatic urethra
-obo:BTO_0003164 rdfs:subClassOf bae:BrendaTissues . # cholangiocyte
-obo:BTO_0003168 rdfs:subClassOf bae:BrendaTissues . # cysticercus
-obo:BTO_0003173 rdfs:subClassOf bae:BrendaTissues . # endostyle
-obo:BTO_0003174 rdfs:subClassOf bae:BrendaTissues . # outer plexiform layer
-obo:BTO_0003175 rdfs:subClassOf bae:BrendaTissues . # inner plexiform layer
-obo:BTO_0003176 rdfs:subClassOf bae:BrendaTissues . # inner nuclear layer
-obo:BTO_0003177 rdfs:subClassOf bae:BrendaTissues . # semimembranosus
-obo:BTO_0003178 rdfs:subClassOf bae:BrendaTissues . # biceps
-obo:BTO_0003217 rdfs:subClassOf bae:BrendaTissues . # melanoblast
-obo:BTO_0003222 rdfs:subClassOf bae:BrendaTissues . # respiratory bronchiole
-obo:BTO_0003223 rdfs:subClassOf bae:BrendaTissues . # terminal bronchiole
-obo:BTO_0003248 rdfs:subClassOf bae:BrendaTissues . # brain endothelium
-obo:BTO_0003256 rdfs:subClassOf bae:BrendaTissues . # corpus amylaceum
-obo:BTO_0003257 rdfs:subClassOf bae:BrendaTissues . # granulation tissue
-obo:BTO_0003271 rdfs:subClassOf bae:BrendaTissues . # great saphenous vein
-obo:BTO_0003272 rdfs:subClassOf bae:BrendaTissues . # small saphenous vein
-obo:BTO_0003305 rdfs:subClassOf bae:BrendaTissues . # epipodite
-obo:BTO_0003358 rdfs:subClassOf bae:BrendaTissues . # groin
-obo:BTO_0003359 rdfs:subClassOf bae:BrendaTissues . # neointima
-obo:BTO_0003360 rdfs:subClassOf bae:BrendaTissues . # extraembryonic tissue
-obo:BTO_0003361 rdfs:subClassOf bae:BrendaTissues . # anterior visceral endoderm
-obo:BTO_0003364 rdfs:subClassOf bae:BrendaTissues . # gingival fluid
-obo:BTO_0003365 rdfs:subClassOf bae:BrendaTissues . # germinated grain
-obo:BTO_0003367 rdfs:subClassOf bae:BrendaTissues . # daphnid
-obo:BTO_0003368 rdfs:subClassOf bae:BrendaTissues . # frontal gland
-obo:BTO_0003369 rdfs:subClassOf bae:BrendaTissues . # face
-obo:BTO_0003370 rdfs:subClassOf bae:BrendaTissues . # craniofacial region
-obo:BTO_0003372 rdfs:subClassOf bae:BrendaTissues . # gametophore
-obo:BTO_0003374 rdfs:subClassOf bae:BrendaTissues . # antheridium
-obo:BTO_0003375 rdfs:subClassOf bae:BrendaTissues . # archegonium
-obo:BTO_0003377 rdfs:subClassOf bae:BrendaTissues . # periderm
-obo:BTO_0003378 rdfs:subClassOf bae:BrendaTissues . # phellem
-obo:BTO_0003380 rdfs:subClassOf bae:BrendaTissues . # phelloderm
-obo:BTO_0003381 rdfs:subClassOf bae:BrendaTissues . # vestibular system
-obo:BTO_0003382 rdfs:subClassOf bae:BrendaTissues . # inner ear vestibulum
-obo:BTO_0003383 rdfs:subClassOf bae:BrendaTissues . # semicircular canal
-obo:BTO_0003385 rdfs:subClassOf bae:BrendaTissues . # etiolated plant tissue
-obo:BTO_0003386 rdfs:subClassOf bae:BrendaTissues . # hypoglossal nerve
-obo:BTO_0003387 rdfs:subClassOf bae:BrendaTissues . # raphe nucleus
-obo:BTO_0003388 rdfs:subClassOf bae:BrendaTissues . # tegmentum
-obo:BTO_0003389 rdfs:subClassOf bae:BrendaTissues . # nidopallium
-obo:BTO_0003390 rdfs:subClassOf bae:BrendaTissues . # high vocal center
-obo:BTO_0003391 rdfs:subClassOf bae:BrendaTissues . # hepatic primordium
-obo:BTO_0003394 rdfs:subClassOf bae:BrendaTissues . # Brockmann body
-obo:BTO_0003396 rdfs:subClassOf bae:BrendaTissues . # pontine nucleus
-obo:BTO_0003398 rdfs:subClassOf bae:BrendaTissues . # ganglion cell layer
-obo:BTO_0003399 rdfs:subClassOf bae:BrendaTissues . # avian pallium
-obo:BTO_0003400 rdfs:subClassOf bae:BrendaTissues . # hyperpallium
-obo:BTO_0003401 rdfs:subClassOf bae:BrendaTissues . # subpallium
-obo:BTO_0003405 rdfs:subClassOf bae:BrendaTissues . # mesopallium
-obo:BTO_0003408 rdfs:subClassOf bae:BrendaTissues . # arcopallium
-obo:BTO_0003411 rdfs:subClassOf bae:BrendaTissues . # nucleus isthmo-opticus
-obo:BTO_0003412 rdfs:subClassOf bae:BrendaTissues . # rostral migratory stream
-obo:BTO_0003415 rdfs:subClassOf bae:BrendaTissues . # conjunctiva
-obo:BTO_0003418 rdfs:subClassOf bae:BrendaTissues . # biceps femoris
-obo:BTO_0003419 rdfs:subClassOf bae:BrendaTissues . # biceps brachii
-obo:BTO_0003425 rdfs:subClassOf bae:BrendaTissues . # area postrema
-obo:BTO_0003426 rdfs:subClassOf bae:BrendaTissues . # fourth ventricle
-obo:BTO_0003427 rdfs:subClassOf bae:BrendaTissues . # Barrett's esophagus
-obo:BTO_0003433 rdfs:subClassOf bae:BrendaTissues . # endometrial gland
-obo:BTO_0003434 rdfs:subClassOf bae:BrendaTissues . # choanomastigote
-obo:BTO_0003445 rdfs:subClassOf bae:BrendaTissues . # carotid atherosclerotic plaque
-obo:BTO_0003446 rdfs:subClassOf bae:BrendaTissues . # cholesteatoma tissue
-obo:BTO_0003447 rdfs:subClassOf bae:BrendaTissues . # cavum septum pellucidum
-obo:BTO_0003448 rdfs:subClassOf bae:BrendaTissues . # septum pellucidum
-obo:BTO_0003453 rdfs:subClassOf bae:BrendaTissues . # dentin
-obo:BTO_0003454 rdfs:subClassOf bae:BrendaTissues . # eosinophilic myelocyte
-obo:BTO_0003455 rdfs:subClassOf bae:BrendaTissues . # neutrophilic myelocyte
-obo:BTO_0003462 rdfs:subClassOf bae:BrendaTissues . # outer dental epithelium
-obo:BTO_0003463 rdfs:subClassOf bae:BrendaTissues . # inner dental epithelium
-obo:BTO_0003472 rdfs:subClassOf bae:BrendaTissues . # vagus nerve
-obo:BTO_0003487 rdfs:subClassOf bae:BrendaTissues . # visceral endoderm
-obo:BTO_0003488 rdfs:subClassOf bae:BrendaTissues . # vibrissa
-obo:BTO_0003489 rdfs:subClassOf bae:BrendaTissues . # vibrissal follicle
-obo:BTO_0003490 rdfs:subClassOf bae:BrendaTissues . # vestibulocochlear nerve
-obo:BTO_0003509 rdfs:subClassOf bae:BrendaTissues . # headfoot
-obo:BTO_0003594 rdfs:subClassOf bae:BrendaTissues . # hypnozoite
-obo:BTO_0003595 rdfs:subClassOf bae:BrendaTissues . # knee
-obo:BTO_0003603 rdfs:subClassOf bae:BrendaTissues . # respiratory mucus
-obo:BTO_0003604 rdfs:subClassOf bae:BrendaTissues . # renal parenchyma
-obo:BTO_0003606 rdfs:subClassOf bae:BrendaTissues . # airway fluid
-obo:BTO_0003607 rdfs:subClassOf bae:BrendaTissues . # chondroblast
-obo:BTO_0003616 rdfs:subClassOf bae:BrendaTissues . # peritoneal dialysis fluid
-obo:BTO_0003617 rdfs:subClassOf bae:BrendaTissues . # peritoneal exudate
-obo:BTO_0003623 rdfs:subClassOf bae:BrendaTissues . # uterine fluid
-obo:BTO_0003625 rdfs:subClassOf bae:BrendaTissues . # intervertebral disc
-obo:BTO_0003626 rdfs:subClassOf bae:BrendaTissues . # nucleus pulposus
-obo:BTO_0003627 rdfs:subClassOf bae:BrendaTissues . # annulus fibrosus
-obo:BTO_0003632 rdfs:subClassOf bae:BrendaTissues . # cervicovaginal fluid
-obo:BTO_0003634 rdfs:subClassOf bae:BrendaTissues . # esophageal gland
-obo:BTO_0003647 rdfs:subClassOf bae:BrendaTissues . # olfactory tract
-obo:BTO_0003648 rdfs:subClassOf bae:BrendaTissues . # olfactory nerve
-obo:BTO_0003649 rdfs:subClassOf bae:BrendaTissues . # anterior olfactory nucleus
-obo:BTO_0003650 rdfs:subClassOf bae:BrendaTissues . # optic ganglion
-obo:BTO_0003653 rdfs:subClassOf bae:BrendaTissues . # olfactory glomerulus
-obo:BTO_0003654 rdfs:subClassOf bae:BrendaTissues . # ventricular zone
-obo:BTO_0003655 rdfs:subClassOf bae:BrendaTissues . # thyroid cartilage
-obo:BTO_0003657 rdfs:subClassOf bae:BrendaTissues . # tergal gland
-obo:BTO_0003658 rdfs:subClassOf bae:BrendaTissues . # tergal gland secretion
-obo:BTO_0003660 rdfs:subClassOf bae:BrendaTissues . # laryngeal cartilage
-obo:BTO_0003661 rdfs:subClassOf bae:BrendaTissues . # ovary epithelium
-obo:BTO_0003662 rdfs:subClassOf bae:BrendaTissues . # nucleus recessus lateralis
-obo:BTO_0003668 rdfs:subClassOf bae:BrendaTissues . # leaf bud
-obo:BTO_0003669 rdfs:subClassOf bae:BrendaTissues . # keloid
-obo:BTO_0003670 rdfs:subClassOf bae:BrendaTissues . # microfilarial stage
-obo:BTO_0003671 rdfs:subClassOf bae:BrendaTissues . # germinal center
-obo:BTO_0003673 rdfs:subClassOf bae:BrendaTissues . # nephrotome
-obo:BTO_0003674 rdfs:subClassOf bae:BrendaTissues . # temporomandibular joint
-obo:BTO_0003678 rdfs:subClassOf bae:BrendaTissues . # placental disc
-obo:BTO_0003684 rdfs:subClassOf bae:BrendaTissues . # habenula
-obo:BTO_0003686 rdfs:subClassOf bae:BrendaTissues . # medial habenular nucleus
-obo:BTO_0003698 rdfs:subClassOf bae:BrendaTissues . # coronary atherosclerotic plaque
-obo:BTO_0003702 rdfs:subClassOf bae:BrendaTissues . # rheumatoid arthritis disease specific synovial tissue
-obo:BTO_0003703 rdfs:subClassOf bae:BrendaTissues . # rheumatoid arthritis disease specific fibroblast-like synoviocyte
-obo:BTO_0003705 rdfs:subClassOf bae:BrendaTissues . # cornu ammonis
-obo:BTO_0003717 rdfs:subClassOf bae:BrendaTissues . # vesicular gland
-obo:BTO_0003718 rdfs:subClassOf bae:BrendaTissues . # vasculature
-obo:BTO_0003737 rdfs:subClassOf bae:BrendaTissues . # tailbud stage
-obo:BTO_0003738 rdfs:subClassOf bae:BrendaTissues . # tenia tecta
-obo:BTO_0003747 rdfs:subClassOf bae:BrendaTissues . # superficial temporal artery
-obo:BTO_0003748 rdfs:subClassOf bae:BrendaTissues . # superficial temporal vein
-obo:BTO_0003749 rdfs:subClassOf bae:BrendaTissues . # pars compacta
-obo:BTO_0003750 rdfs:subClassOf bae:BrendaTissues . # pars reticulata
-obo:BTO_0003751 rdfs:subClassOf bae:BrendaTissues . # submucosal gland
-obo:BTO_0003752 rdfs:subClassOf bae:BrendaTissues . # lamina epithelialis mucosa
-obo:BTO_0003785 rdfs:subClassOf bae:BrendaTissues . # ray floret
-obo:BTO_0003787 rdfs:subClassOf bae:BrendaTissues . # intraparietal sulcus
-obo:BTO_0003788 rdfs:subClassOf bae:BrendaTissues . # splenial gyrus
-obo:BTO_0003791 rdfs:subClassOf bae:BrendaTissues . # glandular stomach
-obo:BTO_0003794 rdfs:subClassOf bae:BrendaTissues . # chlorenchyma
-obo:BTO_0003799 rdfs:subClassOf bae:BrendaTissues . # secretory trichome
-obo:BTO_0003801 rdfs:subClassOf bae:BrendaTissues . # ovum
-obo:BTO_0003802 rdfs:subClassOf bae:BrendaTissues . # macrogamete
-obo:BTO_0003805 rdfs:subClassOf bae:BrendaTissues . # alpha-motoneuron
-obo:BTO_0003810 rdfs:subClassOf bae:BrendaTissues . # enrichment culture
-obo:BTO_0003811 rdfs:subClassOf bae:BrendaTissues . # interneuron
-obo:BTO_0003833 rdfs:subClassOf bae:BrendaTissues . # buccal mucosa
-obo:BTO_0003834 rdfs:subClassOf bae:BrendaTissues . # conceptus
-obo:BTO_0003835 rdfs:subClassOf bae:BrendaTissues . # cerebellar nucleus
-obo:BTO_0003840 rdfs:subClassOf bae:BrendaTissues . # cerebrovascular system
-obo:BTO_0003844 rdfs:subClassOf bae:BrendaTissues . # inferior olivary nucleus
-obo:BTO_0003852 rdfs:subClassOf bae:BrendaTissues . # astroglia
-obo:BTO_0003867 rdfs:subClassOf bae:BrendaTissues . # deutocerebrum
-obo:BTO_0003868 rdfs:subClassOf bae:BrendaTissues . # protocerebrum
-obo:BTO_0003869 rdfs:subClassOf bae:BrendaTissues . # tritocerebrum
-obo:BTO_0003870 rdfs:subClassOf bae:BrendaTissues . # insect tracheal system
-obo:BTO_0003876 rdfs:subClassOf bae:BrendaTissues . # plant funiculus
-obo:BTO_0003882 rdfs:subClassOf bae:BrendaTissues . # blastocyte
-obo:BTO_0003906 rdfs:subClassOf bae:BrendaTissues . # uroepithelium
-obo:BTO_0003914 rdfs:subClassOf bae:BrendaTissues . # interstitial cell of Cajal
-obo:BTO_0003915 rdfs:subClassOf bae:BrendaTissues . # hairy root culture
-obo:BTO_0003925 rdfs:subClassOf bae:BrendaTissues . # renal papilla
-obo:BTO_0003926 rdfs:subClassOf bae:BrendaTissues . # renal pyramid
-obo:BTO_0003927 rdfs:subClassOf bae:BrendaTissues . # metacercaria
-obo:BTO_0003938 rdfs:subClassOf bae:BrendaTissues . # leaf disc
-obo:BTO_0003940 rdfs:subClassOf bae:BrendaTissues . # macula densa
-obo:BTO_0003948 rdfs:subClassOf bae:BrendaTissues . # distal tubular epithelium
-obo:BTO_0003951 rdfs:subClassOf bae:BrendaTissues . # medial longitudinal fasciculus
-obo:BTO_0003953 rdfs:subClassOf bae:BrendaTissues . # endomesoderm
-obo:BTO_0003954 rdfs:subClassOf bae:BrendaTissues . # dopaminergic system
-obo:BTO_0003963 rdfs:subClassOf bae:BrendaTissues . # nucleus solitarius
-obo:BTO_0003969 rdfs:subClassOf bae:BrendaTissues . # hair follicle outer root sheath
-obo:BTO_0003971 rdfs:subClassOf bae:BrendaTissues . # hair follicle inner root sheath
-obo:BTO_0003975 rdfs:subClassOf bae:BrendaTissues . # cingulate cortex
-obo:BTO_0003976 rdfs:subClassOf bae:BrendaTissues . # cingulate gyrus
-obo:BTO_0003977 rdfs:subClassOf bae:BrendaTissues . # retrosplenial region
-obo:BTO_0003987 rdfs:subClassOf bae:BrendaTissues . # root culture
-obo:BTO_0003994 rdfs:subClassOf bae:BrendaTissues . # hoof
-obo:BTO_0004014 rdfs:subClassOf bae:BrendaTissues . # embryonic cerebral cortex
-obo:BTO_0004024 rdfs:subClassOf bae:BrendaTissues . # neural cord
-obo:BTO_0004032 rdfs:subClassOf bae:BrendaTissues . # dopaminergic neuron
-obo:BTO_0004033 rdfs:subClassOf bae:BrendaTissues . # catecholaminergic neuron
-obo:BTO_0004041 rdfs:subClassOf bae:BrendaTissues . # abdominal adipose tissue
-obo:BTO_0004042 rdfs:subClassOf bae:BrendaTissues . # subcutaneous adipose tissue
-obo:BTO_0004043 rdfs:subClassOf bae:BrendaTissues . # intramuscular adipose tissue
-obo:BTO_0004045 rdfs:subClassOf bae:BrendaTissues . # air pouch
-obo:BTO_0004046 rdfs:subClassOf bae:BrendaTissues . # alveolar mucosa
-obo:BTO_0004047 rdfs:subClassOf bae:BrendaTissues . # apical hook
-obo:BTO_0004048 rdfs:subClassOf bae:BrendaTissues . # aril
-obo:BTO_0004053 rdfs:subClassOf bae:BrendaTissues . # umbilical cord blood
-obo:BTO_0004057 rdfs:subClassOf bae:BrendaTissues . # fruit juice
-obo:BTO_0004060 rdfs:subClassOf bae:BrendaTissues . # fibroblast-like synoviocyte
-obo:BTO_0004064 rdfs:subClassOf bae:BrendaTissues . # chloragocyte
-obo:BTO_0004074 rdfs:subClassOf bae:BrendaTissues . # cystocyte
-obo:BTO_0004084 rdfs:subClassOf bae:BrendaTissues . # epitrochlearis muscle
-obo:BTO_0004089 rdfs:subClassOf bae:BrendaTissues . # male urethra
-obo:BTO_0004101 rdfs:subClassOf bae:BrendaTissues . # fascicle
-obo:BTO_0004102 rdfs:subClassOf bae:BrendaTissues . # cerebral cortical neuron
-obo:BTO_0004103 rdfs:subClassOf bae:BrendaTissues . # leaf primordium
-obo:BTO_0004104 rdfs:subClassOf bae:BrendaTissues . # insect labium
-obo:BTO_0004107 rdfs:subClassOf bae:BrendaTissues . # antral mucosa
-obo:BTO_0004110 rdfs:subClassOf bae:BrendaTissues . # pyloric mucosa
-obo:BTO_0004128 rdfs:subClassOf bae:BrendaTissues . # lung endothelium
-obo:BTO_0004140 rdfs:subClassOf bae:BrendaTissues . # ethmoid bone
-obo:BTO_0004141 rdfs:subClassOf bae:BrendaTissues . # cribriform plate
-obo:BTO_0004147 rdfs:subClassOf bae:BrendaTissues . # lumbar spine
-obo:BTO_0004148 rdfs:subClassOf bae:BrendaTissues . # cervical spine
-obo:BTO_0004150 rdfs:subClassOf bae:BrendaTissues . # thoracic spine
-obo:BTO_0004165 rdfs:subClassOf bae:BrendaTissues . # meibomian gland
-obo:BTO_0004185 rdfs:subClassOf bae:BrendaTissues . # olfactory receptor neuron
-obo:BTO_0004195 rdfs:subClassOf bae:BrendaTissues . # pharyngeal organ
-obo:BTO_0004198 rdfs:subClassOf bae:BrendaTissues . # prostomium
-obo:BTO_0004209 rdfs:subClassOf bae:BrendaTissues . # seed vessel
-obo:BTO_0004211 rdfs:subClassOf bae:BrendaTissues . # sensillum trichodeum
-obo:BTO_0004212 rdfs:subClassOf bae:BrendaTissues . # seta
-obo:BTO_0004224 rdfs:subClassOf bae:BrendaTissues . # stomodeum
-obo:BTO_0004235 rdfs:subClassOf bae:BrendaTissues . # uterine horn
-obo:BTO_0004241 rdfs:subClassOf bae:BrendaTissues . # ovariole
-obo:BTO_0004242 rdfs:subClassOf bae:BrendaTissues . # vitellarium
-obo:BTO_0004249 rdfs:subClassOf bae:BrendaTissues . # anterior cingulate cortex
-obo:BTO_0004250 rdfs:subClassOf bae:BrendaTissues . # posterior cingulate cortex
-obo:BTO_0004253 rdfs:subClassOf bae:BrendaTissues . # plant candle
-obo:BTO_0004256 rdfs:subClassOf bae:BrendaTissues . # long bone
-obo:BTO_0004271 rdfs:subClassOf bae:BrendaTissues . # hyalocyte
-obo:BTO_0004280 rdfs:subClassOf bae:BrendaTissues . # peptonephridium
-obo:BTO_0004285 rdfs:subClassOf bae:BrendaTissues . # oviductal ampulla
-obo:BTO_0004291 rdfs:subClassOf bae:BrendaTissues . # umbilical vein smooth muscle
-obo:BTO_0004292 rdfs:subClassOf bae:BrendaTissues . # claustrum
-obo:BTO_0004304 rdfs:subClassOf bae:BrendaTissues . # cell lysate
-obo:BTO_0004305 rdfs:subClassOf bae:BrendaTissues . # hairy root
-obo:BTO_0004307 rdfs:subClassOf bae:BrendaTissues . # hepatic artery
-obo:BTO_0004342 rdfs:subClassOf bae:BrendaTissues . # agranular insular cortex
-obo:BTO_0004343 rdfs:subClassOf bae:BrendaTissues . # auditory cortex
-obo:BTO_0004345 rdfs:subClassOf bae:BrendaTissues . # entorhinal cortex
-obo:BTO_0004346 rdfs:subClassOf bae:BrendaTissues . # medial entorhinal cortex
-obo:BTO_0004347 rdfs:subClassOf bae:BrendaTissues . # lateral entorhinal cortex
-obo:BTO_0004348 rdfs:subClassOf bae:BrendaTissues . # motor cortex
-obo:BTO_0004353 rdfs:subClassOf bae:BrendaTissues . # somatosensory cortex
-obo:BTO_0004354 rdfs:subClassOf bae:BrendaTissues . # postcentral gyrus
-obo:BTO_0004355 rdfs:subClassOf bae:BrendaTissues . # perirhinal cortex
-obo:BTO_0004358 rdfs:subClassOf bae:BrendaTissues . # sinus node
-obo:BTO_0004359 rdfs:subClassOf bae:BrendaTissues . # paw
-obo:BTO_0004361 rdfs:subClassOf bae:BrendaTissues . # callus culture
-obo:BTO_0004362 rdfs:subClassOf bae:BrendaTissues . # colon muscle
-obo:BTO_0004364 rdfs:subClassOf bae:BrendaTissues . # gastroesophageal junction
-obo:BTO_0004366 rdfs:subClassOf bae:BrendaTissues . # lateral geniculate nucleus
-obo:BTO_0004367 rdfs:subClassOf bae:BrendaTissues . # lateral geniculate body
-obo:BTO_0004368 rdfs:subClassOf bae:BrendaTissues . # vestibular nucleus
-obo:BTO_0004370 rdfs:subClassOf bae:BrendaTissues . # lateral vestibular nucleus
-obo:BTO_0004371 rdfs:subClassOf bae:BrendaTissues . # medial vestibular nucleus
-obo:BTO_0004372 rdfs:subClassOf bae:BrendaTissues . # superior vestibular nucleus
-obo:BTO_0004373 rdfs:subClassOf bae:BrendaTissues . # ventral posterior nucleus
-obo:BTO_0004377 rdfs:subClassOf bae:BrendaTissues . # pup
-obo:BTO_0004378 rdfs:subClassOf bae:BrendaTissues . # blood vessel wall
-obo:BTO_0004379 rdfs:subClassOf bae:BrendaTissues . # parahippocampal region
-obo:BTO_0004380 rdfs:subClassOf bae:BrendaTissues . # parahippocampal gyrus
-obo:BTO_0004381 rdfs:subClassOf bae:BrendaTissues . # prelimbic cortex
-obo:BTO_0004382 rdfs:subClassOf bae:BrendaTissues . # skin epithelium
-obo:BTO_0004383 rdfs:subClassOf bae:BrendaTissues . # follicular fluid
-obo:BTO_0004385 rdfs:subClassOf bae:BrendaTissues . # cardinal vein
-obo:BTO_0004387 rdfs:subClassOf bae:BrendaTissues . # anterior cardinal vein
-obo:BTO_0004388 rdfs:subClassOf bae:BrendaTissues . # common cardinal vein
-obo:BTO_0004395 rdfs:subClassOf bae:BrendaTissues . # microvessel
-obo:BTO_0004396 rdfs:subClassOf bae:BrendaTissues . # femorotibial joint
-obo:BTO_0004418 rdfs:subClassOf bae:BrendaTissues . # Daltons lymphoma ascites
-obo:BTO_0004419 rdfs:subClassOf bae:BrendaTissues . # dermal fibroblast
-obo:BTO_0004421 rdfs:subClassOf bae:BrendaTissues . # salivary gland epithelium
-obo:BTO_0004422 rdfs:subClassOf bae:BrendaTissues . # pleural cavity
-obo:BTO_0004423 rdfs:subClassOf bae:BrendaTissues . # empyema fluid
-obo:BTO_0004425 rdfs:subClassOf bae:BrendaTissues . # stratum granulosum cerebelli
-obo:BTO_0004477 rdfs:subClassOf bae:BrendaTissues . # medial temporal lobe
-obo:BTO_0004480 rdfs:subClassOf bae:BrendaTissues . # nasopharynx epithelium
-obo:BTO_0004483 rdfs:subClassOf bae:BrendaTissues . # ovarian surface epithelium
-obo:BTO_0004496 rdfs:subClassOf bae:BrendaTissues . # preosteoclast
-obo:BTO_0004502 rdfs:subClassOf bae:BrendaTissues . # vascular cambium
-obo:BTO_0004503 rdfs:subClassOf bae:BrendaTissues . # submerged culture
-obo:BTO_0004518 rdfs:subClassOf bae:BrendaTissues . # uterine gland
-obo:BTO_0004520 rdfs:subClassOf bae:BrendaTissues . # regulatory T-lymphocyte
-obo:BTO_0004524 rdfs:subClassOf bae:BrendaTissues . # germinal epithelium
-obo:BTO_0004525 rdfs:subClassOf bae:BrendaTissues . # subcutaneous tissue
-obo:BTO_0004527 rdfs:subClassOf bae:BrendaTissues . # uterine luminal fluid
-obo:BTO_0004528 rdfs:subClassOf bae:BrendaTissues . # high endothelial venule
-obo:BTO_0004536 rdfs:subClassOf bae:BrendaTissues . # medullary collecting duct
-obo:BTO_0004538 rdfs:subClassOf bae:BrendaTissues . # initial collecting tubule
-obo:BTO_0004539 rdfs:subClassOf bae:BrendaTissues . # connecting tubule
-obo:BTO_0004544 rdfs:subClassOf bae:BrendaTissues . # inner medullary collecting duct
-obo:BTO_0004549 rdfs:subClassOf bae:BrendaTissues . # superficial inguinal lymph node
-obo:BTO_0004554 rdfs:subClassOf bae:BrendaTissues . # parotid gland duct
-obo:BTO_0004556 rdfs:subClassOf bae:BrendaTissues . # submandibular gland duct
-obo:BTO_0004560 rdfs:subClassOf bae:BrendaTissues . # thymic medulla
-obo:BTO_0004565 rdfs:subClassOf bae:BrendaTissues . # thymic medullary epithelium
-obo:BTO_0004569 rdfs:subClassOf bae:BrendaTissues . # ovarian fluid
-obo:BTO_0004570 rdfs:subClassOf bae:BrendaTissues . # ulcer tissue
-obo:BTO_0004579 rdfs:subClassOf bae:BrendaTissues . # parenchyma of thyroid gland
-obo:BTO_0004586 rdfs:subClassOf bae:BrendaTissues . # alevin
-obo:BTO_0004593 rdfs:subClassOf bae:BrendaTissues . # epiblast
-obo:BTO_0004597 rdfs:subClassOf bae:BrendaTissues . # nephrocyte
-obo:BTO_0004608 rdfs:subClassOf bae:BrendaTissues . # Henles loop
-obo:BTO_0004617 rdfs:subClassOf bae:BrendaTissues . # mucilage
-obo:BTO_0004628 rdfs:subClassOf bae:BrendaTissues . # aortic valve
-obo:BTO_0004629 rdfs:subClassOf bae:BrendaTissues . # metaphloem
-obo:BTO_0004630 rdfs:subClassOf bae:BrendaTissues . # middle midgut
-obo:BTO_0004634 rdfs:subClassOf bae:BrendaTissues . # thoracico-abdominal ganglion
-obo:BTO_0004638 rdfs:subClassOf bae:BrendaTissues . # peribronchial gland
-obo:BTO_0004642 rdfs:subClassOf bae:BrendaTissues . # abductor
-obo:BTO_0004650 rdfs:subClassOf bae:BrendaTissues . # dorsal fin
-obo:BTO_0004651 rdfs:subClassOf bae:BrendaTissues . # pelvic fin
-obo:BTO_0004652 rdfs:subClassOf bae:BrendaTissues . # anal fin
-obo:BTO_0004653 rdfs:subClassOf bae:BrendaTissues . # pectoral fin
-obo:BTO_0004657 rdfs:subClassOf bae:BrendaTissues . # premonocyte
-obo:BTO_0004658 rdfs:subClassOf bae:BrendaTissues . # imaginal disc
-obo:BTO_0004659 rdfs:subClassOf bae:BrendaTissues . # exoskeleton
-obo:BTO_0004665 rdfs:subClassOf bae:BrendaTissues . # iliac artery
-obo:BTO_0004666 rdfs:subClassOf bae:BrendaTissues . # external iliac artery
-obo:BTO_0004667 rdfs:subClassOf bae:BrendaTissues . # internal iliac artery
-obo:BTO_0004668 rdfs:subClassOf bae:BrendaTissues . # hand
-obo:BTO_0004669 rdfs:subClassOf bae:BrendaTissues . # finger
-obo:BTO_0004670 rdfs:subClassOf bae:BrendaTissues . # interdigit
-obo:BTO_0004671 rdfs:subClassOf bae:BrendaTissues . # hair medulla
-obo:BTO_0004672 rdfs:subClassOf bae:BrendaTissues . # hair shaft
-obo:BTO_0004673 rdfs:subClassOf bae:BrendaTissues . # dorsal aorta
-obo:BTO_0004674 rdfs:subClassOf bae:BrendaTissues . # ventral aorta
-obo:BTO_0004676 rdfs:subClassOf bae:BrendaTissues . # cerebral peduncle
-obo:BTO_0004679 rdfs:subClassOf bae:BrendaTissues . # capillary pericyte
-obo:BTO_0004680 rdfs:subClassOf bae:BrendaTissues . # stratum basale
-obo:BTO_0004681 rdfs:subClassOf bae:BrendaTissues . # bursa copulatrix
-obo:BTO_0004684 rdfs:subClassOf bae:BrendaTissues . # genital pore
-obo:BTO_0004685 rdfs:subClassOf bae:BrendaTissues . # bony labyrinth
-obo:BTO_0004687 rdfs:subClassOf bae:BrendaTissues . # orbit
-obo:BTO_0004688 rdfs:subClassOf bae:BrendaTissues . # regio orbitalis
-obo:BTO_0004689 rdfs:subClassOf bae:BrendaTissues . # external gill
-obo:BTO_0004690 rdfs:subClassOf bae:BrendaTissues . # arterial system
-obo:BTO_0004691 rdfs:subClassOf bae:BrendaTissues . # hippocampus minor
-obo:BTO_0004692 rdfs:subClassOf bae:BrendaTissues . # venous system
-obo:BTO_0004693 rdfs:subClassOf bae:BrendaTissues . # regio parietalis capitis
-obo:BTO_0004695 rdfs:subClassOf bae:BrendaTissues . # aortic root
-obo:BTO_0004696 rdfs:subClassOf bae:BrendaTissues . # external carotid artery
-obo:BTO_0004697 rdfs:subClassOf bae:BrendaTissues . # internal carotid artery
-obo:BTO_0004698 rdfs:subClassOf bae:BrendaTissues . # regio oralis
-obo:BTO_0004700 rdfs:subClassOf bae:BrendaTissues . # anterior pharynx
-obo:BTO_0004701 rdfs:subClassOf bae:BrendaTissues . # dorsal striatum
-obo:BTO_0004702 rdfs:subClassOf bae:BrendaTissues . # ventral striatum
-obo:BTO_0004703 rdfs:subClassOf bae:BrendaTissues . # striate cortex
-obo:BTO_0004704 rdfs:subClassOf bae:BrendaTissues . # extrastriate cortex
-obo:BTO_0004705 rdfs:subClassOf bae:BrendaTissues . # connecting stalk
-obo:BTO_0004706 rdfs:subClassOf bae:BrendaTissues . # ankle joint
-obo:BTO_0004708 rdfs:subClassOf bae:BrendaTissues . # thyroid follicle
-obo:BTO_0004709 rdfs:subClassOf bae:BrendaTissues . # thyroid primordium
-obo:BTO_0004711 rdfs:subClassOf bae:BrendaTissues . # head capsule
-obo:BTO_0004714 rdfs:subClassOf bae:BrendaTissues . # palatine tonsil
-obo:BTO_0004719 rdfs:subClassOf bae:BrendaTissues . # excretory canal
-obo:BTO_0004724 rdfs:subClassOf bae:BrendaTissues . # animal cap
-obo:BTO_0004725 rdfs:subClassOf bae:BrendaTissues . # embryonic fibroblast
-obo:BTO_0004726 rdfs:subClassOf bae:BrendaTissues . # embryonic brain
-obo:BTO_0004727 rdfs:subClassOf bae:BrendaTissues . # larval brain
-obo:BTO_0004728 rdfs:subClassOf bae:BrendaTissues . # rheumatoid arthritis disease specific synovial fluid
-obo:BTO_0004729 rdfs:subClassOf bae:BrendaTissues . # peripheral blood lymphocyte
-obo:BTO_0004732 rdfs:subClassOf bae:BrendaTissues . # bone marrow-derived macrophage
-obo:BTO_0004733 rdfs:subClassOf bae:BrendaTissues . # gravid adult
-obo:BTO_0004756 rdfs:subClassOf bae:BrendaTissues . # venous endothelium
-obo:BTO_0004757 rdfs:subClassOf bae:BrendaTissues . # arterial endothelium
-obo:BTO_0004769 rdfs:subClassOf bae:BrendaTissues . # teratocyte
-obo:BTO_0004776 rdfs:subClassOf bae:BrendaTissues . # striatonigral neuron
-obo:BTO_0004778 rdfs:subClassOf bae:BrendaTissues . # medium spiny neuron
-obo:BTO_0004789 rdfs:subClassOf bae:BrendaTissues . # ruminal fluid
-obo:BTO_0004791 rdfs:subClassOf bae:BrendaTissues . # root primordium
-obo:BTO_0004797 rdfs:subClassOf bae:BrendaTissues . # accessory olfactory bulb
-obo:BTO_0004798 rdfs:subClassOf bae:BrendaTissues . # accessory sex gland
-obo:BTO_0004800 rdfs:subClassOf bae:BrendaTissues . # amnioserosa
-obo:BTO_0004803 rdfs:subClassOf bae:BrendaTissues . # buccal epithelium
-obo:BTO_0004834 rdfs:subClassOf bae:BrendaTissues . # middle frontal gyrus
-obo:BTO_0004835 rdfs:subClassOf bae:BrendaTissues . # inferior frontal gyrus
-obo:BTO_0004836 rdfs:subClassOf bae:BrendaTissues . # superior frontal gyrus
-obo:BTO_0004838 rdfs:subClassOf bae:BrendaTissues . # muscular coat
-obo:BTO_0004849 rdfs:subClassOf bae:BrendaTissues . # pharyngeal gland
-obo:BTO_0004857 rdfs:subClassOf bae:BrendaTissues . # ookinete
-obo:BTO_0004875 rdfs:subClassOf bae:BrendaTissues . # labellum
-obo:BTO_0004876 rdfs:subClassOf bae:BrendaTissues . # distal tip
-obo:BTO_0004878 rdfs:subClassOf bae:BrendaTissues . # enteric muscle
-obo:BTO_0004882 rdfs:subClassOf bae:BrendaTissues . # ventral midbrain
-obo:BTO_0004902 rdfs:subClassOf bae:BrendaTissues . # cholinergic neuron
-obo:BTO_0004906 rdfs:subClassOf bae:BrendaTissues . # molecular layer
-obo:BTO_0004909 rdfs:subClassOf bae:BrendaTissues . # Purkinje layer
-obo:BTO_0004913 rdfs:subClassOf bae:BrendaTissues . # vastus medialis
-obo:BTO_0004914 rdfs:subClassOf bae:BrendaTissues . # rheumatoid arthritis disease specific synovial fibroblast
-obo:BTO_0004957 rdfs:subClassOf bae:BrendaTissues . # hydathode
-obo:BTO_0004977 rdfs:subClassOf bae:BrendaTissues . # nasal lavage fluid
-obo:BTO_0004978 rdfs:subClassOf bae:BrendaTissues . # carotid sinus nerve
-obo:BTO_0004979 rdfs:subClassOf bae:BrendaTissues . # glossopharyngeal nerve
-obo:BTO_0004982 rdfs:subClassOf bae:BrendaTissues . # gonocyte
-obo:BTO_0004984 rdfs:subClassOf bae:BrendaTissues . # alate adult
-obo:BTO_0004985 rdfs:subClassOf bae:BrendaTissues . # angioblast
-obo:BTO_0004995 rdfs:subClassOf bae:BrendaTissues . # osphradium
-obo:BTO_0004999 rdfs:subClassOf bae:BrendaTissues . # vaginal smooth muscle
-obo:BTO_0005003 rdfs:subClassOf bae:BrendaTissues . # villous trophoblast
-obo:BTO_0005008 rdfs:subClassOf bae:BrendaTissues . # psammoma body
-obo:BTO_0005024 rdfs:subClassOf bae:BrendaTissues . # gastrointestinal smooth muscle
-obo:BTO_0005035 rdfs:subClassOf bae:BrendaTissues . # Fanconi anemia disease specific cell type
-obo:BTO_0005053 rdfs:subClassOf bae:BrendaTissues . # midgut epithelium
-obo:BTO_0005055 rdfs:subClassOf bae:BrendaTissues . # scale
-obo:BTO_0005078 rdfs:subClassOf bae:BrendaTissues . # foot sole
-obo:BTO_0005081 rdfs:subClassOf bae:BrendaTissues . # periurethral tissue
-obo:BTO_0005082 rdfs:subClassOf bae:BrendaTissues . # skin mucus
-obo:BTO_0005084 rdfs:subClassOf bae:BrendaTissues . # vocal fold
-obo:BTO_0005085 rdfs:subClassOf bae:BrendaTissues . # common penile artery
-obo:BTO_0005086 rdfs:subClassOf bae:BrendaTissues . # arteria profunda penis
-obo:BTO_0005089 rdfs:subClassOf bae:BrendaTissues . # perichondrium
-obo:BTO_0005090 rdfs:subClassOf bae:BrendaTissues . # inner chondrogenic layer of perichondrium
-obo:BTO_0005094 rdfs:subClassOf bae:BrendaTissues . # leaf sheath
-obo:BTO_0005100 rdfs:subClassOf bae:BrendaTissues . # implantation fossa
-obo:BTO_0005115 rdfs:subClassOf bae:BrendaTissues . # salivary duct
-obo:BTO_0005122 rdfs:subClassOf bae:BrendaTissues . # ovarian cyst
-obo:BTO_0005123 rdfs:subClassOf bae:BrendaTissues . # ovarian cyst fluid
-obo:BTO_0005124 rdfs:subClassOf bae:BrendaTissues . # platysma muscle
-obo:BTO_0005125 rdfs:subClassOf bae:BrendaTissues . # sternocleidomastoid muscle
-obo:BTO_0005132 rdfs:subClassOf bae:BrendaTissues . # arrector pili muscle
-obo:BTO_0005142 rdfs:subClassOf bae:BrendaTissues . # ameloblastic layer
-obo:BTO_0005145 rdfs:subClassOf bae:BrendaTissues . # chorionic epithelium
-obo:BTO_0005151 rdfs:subClassOf bae:BrendaTissues . # anterior horn
-obo:BTO_0005157 rdfs:subClassOf bae:BrendaTissues . # juxtaglomerular apparatus
-obo:BTO_0005160 rdfs:subClassOf bae:BrendaTissues . # oil gland
-obo:BTO_0005170 rdfs:subClassOf bae:BrendaTissues . # keratocyte
-obo:BTO_0005180 rdfs:subClassOf bae:BrendaTissues . # pterygium
-obo:BTO_0005188 rdfs:subClassOf bae:BrendaTissues . # trunk kidney
-obo:BTO_0005189 rdfs:subClassOf bae:BrendaTissues . # head kidney
-obo:BTO_0005194 rdfs:subClassOf bae:BrendaTissues . # fine root
-obo:BTO_0005197 rdfs:subClassOf bae:BrendaTissues . # peltate gland
-obo:BTO_0005202 rdfs:subClassOf bae:BrendaTissues . # bulbil
-obo:BTO_0005205 rdfs:subClassOf bae:BrendaTissues . # cerebral artery
-obo:BTO_0005206 rdfs:subClassOf bae:BrendaTissues . # middle cerebral artery
-obo:BTO_0005208 rdfs:subClassOf bae:BrendaTissues . # right middle cerebral artery
-obo:BTO_0005211 rdfs:subClassOf bae:BrendaTissues . # choriodecidua
-obo:BTO_0005213 rdfs:subClassOf bae:BrendaTissues . # circular smooth muscle
-obo:BTO_0005214 rdfs:subClassOf bae:BrendaTissues . # longitudinal smooth muscle
-obo:BTO_0005216 rdfs:subClassOf bae:BrendaTissues . # keratocyst
-obo:BTO_0005219 rdfs:subClassOf bae:BrendaTissues . # osteophyte
-obo:BTO_0005226 rdfs:subClassOf bae:BrendaTissues . # medial pterygoid muscle
-obo:BTO_0005239 rdfs:subClassOf bae:BrendaTissues . # renal tubule epithelium
-obo:BTO_0005240 rdfs:subClassOf bae:BrendaTissues . # pharyngeal epithelium
-obo:BTO_0005257 rdfs:subClassOf bae:BrendaTissues . # oropharynx
-obo:BTO_0005268 rdfs:subClassOf bae:BrendaTissues . # neuropil
-obo:BTO_0005269 rdfs:subClassOf bae:BrendaTissues . # antennal lobe
-obo:BTO_0005273 rdfs:subClassOf bae:BrendaTissues . # adventitious root
-obo:BTO_0005278 rdfs:subClassOf bae:BrendaTissues . # cestode
-obo:BTO_0005281 rdfs:subClassOf bae:BrendaTissues . # intercostal muscle
-obo:BTO_0005305 rdfs:subClassOf bae:BrendaTissues . # corn ear
-obo:BTO_0005312 rdfs:subClassOf bae:BrendaTissues . # amoeba
-obo:BTO_0005313 rdfs:subClassOf bae:BrendaTissues . # nerve sheath
-obo:BTO_0005351 rdfs:subClassOf bae:BrendaTissues . # optic cup
-obo:BTO_0005385 rdfs:subClassOf bae:BrendaTissues . # root quiescent center
-obo:BTO_0005401 rdfs:subClassOf bae:BrendaTissues . # junctional zone
-obo:BTO_0005404 rdfs:subClassOf bae:BrendaTissues . # labyrinthine zone
-obo:BTO_0005405 rdfs:subClassOf bae:BrendaTissues . # velum
-obo:BTO_0005444 rdfs:subClassOf bae:BrendaTissues . # root nodule primordium
+obo:BTO_0000000 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tissues, cell types and enzyme sources
+obo:BTO_0000020 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # abdomen
+obo:BTO_0000022 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # abdominal ganglion
+obo:BTO_0000023 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pectoral muscle
+obo:BTO_0000025 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amniotic cavity
+obo:BTO_0000027 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # achene
+obo:BTO_0000029 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adductor longus
+obo:BTO_0000030 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adductor
+obo:BTO_0000031 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fruit peduncle
+obo:BTO_0000034 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # apical meristem
+obo:BTO_0000039 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # root cap
+obo:BTO_0000040 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adenohypophysis
+obo:BTO_0000041 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medulla oblongata
+obo:BTO_0000043 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebellar cortex
+obo:BTO_0000044 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tear gland
+obo:BTO_0000045 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adrenal cortex
+obo:BTO_0000047 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adrenal gland
+obo:BTO_0000048 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # zona glomerulosa
+obo:BTO_0000049 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adrenal medulla
+obo:BTO_0000050 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # zona fasciculata
+obo:BTO_0000051 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tendon sheath
+obo:BTO_0000052 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stoma
+obo:BTO_0000053 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # albedo
+obo:BTO_0000054 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # albumen gland
+obo:BTO_0000055 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pars recta
+obo:BTO_0000057 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aleurone layer
+obo:BTO_0000058 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alimentary canal
+obo:BTO_0000059 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal epithelium
+obo:BTO_0000060 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolus
+obo:BTO_0000061 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolar sac
+obo:BTO_0000062 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amastigote
+obo:BTO_0000065 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amnion
+obo:BTO_0000066 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amniocyte
+obo:BTO_0000068 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amniotic fluid
+obo:BTO_0000071 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amoebocyte
+obo:BTO_0000072 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # carpel
+obo:BTO_0000074 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # antenna
+obo:BTO_0000075 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # antennal gland
+obo:BTO_0000076 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior midgut
+obo:BTO_0000077 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # posterior midgut
+obo:BTO_0000078 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # microglia
+obo:BTO_0000079 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anther
+obo:BTO_0000081 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # reproductive system
+obo:BTO_0000083 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # female reproductive system
+obo:BTO_0000084 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vermiform appendix
+obo:BTO_0000087 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # arterial smooth muscle
+obo:BTO_0000088 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cardiovascular system
+obo:BTO_0000089 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blood
+obo:BTO_0000090 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ascidian
+obo:BTO_0000091 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ascites
+obo:BTO_0000092 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trypanosomoid form
+obo:BTO_0000099 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # astrocyte
+obo:BTO_0000102 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blood clot
+obo:BTO_0000105 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # upper epidermis
+obo:BTO_0000108 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory epithelium
+obo:BTO_0000109 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bacteroid
+obo:BTO_0000119 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # berry
+obo:BTO_0000121 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bile
+obo:BTO_0000122 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bile duct
+obo:BTO_0000123 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bladder
+obo:BTO_0000124 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # microspore
+obo:BTO_0000126 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blastoderm
+obo:BTO_0000128 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blastula
+obo:BTO_0000129 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # basophil
+obo:BTO_0000130 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neutrophil
+obo:BTO_0000131 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blood plasma
+obo:BTO_0000132 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blood platelet
+obo:BTO_0000134 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bloodstream form
+obo:BTO_0000135 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aorta
+obo:BTO_0000136 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchoalveolar system
+obo:BTO_0000138 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # midbrain
+obo:BTO_0000139 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # body wall
+obo:BTO_0000140 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone
+obo:BTO_0000141 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone marrow
+obo:BTO_0000142 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brain
+obo:BTO_0000143 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # substantia nigra
+obo:BTO_0000144 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # meninx
+obo:BTO_0000145 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brain myelin
+obo:BTO_0000146 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brain stem
+obo:BTO_0000147 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # microgametophyte
+obo:BTO_0000148 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # branch
+obo:BTO_0000149 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # breast
+obo:BTO_0000151 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # extensor
+obo:BTO_0000155 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchoalveolar lavage
+obo:BTO_0000156 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brown adipose tissue
+obo:BTO_0000159 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bulb
+obo:BTO_0000160 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bundle sheath
+obo:BTO_0000163 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corolla
+obo:BTO_0000166 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cecum
+obo:BTO_0000168 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # carotid artery
+obo:BTO_0000169 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # calyx
+obo:BTO_0000170 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cambium
+obo:BTO_0000171 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # L-cell
+obo:BTO_0000175 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epithalamus
+obo:BTO_0000187 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myeloblast
+obo:BTO_0000198 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cardia
+obo:BTO_0000199 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cardiac muscle
+obo:BTO_0000202 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sense organ
+obo:BTO_0000203 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # respiratory system
+obo:BTO_0000204 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # carotid body
+obo:BTO_0000205 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nerve plexus
+obo:BTO_0000206 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cartilage
+obo:BTO_0000207 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tibial cartilage
+obo:BTO_0000208 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # caryopsis
+obo:BTO_0000209 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corpus epididymis
+obo:BTO_0000210 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cauda epididymis
+obo:BTO_0000211 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # caudate nucleus
+obo:BTO_0000212 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # caudate putamen
+obo:BTO_0000214 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cell culture
+obo:BTO_0000216 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # culture condition
+obo:BTO_0000221 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cell suspension culture
+obo:BTO_0000222 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myoblast
+obo:BTO_0000227 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # central nervous system
+obo:BTO_0000229 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # centrum semiovale
+obo:BTO_0000230 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subarachnoid space
+obo:BTO_0000231 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral hemisphere
+obo:BTO_0000232 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebellum
+obo:BTO_0000233 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral cortex
+obo:BTO_0000234 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vein
+obo:BTO_0000236 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral white matter
+obo:BTO_0000237 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebrospinal fluid
+obo:BTO_0000239 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # telencephalon
+obo:BTO_0000240 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inferior cervical ganglion
+obo:BTO_0000241 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical epithelium
+obo:BTO_0000242 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical mucus
+obo:BTO_0000243 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vagina
+obo:BTO_0000247 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # shoot tip
+obo:BTO_0000249 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chondrocyte
+obo:BTO_0000251 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chorioallantois
+obo:BTO_0000258 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # choroid plexus
+obo:BTO_0000260 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ciliary body
+obo:BTO_0000262 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # clove
+obo:BTO_0000265 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # coagulating gland
+obo:BTO_0000266 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cob
+obo:BTO_0000267 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cochlea
+obo:BTO_0000268 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # coleoptile
+obo:BTO_0000269 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colon
+obo:BTO_0000271 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colonic mucosa
+obo:BTO_0000272 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colon transversum
+obo:BTO_0000273 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ink gland
+obo:BTO_0000274 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # apical bud
+obo:BTO_0000275 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colonocyte
+obo:BTO_0000278 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # commercial preparation
+obo:BTO_0000280 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cone
+obo:BTO_0000282 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # head
+obo:BTO_0000284 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # organism form
+obo:BTO_0000285 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corm
+obo:BTO_0000286 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cornea
+obo:BTO_0000287 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corneal epithelium
+obo:BTO_0000289 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cytotoxic T-lymphocyte
+obo:BTO_0000290 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # coronary artery
+obo:BTO_0000291 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corpus allatum
+obo:BTO_0000292 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corpus luteum
+obo:BTO_0000293 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # occipital lobe
+obo:BTO_0000294 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dermis
+obo:BTO_0000299 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cotton fibre
+obo:BTO_0000300 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cotyledon
+obo:BTO_0000303 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # crown gall
+obo:BTO_0000305 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # crypt
+obo:BTO_0000307 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # crystalline style
+obo:BTO_0000310 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # protophloem
+obo:BTO_0000311 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # culture filtrate
+obo:BTO_0000312 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # motoneuron
+obo:BTO_0000313 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hypodermis
+obo:BTO_0000314 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuroepithelium
+obo:BTO_0000315 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ectoderm
+obo:BTO_0000316 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # culture medium
+obo:BTO_0000317 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # caulonema
+obo:BTO_0000320 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cyst
+obo:BTO_0000321 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant cuticle
+obo:BTO_0000322 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cytotrophoblast
+obo:BTO_0000333 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal corpuscle
+obo:BTO_0000334 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # decidua parietalis
+obo:BTO_0000336 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # caput epididymis
+obo:BTO_0000337 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dental follicle
+obo:BTO_0000338 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dental plaque
+obo:BTO_0000339 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dental pulp
+obo:BTO_0000341 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # diaphragm
+obo:BTO_0000342 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # diencephalon
+obo:BTO_0000343 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal tubule
+obo:BTO_0000344 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stratum corneum
+obo:BTO_0000345 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # digestive gland
+obo:BTO_0000347 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # reticulum
+obo:BTO_0000348 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # omasum
+obo:BTO_0000349 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gut cavity
+obo:BTO_0000351 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # disc
+obo:BTO_0000357 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nectary
+obo:BTO_0000359 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # middle cervical ganglion
+obo:BTO_0000361 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stratum granulosum
+obo:BTO_0000364 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stratum lucidum
+obo:BTO_0000365 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # duodenum
+obo:BTO_0000366 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # duodenal juice
+obo:BTO_0000367 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # duodenal mucosa
+obo:BTO_0000368 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ear
+obo:BTO_0000369 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # egg
+obo:BTO_0000370 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # egg white
+obo:BTO_0000371 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # egg yolk
+obo:BTO_0000376 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # electric organ
+obo:BTO_0000377 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # elementary body
+obo:BTO_0000378 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # elytron
+obo:BTO_0000379 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryo
+obo:BTO_0000380 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic axis
+obo:BTO_0000381 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic blood
+obo:BTO_0000387 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endocardium
+obo:BTO_0000388 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endodermis
+obo:BTO_0000389 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mature ovarian follicle
+obo:BTO_0000390 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endosperm
+obo:BTO_0000393 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endothelium
+obo:BTO_0000394 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aorta endothelium
+obo:BTO_0000397 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tooth
+obo:BTO_0000398 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # enterocyte
+obo:BTO_0000399 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eosinophil
+obo:BTO_0000401 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ependymal epithelium
+obo:BTO_0000402 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epicotyl
+obo:BTO_0000404 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epidermis
+obo:BTO_0000405 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # penis
+obo:BTO_0000408 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epididymis
+obo:BTO_0000409 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epimastigote
+obo:BTO_0000410 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # immature ovarian follicle
+obo:BTO_0000411 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical mucosa
+obo:BTO_0000412 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epiphyseal growth plate
+obo:BTO_0000413 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epiphysis
+obo:BTO_0000416 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epithelium
+obo:BTO_0000417 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bile duct epithelium
+obo:BTO_0000418 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neostriatum
+obo:BTO_0000419 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # respiratory epithelium
+obo:BTO_0000420 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neck
+obo:BTO_0000421 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # connective tissue
+obo:BTO_0000422 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vaginal epithelium
+obo:BTO_0000424 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # erythrocyte
+obo:BTO_0000425 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # erythrocytic stage
+obo:BTO_0000431 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # excretory gland
+obo:BTO_0000432 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corpus cardiacum
+obo:BTO_0000434 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # exocrine pancreas
+obo:BTO_0000435 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stratum spinosum
+obo:BTO_0000436 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # extensor digitorum longus
+obo:BTO_0000438 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stratum germinativum
+obo:BTO_0000439 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eye
+obo:BTO_0000442 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fat body
+obo:BTO_0000443 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adipocyte
+obo:BTO_0000445 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral lobe
+obo:BTO_0000447 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # feather
+obo:BTO_0000449 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fetus
+obo:BTO_0000450 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fiber
+obo:BTO_0000452 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fibroblast
+obo:BTO_0000463 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # filament
+obo:BTO_0000464 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # flagellate
+obo:BTO_0000465 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # flavedo
+obo:BTO_0000466 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # flexor digitorum longus
+obo:BTO_0000467 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # flight muscle
+obo:BTO_0000468 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # floret
+obo:BTO_0000469 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # flower
+obo:BTO_0000470 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # flower bud
+obo:BTO_0000473 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fetal membrane
+obo:BTO_0000474 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # allantois
+obo:BTO_0000475 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian follicle
+obo:BTO_0000476 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # foot
+obo:BTO_0000477 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # foot muscle
+obo:BTO_0000478 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # forebrain
+obo:BTO_0000479 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # forelimb muscle
+obo:BTO_0000482 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal distal tubule
+obo:BTO_0000483 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # frond
+obo:BTO_0000484 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # frontal lobe
+obo:BTO_0000486 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fruit
+obo:BTO_0000487 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fruit body
+obo:BTO_0000488 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lower epidermis
+obo:BTO_0000493 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gall bladder
+obo:BTO_0000494 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # germinal disc
+obo:BTO_0000495 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gametophyte
+obo:BTO_0000496 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior lobe
+obo:BTO_0000497 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ganglion
+obo:BTO_0000500 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric epithelium
+obo:BTO_0000501 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric juice
+obo:BTO_0000503 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric gland
+obo:BTO_0000504 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic juice
+obo:BTO_0000506 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastrocnemius
+obo:BTO_0000507 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # foregut
+obo:BTO_0000509 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastrodermis
+obo:BTO_0000510 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hindgut
+obo:BTO_0000511 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastrointestinal tract
+obo:BTO_0000512 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primary oocyte
+obo:BTO_0000514 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # germ
+obo:BTO_0000516 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ghost
+obo:BTO_0000518 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gill
+obo:BTO_0000519 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gingiva
+obo:BTO_0000520 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gizzard
+obo:BTO_0000524 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glia
+obo:BTO_0000530 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal glomerulus
+obo:BTO_0000531 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gluteal muscle
+obo:BTO_0000534 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gonad
+obo:BTO_0000536 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gracilis muscle
+obo:BTO_0000537 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nectar
+obo:BTO_0000538 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolar cell type II
+obo:BTO_0000539 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # granulocyte
+obo:BTO_0000545 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gut
+obo:BTO_0000546 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gut mucosa
+obo:BTO_0000547 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gut wall
+obo:BTO_0000553 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peripheral blood
+obo:BTO_0000554 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hair follicle
+obo:BTO_0000555 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hair root
+obo:BTO_0000556 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # germ layer
+obo:BTO_0000557 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # harderian gland
+obo:BTO_0000558 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hatching gland
+obo:BTO_0000561 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # posterior lobe
+obo:BTO_0000562 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # heart
+obo:BTO_0000564 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # heart valve
+obo:BTO_0000569 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # exoerythrocytic stage
+obo:BTO_0000570 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hematopoietic system
+obo:BTO_0000571 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hemocyte
+obo:BTO_0000572 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hemolymph
+obo:BTO_0000573 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # artery
+obo:BTO_0000575 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatocyte
+obo:BTO_0000589 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primary meristem
+obo:BTO_0000597 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatopancreas
+obo:BTO_0000601 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hippocampus
+obo:BTO_0000602 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # histiocyte
+obo:BTO_0000605 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # honey
+obo:BTO_0000609 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # husk
+obo:BTO_0000613 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hypocotyl
+obo:BTO_0000614 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hypothalamus
+obo:BTO_0000615 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corpus callosum
+obo:BTO_0000616 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # I-cell
+obo:BTO_0000619 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ileal mucosa
+obo:BTO_0000620 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ileum
+obo:BTO_0000621 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # iliopsoas muscle
+obo:BTO_0000628 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inflorescence
+obo:BTO_0000629 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ink
+obo:BTO_0000630 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inner ear
+obo:BTO_0000634 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # integument
+obo:BTO_0000635 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # yellow bone marrow
+obo:BTO_0000639 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intersegmental muscle
+obo:BTO_0000640 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intestinal gland
+obo:BTO_0000641 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colon descendens
+obo:BTO_0000642 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intestinal mucosa
+obo:BTO_0000643 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intestinal muscle
+obo:BTO_0000644 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intestinal juice
+obo:BTO_0000645 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colon sigmoideum
+obo:BTO_0000646 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # left colon
+obo:BTO_0000647 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intestinal wall
+obo:BTO_0000648 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intestine
+obo:BTO_0000649 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # right colon
+obo:BTO_0000650 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endocrine pancreas
+obo:BTO_0000651 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # small intestine
+obo:BTO_0000653 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # iris
+obo:BTO_0000654 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ciliary muscle
+obo:BTO_0000656 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # iris sphincter muscle
+obo:BTO_0000657 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # jejunum
+obo:BTO_0000659 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # juice
+obo:BTO_0000662 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nasopharynx
+obo:BTO_0000667 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # keratinocyte
+obo:BTO_0000668 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # kernel
+obo:BTO_0000671 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # kidney
+obo:BTO_0000672 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hindbrain
+obo:BTO_0000673 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # metencephalon
+obo:BTO_0000703 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lacquer
+obo:BTO_0000706 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # large intestine
+obo:BTO_0000707 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # larva
+obo:BTO_0000708 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # larval integument
+obo:BTO_0000709 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # secondary spermatocyte
+obo:BTO_0000710 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # latex
+obo:BTO_0000712 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # laticifer
+obo:BTO_0000713 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leaf
+obo:BTO_0000714 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leaf axil
+obo:BTO_0000715 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leaf base
+obo:BTO_0000717 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pericardium
+obo:BTO_0000718 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leaf epidermis
+obo:BTO_0000719 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leaf lamina
+obo:BTO_0000722 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leg muscle
+obo:BTO_0000723 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lens
+obo:BTO_0000724 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lens fiber
+obo:BTO_0000730 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endocarp
+obo:BTO_0000733 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # exocarp
+obo:BTO_0000734 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myelocyte
+obo:BTO_0000735 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sporophyte
+obo:BTO_0000742 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myotome
+obo:BTO_0000747 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sporangiospore
+obo:BTO_0000750 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant ovary
+obo:BTO_0000751 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leukocyte
+obo:BTO_0000752 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymph vessel
+obo:BTO_0000753 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphoid tissue
+obo:BTO_0000758 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myelencephalon
+obo:BTO_0000759 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # liver
+obo:BTO_0000761 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # collecting duct
+obo:BTO_0000763 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung
+obo:BTO_0000764 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung fibroblast
+obo:BTO_0000765 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # exocrine gland
+obo:BTO_0000766 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blood vessel endothelium
+obo:BTO_0000767 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesenteric lymph node
+obo:BTO_0000768 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # infundibulum
+obo:BTO_0000770 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oligodendroglia
+obo:BTO_0000772 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphoblast
+obo:BTO_0000775 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphocyte
+obo:BTO_0000776 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-lymphocyte
+obo:BTO_0000777 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adenoid
+obo:BTO_0000778 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pulmonary artery
+obo:BTO_0000780 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolar cell type I
+obo:BTO_0000781 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intestinal epithelium
+obo:BTO_0000782 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T-lymphocyte
+obo:BTO_0000784 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymph node
+obo:BTO_0000800 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endoderm
+obo:BTO_0000801 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # macrophage
+obo:BTO_0000802 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolar macrophage
+obo:BTO_0000808 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # interrenal gland
+obo:BTO_0000810 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # malpighian tubule
+obo:BTO_0000817 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mammary gland
+obo:BTO_0000818 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spinal column
+obo:BTO_0000821 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nipple
+obo:BTO_0000823 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral gray matter
+obo:BTO_0000825 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mantle
+obo:BTO_0000826 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mantle cavity
+obo:BTO_0000827 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mantle muscle
+obo:BTO_0000828 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # throat
+obo:BTO_0000829 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # marrow
+obo:BTO_0000838 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # meconium
+obo:BTO_0000839 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesoderm
+obo:BTO_0000840 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nose
+obo:BTO_0000841 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # umbilical artery
+obo:BTO_0000842 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # megagametophyte
+obo:BTO_0000843 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # megakaryocyte
+obo:BTO_0000847 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # melanocyte
+obo:BTO_0000852 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # meristem
+obo:BTO_0000854 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # zygote
+obo:BTO_0000855 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymph
+obo:BTO_0000856 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesocarp
+obo:BTO_0000858 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesophyll
+obo:BTO_0000859 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # metacestode
+obo:BTO_0000862 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # heart ventricle
+obo:BTO_0000863 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # midgut
+obo:BTO_0000865 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior spinal root
+obo:BTO_0000866 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # midgut secretion
+obo:BTO_0000867 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tibialis posterior
+obo:BTO_0000868 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # milk
+obo:BTO_0000870 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spinal nerve
+obo:BTO_0000874 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # molting gland
+obo:BTO_0000876 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # monocyte
+obo:BTO_0000879 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lateral ventricle
+obo:BTO_0000883 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spinal root
+obo:BTO_0000884 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # molting fluid
+obo:BTO_0000886 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mucosa
+obo:BTO_0000887 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # muscle
+obo:BTO_0000888 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # muscle fibre
+obo:BTO_0000897 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amnion epithelium
+obo:BTO_0000901 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myocardium
+obo:BTO_0000902 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant vessel
+obo:BTO_0000903 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # atrium
+obo:BTO_0000907 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myometrium
+obo:BTO_0000912 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nasal mucosa
+obo:BTO_0000913 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nasal polyp
+obo:BTO_0000915 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nauplius
+obo:BTO_0000917 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # needle
+obo:BTO_0000920 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neocortex
+obo:BTO_0000923 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nephridium
+obo:BTO_0000924 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nephron
+obo:BTO_0000925 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nerve
+obo:BTO_0000926 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ophthalmic nerve
+obo:BTO_0000927 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nerve trunk
+obo:BTO_0000928 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # limbic system
+obo:BTO_0000929 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neural retina
+obo:BTO_0000930 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuroblast
+obo:BTO_0000937 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neurohypophysis
+obo:BTO_0000938 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuron
+obo:BTO_0000952 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nuchal ligament
+obo:BTO_0000954 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nymph
+obo:BTO_0000956 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gut epithelium
+obo:BTO_0000957 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nape
+obo:BTO_0000958 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spermatogonium
+obo:BTO_0000959 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # esophagus
+obo:BTO_0000961 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory bulb
+obo:BTO_0000962 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oligodendrocyte
+obo:BTO_0000964 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oocyte
+obo:BTO_0000965 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # optic lobe
+obo:BTO_0000966 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # optic nerve
+obo:BTO_0000967 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osseous plate
+obo:BTO_0000968 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteoclast
+obo:BTO_0000973 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # respiratory mucosa
+obo:BTO_0000975 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovary
+obo:BTO_0000980 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oviduct
+obo:BTO_0000981 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovotestis
+obo:BTO_0000987 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # palisade parenchyma
+obo:BTO_0000988 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreas
+obo:BTO_0000989 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # taste bud
+obo:BTO_0000991 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic islet
+obo:BTO_0000992 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tongue epithelium
+obo:BTO_0000995 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # paramyeloblast
+obo:BTO_0000996 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gametocyte
+obo:BTO_0000997 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parathyroid gland
+obo:BTO_0000999 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant parenchyma
+obo:BTO_0001001 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parietal lobe
+obo:BTO_0001002 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # schizont
+obo:BTO_0001004 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parotid gland
+obo:BTO_0001006 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pelvis
+obo:BTO_0001010 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # callus
+obo:BTO_0001012 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pedal ganglion
+obo:BTO_0001016 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pericardial fluid
+obo:BTO_0001017 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pericarp
+obo:BTO_0001020 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # periodontal ligament
+obo:BTO_0001022 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # periosteum
+obo:BTO_0001024 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinal rod
+obo:BTO_0001027 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peripheral nerve
+obo:BTO_0001028 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peripheral nervous system
+obo:BTO_0001029 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # perisperm
+obo:BTO_0001031 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peritoneal fluid
+obo:BTO_0001036 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinal cone
+obo:BTO_0001038 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peritrophic membrane
+obo:BTO_0001040 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # petal
+obo:BTO_0001041 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # petiole
+obo:BTO_0001042 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amygdala
+obo:BTO_0001043 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adult
+obo:BTO_0001044 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # phagocyte
+obo:BTO_0001046 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pharate pupa
+obo:BTO_0001048 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pharyngeal muscle
+obo:BTO_0001049 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pharynx
+obo:BTO_0001057 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neural tube
+obo:BTO_0001058 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # phloem
+obo:BTO_0001060 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # photoreceptor
+obo:BTO_0001063 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # phrenic nerve
+obo:BTO_0001064 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # phycobiont
+obo:BTO_0001066 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hippocampal pyramidal layer
+obo:BTO_0001067 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pineal gland
+obo:BTO_0001068 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pinealocyte
+obo:BTO_0001069 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pitcher
+obo:BTO_0001071 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pith
+obo:BTO_0001072 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trigeminal nerve
+obo:BTO_0001073 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hypophysis
+obo:BTO_0001075 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # motor trigeminal nucleus
+obo:BTO_0001078 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # placenta
+obo:BTO_0001079 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trophoblast
+obo:BTO_0001084 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plantlet
+obo:BTO_0001085 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular system
+obo:BTO_0001090 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mouth
+obo:BTO_0001091 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # axenic culture
+obo:BTO_0001097 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pollen
+obo:BTO_0001099 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blastocyst
+obo:BTO_0001101 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pons
+obo:BTO_0001102 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blood vessel
+obo:BTO_0001103 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skeletal muscle
+obo:BTO_0001104 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cranial nerve
+obo:BTO_0001105 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # insular cortex
+obo:BTO_0001107 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # preadipocyte
+obo:BTO_0001108 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mitral cell layer
+obo:BTO_0001110 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prepupa
+obo:BTO_0001111 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # preputial gland
+obo:BTO_0001113 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prepuce
+obo:BTO_0001114 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primary leaf
+obo:BTO_0001115 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primary spermatocyte
+obo:BTO_0001116 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # floral primordium
+obo:BTO_0001117 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # proboscis
+obo:BTO_0001119 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # procambium
+obo:BTO_0001121 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cauline leaf
+obo:BTO_0001122 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # procyclic form
+obo:BTO_0001124 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # promastigote
+obo:BTO_0001127 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primary culture
+obo:BTO_0001128 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostasome
+obo:BTO_0001129 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostate gland
+obo:BTO_0001133 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pre-B-lymphocyte
+obo:BTO_0001134 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # protonema
+obo:BTO_0001135 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # protoxylem
+obo:BTO_0001136 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # proventriculus
+obo:BTO_0001138 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # somatic embryo
+obo:BTO_0001140 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # psoas
+obo:BTO_0001142 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pulp
+obo:BTO_0001146 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pyloric region
+obo:BTO_0001149 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # quadriceps
+obo:BTO_0001152 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # radicle
+obo:BTO_0001153 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # radular muscle
+obo:BTO_0001156 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # node
+obo:BTO_0001157 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rectal gland
+obo:BTO_0001158 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rectum
+obo:BTO_0001160 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # red bone marrow
+obo:BTO_0001161 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chorionic villus
+obo:BTO_0001162 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # apocrine gland
+obo:BTO_0001164 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # megakaryoblast
+obo:BTO_0001165 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal artery
+obo:BTO_0001166 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal cortex
+obo:BTO_0001167 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal medulla
+obo:BTO_0001168 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rennet
+obo:BTO_0001172 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # reticulate body
+obo:BTO_0001173 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # reticulocyte
+obo:BTO_0001174 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # reticuloendothelial system
+obo:BTO_0001175 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retina
+obo:BTO_0001177 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retinal pigment epithelium
+obo:BTO_0001179 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rhizophore
+obo:BTO_0001180 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # idioblast
+obo:BTO_0001181 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rhizome
+obo:BTO_0001182 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primary root
+obo:BTO_0001183 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # secondary root
+obo:BTO_0001184 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rind
+obo:BTO_0001187 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # roe
+obo:BTO_0001188 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # root
+obo:BTO_0001190 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # root nodule
+obo:BTO_0001191 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # root tip
+obo:BTO_0001192 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rootlet
+obo:BTO_0001194 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rumen
+obo:BTO_0001195 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rumen epithelium
+obo:BTO_0001198 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # atrial gland
+obo:BTO_0001201 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rosette
+obo:BTO_0001202 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # saliva
+obo:BTO_0001203 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # salivary gland
+obo:BTO_0001204 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # salt gland
+obo:BTO_0001206 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sarcocarp
+obo:BTO_0001208 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # larynx
+obo:BTO_0001215 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sartorius
+obo:BTO_0001217 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # scape
+obo:BTO_0001218 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # scapula
+obo:BTO_0001221 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sciatic nerve
+obo:BTO_0001222 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sclerenchyma
+obo:BTO_0001223 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # scutellum
+obo:BTO_0001226 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seed
+obo:BTO_0001227 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seed coat
+obo:BTO_0001228 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seedling
+obo:BTO_0001230 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # semen
+obo:BTO_0001231 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trigeminal ganglion
+obo:BTO_0001232 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seminal plasma
+obo:BTO_0001233 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant embryo
+obo:BTO_0001234 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seminal vesicle
+obo:BTO_0001235 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seminiferous tubule
+obo:BTO_0001236 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # semitendinosus
+obo:BTO_0001237 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sensillum
+obo:BTO_0001239 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # serum
+obo:BTO_0001241 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # shell gland
+obo:BTO_0001243 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # shoot
+obo:BTO_0001244 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urinary tract
+obo:BTO_0001246 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # flexor digitorum profundus
+obo:BTO_0001247 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sieve tube
+obo:BTO_0001249 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # silique
+obo:BTO_0001250 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # silk gland
+obo:BTO_0001252 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tibia
+obo:BTO_0001253 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skin
+obo:BTO_0001254 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sweat
+obo:BTO_0001255 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skin fibroblast
+obo:BTO_0001257 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # flexor
+obo:BTO_0001259 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # small intestine mucosa
+obo:BTO_0001260 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # smooth muscle
+obo:BTO_0001261 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # abdominal muscle
+obo:BTO_0001262 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # soft body part
+obo:BTO_0001264 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spinal ganglion
+obo:BTO_0001265 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # soleus
+obo:BTO_0001266 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # invertebrate muscular system
+obo:BTO_0001269 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spadix
+obo:BTO_0001270 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spear
+obo:BTO_0001273 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spermatheca
+obo:BTO_0001274 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spermatid
+obo:BTO_0001275 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spermatocyte
+obo:BTO_0001277 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spermatozoon
+obo:BTO_0001278 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spike
+obo:BTO_0001279 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spinal cord
+obo:BTO_0001281 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spleen
+obo:BTO_0001284 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # femur
+obo:BTO_0001287 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sporangium
+obo:BTO_0001290 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sporocarp
+obo:BTO_0001292 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sporozoite
+obo:BTO_0001293 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sporulated oocyst
+obo:BTO_0001295 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cranium
+obo:BTO_0001296 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sprout
+obo:BTO_0001297 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sputum
+obo:BTO_0001299 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stele
+obo:BTO_0001300 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stem
+obo:BTO_0001301 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bark
+obo:BTO_0001302 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sternum
+obo:BTO_0001303 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stigma
+obo:BTO_0001304 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stipe
+obo:BTO_0001305 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stipule
+obo:BTO_0001306 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stolon
+obo:BTO_0001307 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stomach
+obo:BTO_0001308 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric mucosa
+obo:BTO_0001309 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tuberous root
+obo:BTO_0001310 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # storage tissue
+obo:BTO_0001311 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corpus striatum
+obo:BTO_0001312 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adductor magnus
+obo:BTO_0001313 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # style
+obo:BTO_0001314 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subcutis
+obo:BTO_0001315 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sublingual gland
+obo:BTO_0001316 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # submandibular gland
+obo:BTO_0001317 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glomerular layer
+obo:BTO_0001318 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # submandibular ganglion
+obo:BTO_0001319 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # external plexiform layer
+obo:BTO_0001320 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # internal plexiform layer
+obo:BTO_0001325 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # superior cervical ganglion
+obo:BTO_0001327 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # granule cell layer
+obo:BTO_0001328 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # calvarium
+obo:BTO_0001331 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sweat gland
+obo:BTO_0001335 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # syncytiotrophoblast
+obo:BTO_0001336 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # synovial fibroblast
+obo:BTO_0001337 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # extensor digitorum brevis
+obo:BTO_0001338 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # synovial tissue
+obo:BTO_0001339 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # synovia
+obo:BTO_0001340 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchus
+obo:BTO_0001343 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # extensor digitorum communis
+obo:BTO_0001346 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tachyzoite
+obo:BTO_0001347 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tadpole
+obo:BTO_0001348 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tail
+obo:BTO_0001350 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tapetum
+obo:BTO_0001351 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vomeronasal nerve
+obo:BTO_0001353 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # telson
+obo:BTO_0001355 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # temporal lobe
+obo:BTO_0001356 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tendon
+obo:BTO_0001357 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tentacle
+obo:BTO_0001360 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # decidua
+obo:BTO_0001362 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory lobe
+obo:BTO_0001363 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # testis
+obo:BTO_0001365 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thalamus
+obo:BTO_0001366 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thallus
+obo:BTO_0001367 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thigh muscle
+obo:BTO_0001368 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thorax
+obo:BTO_0001369 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vertebrate muscular system
+obo:BTO_0001372 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymocyte
+obo:BTO_0001374 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymus
+obo:BTO_0001376 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thigh
+obo:BTO_0001379 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thyroid gland
+obo:BTO_0001380 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesentery
+obo:BTO_0001382 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tibialis anterior
+obo:BTO_0001383 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolar bone
+obo:BTO_0001384 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tissue culture
+obo:BTO_0001385 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tongue
+obo:BTO_0001386 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tongue muscle
+obo:BTO_0001387 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tonsil
+obo:BTO_0001388 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trachea
+obo:BTO_0001389 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tracheal epithelium
+obo:BTO_0001391 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tracheal smooth muscle
+obo:BTO_0001393 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesenchyme
+obo:BTO_0001395 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trichome
+obo:BTO_0001396 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trophosome tissue
+obo:BTO_0001397 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trophozoite
+obo:BTO_0001398 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trypomastigote
+obo:BTO_0001399 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Tay-Sachs disease specific cell type
+obo:BTO_0001400 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tuber
+obo:BTO_0001401 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tuber cortex
+obo:BTO_0001402 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urogenital ridge
+obo:BTO_0001403 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastrula
+obo:BTO_0001408 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # locus ceruleus
+obo:BTO_0001409 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ureter
+obo:BTO_0001411 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # twig
+obo:BTO_0001415 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # umbilical cord
+obo:BTO_0001418 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urinary bladder
+obo:BTO_0001419 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urine
+obo:BTO_0001420 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uropygial gland
+obo:BTO_0001421 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine cervix
+obo:BTO_0001422 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine endometrium
+obo:BTO_0001423 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine lavage
+obo:BTO_0001424 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterus
+obo:BTO_0001426 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urethra
+obo:BTO_0001427 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vas deferens
+obo:BTO_0001428 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # breast epithelium
+obo:BTO_0001429 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular bundle
+obo:BTO_0001431 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular smooth muscle
+obo:BTO_0001432 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular tissue
+obo:BTO_0001438 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vena cava
+obo:BTO_0001439 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # venom
+obo:BTO_0001440 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # venom gland
+obo:BTO_0001442 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brain ventricle
+obo:BTO_0001445 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tail bud
+obo:BTO_0001446 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory cortex
+obo:BTO_0001447 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # forearm
+obo:BTO_0001448 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # visceral hump
+obo:BTO_0001450 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vitelline membrane
+obo:BTO_0001451 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vitreous humor
+obo:BTO_0001452 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nasal nerve
+obo:BTO_0001453 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # detrusor
+obo:BTO_0001456 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # white adipose tissue
+obo:BTO_0001457 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hip
+obo:BTO_0001458 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # apocrine sweat gland
+obo:BTO_0001461 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # whole plant
+obo:BTO_0001462 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bladder wall
+obo:BTO_0001463 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # wing
+obo:BTO_0001464 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # wing disc
+obo:BTO_0001465 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pericycle
+obo:BTO_0001467 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesocotyl
+obo:BTO_0001468 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # xylem
+obo:BTO_0001471 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # yolk sac
+obo:BTO_0001472 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peritoneum
+obo:BTO_0001473 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blastomere
+obo:BTO_0001477 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # photophore
+obo:BTO_0001484 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nervous system
+obo:BTO_0001485 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # muscular system
+obo:BTO_0001486 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skeletal system
+obo:BTO_0001487 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adipose tissue
+obo:BTO_0001488 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endocrine gland
+obo:BTO_0001491 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # viscus
+obo:BTO_0001492 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # limb
+obo:BTO_0001493 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trunk
+obo:BTO_0001494 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fungus
+obo:BTO_0001495 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plumule
+obo:BTO_0001496 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # perivascular astrocyte
+obo:BTO_0001498 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal proximal tubule
+obo:BTO_0001499 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tear
+obo:BTO_0001500 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tendril
+obo:BTO_0001501 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hair
+obo:BTO_0001502 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hip joint
+obo:BTO_0001504 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blastodisc
+obo:BTO_0001505 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # loin
+obo:BTO_0001506 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # radula
+obo:BTO_0001508 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # morula
+obo:BTO_0001509 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # umbilical vein
+obo:BTO_0001511 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tooth germ
+obo:BTO_0001512 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # imago
+obo:BTO_0001513 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # biliary epithelium
+obo:BTO_0001528 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # B-lymphoblast
+obo:BTO_0001539 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parenchyma
+obo:BTO_0001541 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pronephros
+obo:BTO_0001542 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesonephron
+obo:BTO_0001543 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # metanephron
+obo:BTO_0001547 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sepal
+obo:BTO_0001548 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # labial gland
+obo:BTO_0001551 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # free-living state
+obo:BTO_0001558 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # somite
+obo:BTO_0001559 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stamen
+obo:BTO_0001564 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rectus femoris
+obo:BTO_0001571 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # erythroblast
+obo:BTO_0001572 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # articular cartilage
+obo:BTO_0001578 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # esophageal epithelium
+obo:BTO_0001579 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # extraocular muscle
+obo:BTO_0001580 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ejaculatory duct
+obo:BTO_0001592 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # meniscus
+obo:BTO_0001593 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteoblast
+obo:BTO_0001597 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sapling
+obo:BTO_0001601 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epicuticle
+obo:BTO_0001602 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # exocuticle
+obo:BTO_0001603 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endocuticle
+obo:BTO_0001604 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eyestalk
+obo:BTO_0001605 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # reticulum trabeculare
+obo:BTO_0001606 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sclera
+obo:BTO_0001607 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # swim bladder
+obo:BTO_0001608 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # feather calamus
+obo:BTO_0001613 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colorectum
+obo:BTO_0001624 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # femoral artery
+obo:BTO_0001626 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # laryngeal muscle
+obo:BTO_0001627 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glottis
+obo:BTO_0001628 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epiglottis
+obo:BTO_0001629 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # left ventricle
+obo:BTO_0001630 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # right ventricle
+obo:BTO_0001632 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lens cortex
+obo:BTO_0001633 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lens nucleus
+obo:BTO_0001634 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leptomeninx
+obo:BTO_0001635 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pia mater
+obo:BTO_0001636 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # arachnoid mater
+obo:BTO_0001638 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blastema
+obo:BTO_0001640 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # limb bud
+obo:BTO_0001642 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # liver bud
+obo:BTO_0001643 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung bud
+obo:BTO_0001645 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # wing bud
+obo:BTO_0001646 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ureteric bud
+obo:BTO_0001647 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lip
+obo:BTO_0001648 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # longissimus
+obo:BTO_0001651 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # longissimus thoracis
+obo:BTO_0001652 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sacrospinalis
+obo:BTO_0001653 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung epithelium
+obo:BTO_0001654 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # female cone
+obo:BTO_0001655 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # male cone
+obo:BTO_0001656 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nerve cord
+obo:BTO_0001657 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # abscission zone
+obo:BTO_0001658 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aerial part
+obo:BTO_0001659 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aerial root
+obo:BTO_0001660 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # respiratory smooth muscle
+obo:BTO_0001662 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # allantoic fluid
+obo:BTO_0001663 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ameloblast
+obo:BTO_0001679 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Th2-cell
+obo:BTO_0001680 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anus
+obo:BTO_0001681 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anal sac
+obo:BTO_0001682 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # byssus
+obo:BTO_0001684 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # antler
+obo:BTO_0001685 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aortic smooth muscle
+obo:BTO_0001686 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # joint
+obo:BTO_0001687 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # asynchronous muscle
+obo:BTO_0001688 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cochlear ganglion
+obo:BTO_0001689 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # axillary bud
+obo:BTO_0001691 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spiral organ
+obo:BTO_0001692 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cochlear duct
+obo:BTO_0001693 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # modiolus
+obo:BTO_0001694 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urinary bladder epithelium
+obo:BTO_0001695 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blastopore
+obo:BTO_0001696 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # archenteron
+obo:BTO_0001697 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory gland
+obo:BTO_0001698 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bulbourethral gland
+obo:BTO_0001699 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bursa of Fabricius
+obo:BTO_0001700 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cancellous bone
+obo:BTO_0001701 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # carapace
+obo:BTO_0001702 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # left atrium
+obo:BTO_0001703 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # right atrium
+obo:BTO_0001704 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # twitch muscle
+obo:BTO_0001705 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vallate papilla
+obo:BTO_0001706 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cnidoblast
+obo:BTO_0001707 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # coelom
+obo:BTO_0001708 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # coelomic fluid
+obo:BTO_0001709 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colonic epithelium
+obo:BTO_0001711 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # melanophore
+obo:BTO_0001713 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dorsum
+obo:BTO_0001715 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ectoplacental cone
+obo:BTO_0001716 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eggshell
+obo:BTO_0001718 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryoid body
+obo:BTO_0001719 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # claw
+obo:BTO_0001720 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # floor plate
+obo:BTO_0001721 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sternal cartilage
+obo:BTO_0001722 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # enamel organ
+obo:BTO_0001724 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ependymocyte
+obo:BTO_0001725 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # floral meristem
+obo:BTO_0001726 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inflorescence meristem
+obo:BTO_0001727 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # perianth
+obo:BTO_0001728 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tepal
+obo:BTO_0001729 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # forelimb
+obo:BTO_0001732 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric antrum
+obo:BTO_0001733 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gynoecium
+obo:BTO_0001734 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gut juice
+obo:BTO_0001735 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cardiac Purkinje fiber
+obo:BTO_0001739 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pars tuberalis
+obo:BTO_0001740 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hypopharynx
+obo:BTO_0001741 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # incisor
+obo:BTO_0001742 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # jejunal mucosa
+obo:BTO_0001743 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # jejunal epithelium
+obo:BTO_0001744 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # jugular vein
+obo:BTO_0001745 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal inner medulla
+obo:BTO_0001746 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal outer medulla
+obo:BTO_0001747 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # palpus
+obo:BTO_0001748 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mandible
+obo:BTO_0001749 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # jaw
+obo:BTO_0001752 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # invertebrate mandible
+obo:BTO_0001753 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mandibular organ
+obo:BTO_0001754 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cheek
+obo:BTO_0001755 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # masseter
+obo:BTO_0001758 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ocellus
+obo:BTO_0001759 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # molaris
+obo:BTO_0001760 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myotube
+obo:BTO_0001761 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nasal vestibule
+obo:BTO_0001762 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neonate
+obo:BTO_0001763 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neural arch
+obo:BTO_0001764 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neural crest
+obo:BTO_0001765 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neural plate
+obo:BTO_0001766 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neurula
+obo:BTO_0001768 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # notochord
+obo:BTO_0001769 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # odontoblast
+obo:BTO_0001770 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ciliary epithelium
+obo:BTO_0001772 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory organ
+obo:BTO_0001773 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oocyst
+obo:BTO_0001775 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oral epithelium
+obo:BTO_0001776 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant ovule
+obo:BTO_0001777 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # megasporangium
+obo:BTO_0001778 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # microsporangium
+obo:BTO_0001779 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # palate
+obo:BTO_0001782 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peritoneal cavity
+obo:BTO_0001783 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pulvinus
+obo:BTO_0001784 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Peyer's gland
+obo:BTO_0001785 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # branchial arch
+obo:BTO_0001786 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pheromone gland
+obo:BTO_0001787 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pars distalis
+obo:BTO_0001788 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pars intermedia
+obo:BTO_0001790 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pleopod
+obo:BTO_0001791 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pleura
+obo:BTO_0001792 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # portal vein
+obo:BTO_0001793 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tectum mesencephali
+obo:BTO_0001794 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # posterior silk gland
+obo:BTO_0001795 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior silk gland
+obo:BTO_0001796 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # preoptic area
+obo:BTO_0001798 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prothallium
+obo:BTO_0001799 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pulmonary vein
+obo:BTO_0001805 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # saccule
+obo:BTO_0001807 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # utricle
+obo:BTO_0001808 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # saphenous vein
+obo:BTO_0001809 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # scalp
+obo:BTO_0001811 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seminiferous epithelium
+obo:BTO_0001813 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fast twitch muscle fiber
+obo:BTO_0001814 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leaf tip
+obo:BTO_0001815 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stellate ganglion
+obo:BTO_0001816 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stem nodule
+obo:BTO_0001818 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stomach smooth muscle
+obo:BTO_0001819 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stria vascularis
+obo:BTO_0001820 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subcommissural organ
+obo:BTO_0001821 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subesophageal ganglion
+obo:BTO_0001822 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # suprachiasmatic nucleus
+obo:BTO_0001823 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # synovium
+obo:BTO_0001826 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # T-lymphoblast
+obo:BTO_0001827 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tail fin
+obo:BTO_0001828 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tapetum lucidum
+obo:BTO_0001829 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # choroid
+obo:BTO_0001830 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tassel
+obo:BTO_0001831 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thoracic ganglion
+obo:BTO_0001832 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sympathetic nervous system
+obo:BTO_0001833 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parasympathetic nervous system
+obo:BTO_0001834 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sympathetic chain
+obo:BTO_0001835 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vertebral ganglion
+obo:BTO_0001836 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymic epithelium
+obo:BTO_0001837 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # serous gland
+obo:BTO_0001838 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tooth bud
+obo:BTO_0001839 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dental papilla
+obo:BTO_0001840 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trophectoderm
+obo:BTO_0001841 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parietal ganglion
+obo:BTO_0001842 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pleural ganglion
+obo:BTO_0001843 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral ganglion
+obo:BTO_0001844 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tooth enamel
+obo:BTO_0001845 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchial epithelium
+obo:BTO_0001846 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchial mucosa
+obo:BTO_0001847 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # umbilical smooth muscle
+obo:BTO_0001848 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urophysis
+obo:BTO_0001849 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urinary bladder smooth muscle
+obo:BTO_0001850 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # portio vaginalis cervicis
+obo:BTO_0001852 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebrovascular endothelium
+obo:BTO_0001853 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular endothelium
+obo:BTO_0001855 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # venom duct
+obo:BTO_0001856 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vestibular labyrinth
+obo:BTO_0001857 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # visual cortex
+obo:BTO_0001858 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dermal papilla
+obo:BTO_0001859 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # wart
+obo:BTO_0001862 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nucleus accumbens
+obo:BTO_0001863 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # body wall muscle
+obo:BTO_0001866 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchiolar epithelium
+obo:BTO_0001868 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # occipital pole
+obo:BTO_0001871 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # synganglion
+obo:BTO_0001873 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lens epithelium
+obo:BTO_0001886 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primordium
+obo:BTO_0001887 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # heart primordium
+obo:BTO_0001893 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ring stage
+obo:BTO_0001899 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stationary phase culture
+obo:BTO_0001901 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # death phase culture
+obo:BTO_0001902 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lag phase culture
+obo:BTO_0001903 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # logarithmic phase culture
+obo:BTO_0001905 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tail muscle
+obo:BTO_0001906 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cephalothorax
+obo:BTO_0001919 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tube foot
+obo:BTO_0001921 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # compound eye
+obo:BTO_0001922 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ommatidium
+obo:BTO_0001925 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # longissimus lumborum
+obo:BTO_0001940 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cardiomyoblast
+obo:BTO_0001942 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mandibular incisor
+obo:BTO_0001943 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corneocyte
+obo:BTO_0001946 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myofibroblast
+obo:BTO_0001953 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tanycyte
+obo:BTO_0001954 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # median eminence
+obo:BTO_0001965 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # carcass
+obo:BTO_0001978 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anal canal
+obo:BTO_0001979 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mucous gland
+obo:BTO_0001980 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sebaceous gland
+obo:BTO_0001981 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sebum
+obo:BTO_0001982 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chemostat culture
+obo:BTO_0001997 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # arteriole
+obo:BTO_0002009 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # artery wall
+obo:BTO_0002012 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tunica intima vasorum
+obo:BTO_0002017 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant reproductive system
+obo:BTO_0002018 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corpus cavernosum clitoridis
+obo:BTO_0002019 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corpus cavernosum penis
+obo:BTO_0002020 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # clitoris
+obo:BTO_0002038 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteocyte
+obo:BTO_0002045 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # capillary
+obo:BTO_0002046 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spermatozoid
+obo:BTO_0002051 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # preosteoblast
+obo:BTO_0002053 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seminal vesicle fluid
+obo:BTO_0002056 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # siphon
+obo:BTO_0002065 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # venom apparatus
+obo:BTO_0002066 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # venom sac
+obo:BTO_0002067 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stinger
+obo:BTO_0002068 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # scent gland
+obo:BTO_0002069 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # wax gland
+obo:BTO_0002072 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # squamous epithelium
+obo:BTO_0002073 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pavement epithelium
+obo:BTO_0002074 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stratified epithelium
+obo:BTO_0002075 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesenchymal epithelium
+obo:BTO_0002082 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subdural space
+obo:BTO_0002083 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # perilymphatic space
+obo:BTO_0002084 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior chamber of the eye
+obo:BTO_0002085 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chamber of the eye
+obo:BTO_0002086 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # posterior chamber of the eye
+obo:BTO_0002087 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vitreous chamber of the eye
+obo:BTO_0002096 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nasal cavity
+obo:BTO_0002097 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pharyngeal cavity
+obo:BTO_0002098 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tympanum
+obo:BTO_0002099 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # middle ear
+obo:BTO_0002100 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # outer ear
+obo:BTO_0002105 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # perisympathetic organ
+obo:BTO_0002106 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neurohemal organ
+obo:BTO_0002107 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # submucosa
+obo:BTO_0002119 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spikelet
+obo:BTO_0002120 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pyloric cecum
+obo:BTO_0002121 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pyloric stomach
+obo:BTO_0002122 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cardiac stomach
+obo:BTO_0002123 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # primitive endoderm
+obo:BTO_0002124 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ampulla
+obo:BTO_0002125 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # water vascular system
+obo:BTO_0002149 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gill raker
+obo:BTO_0002150 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gill filament
+obo:BTO_0002152 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gill arch
+obo:BTO_0002155 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ceratobranchial
+obo:BTO_0002156 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hypobranchial
+obo:BTO_0002157 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endochondral bone
+obo:BTO_0002168 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # juvenile
+obo:BTO_0002169 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior commissure
+obo:BTO_0002173 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tubercle
+obo:BTO_0002191 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fibre tract
+obo:BTO_0002217 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # culture supernatant
+obo:BTO_0002222 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bract
+obo:BTO_0002224 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cheek pouch
+obo:BTO_0002233 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # culture fluid
+obo:BTO_0002240 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # exodermis
+obo:BTO_0002241 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eyelid
+obo:BTO_0002243 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hypanthium
+obo:BTO_0002244 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # flower stalk
+obo:BTO_0002246 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # globus pallidus
+obo:BTO_0002249 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical canal
+obo:BTO_0002250 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nucleus lentiformis
+obo:BTO_0002252 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subthalamic nucleus
+obo:BTO_0002254 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vas efferens
+obo:BTO_0002272 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # merozoite
+obo:BTO_0002273 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ileocecum
+obo:BTO_0002275 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lateral hypodermal chord
+obo:BTO_0002277 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # melanotroph
+obo:BTO_0002294 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # solid substrate culture
+obo:BTO_0002295 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # podocyte
+obo:BTO_0002297 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal glomerular capsule
+obo:BTO_0002298 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inferior olivary complex
+obo:BTO_0002299 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oliva
+obo:BTO_0002302 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inferior mesenteric artery
+obo:BTO_0002303 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # superior mesenteric artery
+obo:BTO_0002304 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # protoscolex
+obo:BTO_0002305 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # scolex
+obo:BTO_0002308 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myoepithelium
+obo:BTO_0002310 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mammary myoepithelium
+obo:BTO_0002317 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # slow muscle
+obo:BTO_0002318 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fast muscle
+obo:BTO_0002319 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skeletal muscle fiber
+obo:BTO_0002323 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eccrine sweat gland
+obo:BTO_0002324 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # merocrine gland
+obo:BTO_0002325 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # holocrine gland
+obo:BTO_0002328 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ventral nerve cord
+obo:BTO_0002329 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dorsal nerve cord
+obo:BTO_0002330 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lamina propria
+obo:BTO_0002340 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant collar
+obo:BTO_0002342 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bradyzoite
+obo:BTO_0002343 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tarsal bone
+obo:BTO_0002344 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # electrocyte
+obo:BTO_0002345 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hindlimb
+obo:BTO_0002346 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fibula
+obo:BTO_0002347 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # metatarsal bone
+obo:BTO_0002348 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # toe
+obo:BTO_0002349 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hallux
+obo:BTO_0002354 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # talus
+obo:BTO_0002355 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # calcaneal bone
+obo:BTO_0002356 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # navicular bone
+obo:BTO_0002357 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cuboid bone
+obo:BTO_0002360 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial cuneiform bone
+obo:BTO_0002362 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pancreatic duct
+obo:BTO_0002364 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric pit
+obo:BTO_0002366 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # extravillous trophoblast
+obo:BTO_0002370 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colleterial gland
+obo:BTO_0002375 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bronchiole
+obo:BTO_0002376 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # duodenal gland
+obo:BTO_0002397 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostate gland epithelium
+obo:BTO_0002407 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spermary
+obo:BTO_0002417 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # helper T-lymphocyte
+obo:BTO_0002422 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesothelium
+obo:BTO_0002433 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # genital primordium
+obo:BTO_0002434 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dorsal raphe nucleus
+obo:BTO_0002435 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colorectal mucosa
+obo:BTO_0002436 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # myenteric plexus
+obo:BTO_0002437 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # enteric plexus
+obo:BTO_0002441 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pericyte
+obo:BTO_0002444 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # basal forebrain
+obo:BTO_0002445 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # diagonal band
+obo:BTO_0002446 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial septum
+obo:BTO_0002448 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # basal telencephalon
+obo:BTO_0002450 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior hypothalamic nucleus
+obo:BTO_0002451 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dorsal hypothalamic nucleus
+obo:BTO_0002452 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thalamic nucleus
+obo:BTO_0002459 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nucleus reuniens
+obo:BTO_0002462 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # posterior nuclear complex of thalamus
+obo:BTO_0002473 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # infundibular nucleus
+obo:BTO_0002477 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cecal epithelium
+obo:BTO_0002480 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plume
+obo:BTO_0002483 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # interventricular septum
+obo:BTO_0002485 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # atrial appendage
+obo:BTO_0002486 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lupulin gland
+obo:BTO_0002487 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # metacyclic form
+obo:BTO_0002492 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vestimentum
+obo:BTO_0002494 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesangium
+obo:BTO_0002495 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral gyrus
+obo:BTO_0002501 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trabecula
+obo:BTO_0002502 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # kinetoplastid
+obo:BTO_0002503 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # protozoan form
+obo:BTO_0002506 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # enteric nervous system
+obo:BTO_0002507 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # autonomic nervous system
+obo:BTO_0002516 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # odontoclast
+obo:BTO_0002525 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cementum
+obo:BTO_0002536 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # feather vane
+obo:BTO_0002543 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolar wall
+obo:BTO_0002608 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vomeronasal organ
+obo:BTO_0002611 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # axopodium
+obo:BTO_0002613 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lobopodium
+obo:BTO_0002614 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # reticulopodium
+obo:BTO_0002616 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # turion
+obo:BTO_0002617 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thyroid nodule
+obo:BTO_0002619 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # posterior adductor muscle
+obo:BTO_0002621 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # spinal muscle
+obo:BTO_0002626 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # venule
+obo:BTO_0002631 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glume
+obo:BTO_0002643 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cortical collecting duct
+obo:BTO_0002651 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # piriform area
+obo:BTO_0002655 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # postlarva
+obo:BTO_0002660 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inflorescence stalk
+obo:BTO_0002661 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # auditory vesicle
+obo:BTO_0002670 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial geniculate nucleus
+obo:BTO_0002674 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial geniculate body
+obo:BTO_0002675 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mushroom body
+obo:BTO_0002678 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # testicular vein
+obo:BTO_0002681 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal vein
+obo:BTO_0002682 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inferior vena cava
+obo:BTO_0002683 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # superior vena cava
+obo:BTO_0002684 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lymphoid follicle
+obo:BTO_0002689 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oviductal fluid
+obo:BTO_0002690 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # biofilm
+obo:BTO_0002697 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # supraoptic nucleus
+obo:BTO_0002698 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bed nucleus of stria terminalis
+obo:BTO_0002699 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lateral habenular nucleus
+obo:BTO_0002702 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial amygdaloid nucleus
+obo:BTO_0002704 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lateral amygdaloid nucleus
+obo:BTO_0002705 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # septal area
+obo:BTO_0002738 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cement gland
+obo:BTO_0002742 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gynecophoral canal
+obo:BTO_0002743 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # schistosomulum
+obo:BTO_0002774 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amyloid plaque
+obo:BTO_0002776 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inflorescence apex
+obo:BTO_0002778 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rostral ventrolateral medulla
+obo:BTO_0002780 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # visceral muscle
+obo:BTO_0002784 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corpus albicans
+obo:BTO_0002807 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prefrontal cortex
+obo:BTO_0002811 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # flag leaf
+obo:BTO_0002819 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # decidua basalis
+obo:BTO_0002840 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bile ductule
+obo:BTO_0002841 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bile canaliculus
+obo:BTO_0002845 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mammary duct
+obo:BTO_0002851 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # theca interna
+obo:BTO_0002852 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # theca externa
+obo:BTO_0002854 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corn silk
+obo:BTO_0002855 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatic cecum
+obo:BTO_0002856 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # coelomocyte
+obo:BTO_0002857 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eleocyte
+obo:BTO_0002858 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral subcortex
+obo:BTO_0002859 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # esophageal mucosa
+obo:BTO_0002860 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oral mucosa
+obo:BTO_0002879 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chorionic plate
+obo:BTO_0002925 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tracheobronchial epithelium
+obo:BTO_0002930 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fascia
+obo:BTO_0002934 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymic cortex
+obo:BTO_0002977 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # exocrine glandular secretion
+obo:BTO_0002978 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # internal secretion
+obo:BTO_0002984 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # antropyloric mucosa
+obo:BTO_0002990 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastric ulcer
+obo:BTO_0002991 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glandular epithelium
+obo:BTO_0002994 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lacteal cyst
+obo:BTO_0002996 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cavernous artery
+obo:BTO_0003002 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endocervix
+obo:BTO_0003003 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epididymal fluid
+obo:BTO_0003015 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # macula lutea
+obo:BTO_0003048 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neurolemma
+obo:BTO_0003080 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pleural fluid
+obo:BTO_0003082 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine epithelium
+obo:BTO_0003083 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine wall
+obo:BTO_0003084 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vaginal fluid
+obo:BTO_0003086 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rosette leaf
+obo:BTO_0003087 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subiculum
+obo:BTO_0003090 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subventricular zone
+obo:BTO_0003091 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urogenital system
+obo:BTO_0003092 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # urinary system
+obo:BTO_0003093 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cardiofibroblast
+obo:BTO_0003094 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # secondary oocyte
+obo:BTO_0003095 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # normoblast
+obo:BTO_0003096 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # internal male genital organ
+obo:BTO_0003098 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # scrotum
+obo:BTO_0003101 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # female pudendum
+obo:BTO_0003102 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pyramidal neuron
+obo:BTO_0003104 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pro-B-lymphocyte
+obo:BTO_0003114 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # wound fluid
+obo:BTO_0003115 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # major vestibular gland
+obo:BTO_0003116 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # minor vestibular gland
+obo:BTO_0003118 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glans penis
+obo:BTO_0003120 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # atherosclerotic plaque
+obo:BTO_0003121 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # villus
+obo:BTO_0003132 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # microsporidian
+obo:BTO_0003135 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # zona pellucida
+obo:BTO_0003141 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # true leaf
+obo:BTO_0003143 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # coculture
+obo:BTO_0003144 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuron-oligodendrocyte coculture
+obo:BTO_0003145 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vestibulum vaginae
+obo:BTO_0003146 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # zona incerta
+obo:BTO_0003149 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # interalveolar septum
+obo:BTO_0003153 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # perineurium
+obo:BTO_0003155 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pleural mesothelium
+obo:BTO_0003156 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peritoneal mesothelium
+obo:BTO_0003163 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostatic urethra
+obo:BTO_0003164 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cholangiocyte
+obo:BTO_0003168 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cysticercus
+obo:BTO_0003173 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endostyle
+obo:BTO_0003174 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # outer plexiform layer
+obo:BTO_0003175 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inner plexiform layer
+obo:BTO_0003176 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inner nuclear layer
+obo:BTO_0003177 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # semimembranosus
+obo:BTO_0003178 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # biceps
+obo:BTO_0003217 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # melanoblast
+obo:BTO_0003222 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # respiratory bronchiole
+obo:BTO_0003223 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # terminal bronchiole
+obo:BTO_0003248 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # brain endothelium
+obo:BTO_0003256 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corpus amylaceum
+obo:BTO_0003257 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # granulation tissue
+obo:BTO_0003271 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # great saphenous vein
+obo:BTO_0003272 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # small saphenous vein
+obo:BTO_0003305 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epipodite
+obo:BTO_0003358 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # groin
+obo:BTO_0003359 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neointima
+obo:BTO_0003360 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # extraembryonic tissue
+obo:BTO_0003361 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior visceral endoderm
+obo:BTO_0003364 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gingival fluid
+obo:BTO_0003365 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # germinated grain
+obo:BTO_0003367 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # daphnid
+obo:BTO_0003368 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # frontal gland
+obo:BTO_0003369 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # face
+obo:BTO_0003370 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # craniofacial region
+obo:BTO_0003372 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gametophore
+obo:BTO_0003374 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # antheridium
+obo:BTO_0003375 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # archegonium
+obo:BTO_0003377 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # periderm
+obo:BTO_0003378 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # phellem
+obo:BTO_0003380 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # phelloderm
+obo:BTO_0003381 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vestibular system
+obo:BTO_0003382 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inner ear vestibulum
+obo:BTO_0003383 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # semicircular canal
+obo:BTO_0003385 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # etiolated plant tissue
+obo:BTO_0003386 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hypoglossal nerve
+obo:BTO_0003387 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # raphe nucleus
+obo:BTO_0003388 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tegmentum
+obo:BTO_0003389 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nidopallium
+obo:BTO_0003390 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # high vocal center
+obo:BTO_0003391 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatic primordium
+obo:BTO_0003394 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Brockmann body
+obo:BTO_0003396 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pontine nucleus
+obo:BTO_0003398 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ganglion cell layer
+obo:BTO_0003399 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # avian pallium
+obo:BTO_0003400 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hyperpallium
+obo:BTO_0003401 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subpallium
+obo:BTO_0003405 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mesopallium
+obo:BTO_0003408 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # arcopallium
+obo:BTO_0003411 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nucleus isthmo-opticus
+obo:BTO_0003412 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rostral migratory stream
+obo:BTO_0003415 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # conjunctiva
+obo:BTO_0003418 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # biceps femoris
+obo:BTO_0003419 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # biceps brachii
+obo:BTO_0003425 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # area postrema
+obo:BTO_0003426 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fourth ventricle
+obo:BTO_0003427 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Barrett's esophagus
+obo:BTO_0003433 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endometrial gland
+obo:BTO_0003434 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # choanomastigote
+obo:BTO_0003445 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # carotid atherosclerotic plaque
+obo:BTO_0003446 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cholesteatoma tissue
+obo:BTO_0003447 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cavum septum pellucidum
+obo:BTO_0003448 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # septum pellucidum
+obo:BTO_0003453 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dentin
+obo:BTO_0003454 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # eosinophilic myelocyte
+obo:BTO_0003455 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neutrophilic myelocyte
+obo:BTO_0003462 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # outer dental epithelium
+obo:BTO_0003463 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inner dental epithelium
+obo:BTO_0003472 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vagus nerve
+obo:BTO_0003487 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # visceral endoderm
+obo:BTO_0003488 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vibrissa
+obo:BTO_0003489 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vibrissal follicle
+obo:BTO_0003490 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vestibulocochlear nerve
+obo:BTO_0003509 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # headfoot
+obo:BTO_0003594 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hypnozoite
+obo:BTO_0003595 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # knee
+obo:BTO_0003603 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # respiratory mucus
+obo:BTO_0003604 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal parenchyma
+obo:BTO_0003606 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # airway fluid
+obo:BTO_0003607 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chondroblast
+obo:BTO_0003616 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peritoneal dialysis fluid
+obo:BTO_0003617 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peritoneal exudate
+obo:BTO_0003623 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine fluid
+obo:BTO_0003625 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intervertebral disc
+obo:BTO_0003626 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nucleus pulposus
+obo:BTO_0003627 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # annulus fibrosus
+obo:BTO_0003632 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervicovaginal fluid
+obo:BTO_0003634 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # esophageal gland
+obo:BTO_0003647 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory tract
+obo:BTO_0003648 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory nerve
+obo:BTO_0003649 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior olfactory nucleus
+obo:BTO_0003650 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # optic ganglion
+obo:BTO_0003653 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory glomerulus
+obo:BTO_0003654 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ventricular zone
+obo:BTO_0003655 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thyroid cartilage
+obo:BTO_0003657 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tergal gland
+obo:BTO_0003658 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tergal gland secretion
+obo:BTO_0003660 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # laryngeal cartilage
+obo:BTO_0003661 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovary epithelium
+obo:BTO_0003662 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nucleus recessus lateralis
+obo:BTO_0003668 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leaf bud
+obo:BTO_0003669 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # keloid
+obo:BTO_0003670 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # microfilarial stage
+obo:BTO_0003671 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # germinal center
+obo:BTO_0003673 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nephrotome
+obo:BTO_0003674 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # temporomandibular joint
+obo:BTO_0003678 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # placental disc
+obo:BTO_0003684 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # habenula
+obo:BTO_0003686 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial habenular nucleus
+obo:BTO_0003698 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # coronary atherosclerotic plaque
+obo:BTO_0003702 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rheumatoid arthritis disease specific synovial tissue
+obo:BTO_0003703 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rheumatoid arthritis disease specific fibroblast-like synoviocyte
+obo:BTO_0003705 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cornu ammonis
+obo:BTO_0003717 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vesicular gland
+obo:BTO_0003718 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vasculature
+obo:BTO_0003737 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tailbud stage
+obo:BTO_0003738 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tenia tecta
+obo:BTO_0003747 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # superficial temporal artery
+obo:BTO_0003748 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # superficial temporal vein
+obo:BTO_0003749 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pars compacta
+obo:BTO_0003750 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pars reticulata
+obo:BTO_0003751 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # submucosal gland
+obo:BTO_0003752 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lamina epithelialis mucosa
+obo:BTO_0003785 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ray floret
+obo:BTO_0003787 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intraparietal sulcus
+obo:BTO_0003788 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # splenial gyrus
+obo:BTO_0003791 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glandular stomach
+obo:BTO_0003794 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chlorenchyma
+obo:BTO_0003799 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # secretory trichome
+obo:BTO_0003801 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovum
+obo:BTO_0003802 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # macrogamete
+obo:BTO_0003805 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alpha-motoneuron
+obo:BTO_0003810 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # enrichment culture
+obo:BTO_0003811 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # interneuron
+obo:BTO_0003833 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # buccal mucosa
+obo:BTO_0003834 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # conceptus
+obo:BTO_0003835 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebellar nucleus
+obo:BTO_0003840 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebrovascular system
+obo:BTO_0003844 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inferior olivary nucleus
+obo:BTO_0003852 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # astroglia
+obo:BTO_0003867 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # deutocerebrum
+obo:BTO_0003868 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # protocerebrum
+obo:BTO_0003869 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # tritocerebrum
+obo:BTO_0003870 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # insect tracheal system
+obo:BTO_0003876 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant funiculus
+obo:BTO_0003882 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blastocyte
+obo:BTO_0003906 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uroepithelium
+obo:BTO_0003914 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # interstitial cell of Cajal
+obo:BTO_0003915 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hairy root culture
+obo:BTO_0003925 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal papilla
+obo:BTO_0003926 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal pyramid
+obo:BTO_0003927 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # metacercaria
+obo:BTO_0003938 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leaf disc
+obo:BTO_0003940 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # macula densa
+obo:BTO_0003948 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # distal tubular epithelium
+obo:BTO_0003951 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial longitudinal fasciculus
+obo:BTO_0003953 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # endomesoderm
+obo:BTO_0003954 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dopaminergic system
+obo:BTO_0003963 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nucleus solitarius
+obo:BTO_0003969 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hair follicle outer root sheath
+obo:BTO_0003971 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hair follicle inner root sheath
+obo:BTO_0003975 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cingulate cortex
+obo:BTO_0003976 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cingulate gyrus
+obo:BTO_0003977 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # retrosplenial region
+obo:BTO_0003987 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # root culture
+obo:BTO_0003994 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hoof
+obo:BTO_0004014 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic cerebral cortex
+obo:BTO_0004024 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neural cord
+obo:BTO_0004032 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dopaminergic neuron
+obo:BTO_0004033 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # catecholaminergic neuron
+obo:BTO_0004041 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # abdominal adipose tissue
+obo:BTO_0004042 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subcutaneous adipose tissue
+obo:BTO_0004043 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intramuscular adipose tissue
+obo:BTO_0004045 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # air pouch
+obo:BTO_0004046 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alveolar mucosa
+obo:BTO_0004047 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # apical hook
+obo:BTO_0004048 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aril
+obo:BTO_0004053 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # umbilical cord blood
+obo:BTO_0004057 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fruit juice
+obo:BTO_0004060 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fibroblast-like synoviocyte
+obo:BTO_0004064 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chloragocyte
+obo:BTO_0004074 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cystocyte
+obo:BTO_0004084 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epitrochlearis muscle
+obo:BTO_0004089 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # male urethra
+obo:BTO_0004101 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fascicle
+obo:BTO_0004102 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral cortical neuron
+obo:BTO_0004103 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leaf primordium
+obo:BTO_0004104 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # insect labium
+obo:BTO_0004107 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # antral mucosa
+obo:BTO_0004110 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pyloric mucosa
+obo:BTO_0004128 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lung endothelium
+obo:BTO_0004140 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ethmoid bone
+obo:BTO_0004141 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cribriform plate
+obo:BTO_0004147 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lumbar spine
+obo:BTO_0004148 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cervical spine
+obo:BTO_0004150 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thoracic spine
+obo:BTO_0004165 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # meibomian gland
+obo:BTO_0004185 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # olfactory receptor neuron
+obo:BTO_0004195 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pharyngeal organ
+obo:BTO_0004198 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prostomium
+obo:BTO_0004209 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seed vessel
+obo:BTO_0004211 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sensillum trichodeum
+obo:BTO_0004212 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # seta
+obo:BTO_0004224 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stomodeum
+obo:BTO_0004235 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine horn
+obo:BTO_0004241 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovariole
+obo:BTO_0004242 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vitellarium
+obo:BTO_0004249 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior cingulate cortex
+obo:BTO_0004250 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # posterior cingulate cortex
+obo:BTO_0004253 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # plant candle
+obo:BTO_0004256 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # long bone
+obo:BTO_0004271 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hyalocyte
+obo:BTO_0004280 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peptonephridium
+obo:BTO_0004285 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oviductal ampulla
+obo:BTO_0004291 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # umbilical vein smooth muscle
+obo:BTO_0004292 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # claustrum
+obo:BTO_0004304 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cell lysate
+obo:BTO_0004305 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hairy root
+obo:BTO_0004307 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hepatic artery
+obo:BTO_0004342 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # agranular insular cortex
+obo:BTO_0004343 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # auditory cortex
+obo:BTO_0004345 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # entorhinal cortex
+obo:BTO_0004346 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial entorhinal cortex
+obo:BTO_0004347 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lateral entorhinal cortex
+obo:BTO_0004348 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # motor cortex
+obo:BTO_0004353 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # somatosensory cortex
+obo:BTO_0004354 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # postcentral gyrus
+obo:BTO_0004355 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # perirhinal cortex
+obo:BTO_0004358 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sinus node
+obo:BTO_0004359 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # paw
+obo:BTO_0004361 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # callus culture
+obo:BTO_0004362 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # colon muscle
+obo:BTO_0004364 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastroesophageal junction
+obo:BTO_0004366 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lateral geniculate nucleus
+obo:BTO_0004367 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lateral geniculate body
+obo:BTO_0004368 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vestibular nucleus
+obo:BTO_0004370 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # lateral vestibular nucleus
+obo:BTO_0004371 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial vestibular nucleus
+obo:BTO_0004372 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # superior vestibular nucleus
+obo:BTO_0004373 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ventral posterior nucleus
+obo:BTO_0004377 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pup
+obo:BTO_0004378 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # blood vessel wall
+obo:BTO_0004379 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parahippocampal region
+obo:BTO_0004380 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parahippocampal gyrus
+obo:BTO_0004381 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # prelimbic cortex
+obo:BTO_0004382 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skin epithelium
+obo:BTO_0004383 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # follicular fluid
+obo:BTO_0004385 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cardinal vein
+obo:BTO_0004387 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior cardinal vein
+obo:BTO_0004388 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # common cardinal vein
+obo:BTO_0004395 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # microvessel
+obo:BTO_0004396 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # femorotibial joint
+obo:BTO_0004418 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Daltons lymphoma ascites
+obo:BTO_0004419 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dermal fibroblast
+obo:BTO_0004421 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # salivary gland epithelium
+obo:BTO_0004422 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pleural cavity
+obo:BTO_0004423 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # empyema fluid
+obo:BTO_0004425 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stratum granulosum cerebelli
+obo:BTO_0004477 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial temporal lobe
+obo:BTO_0004480 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nasopharynx epithelium
+obo:BTO_0004483 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian surface epithelium
+obo:BTO_0004496 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # preosteoclast
+obo:BTO_0004502 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vascular cambium
+obo:BTO_0004503 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # submerged culture
+obo:BTO_0004518 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine gland
+obo:BTO_0004520 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # regulatory T-lymphocyte
+obo:BTO_0004524 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # germinal epithelium
+obo:BTO_0004525 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # subcutaneous tissue
+obo:BTO_0004527 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # uterine luminal fluid
+obo:BTO_0004528 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # high endothelial venule
+obo:BTO_0004536 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medullary collecting duct
+obo:BTO_0004538 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # initial collecting tubule
+obo:BTO_0004539 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # connecting tubule
+obo:BTO_0004544 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inner medullary collecting duct
+obo:BTO_0004549 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # superficial inguinal lymph node
+obo:BTO_0004554 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parotid gland duct
+obo:BTO_0004556 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # submandibular gland duct
+obo:BTO_0004560 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymic medulla
+obo:BTO_0004565 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thymic medullary epithelium
+obo:BTO_0004569 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian fluid
+obo:BTO_0004570 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ulcer tissue
+obo:BTO_0004579 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # parenchyma of thyroid gland
+obo:BTO_0004586 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alevin
+obo:BTO_0004593 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # epiblast
+obo:BTO_0004597 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nephrocyte
+obo:BTO_0004608 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Henles loop
+obo:BTO_0004617 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # mucilage
+obo:BTO_0004628 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aortic valve
+obo:BTO_0004629 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # metaphloem
+obo:BTO_0004630 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # middle midgut
+obo:BTO_0004634 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thoracico-abdominal ganglion
+obo:BTO_0004638 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peribronchial gland
+obo:BTO_0004642 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # abductor
+obo:BTO_0004650 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dorsal fin
+obo:BTO_0004651 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pelvic fin
+obo:BTO_0004652 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anal fin
+obo:BTO_0004653 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pectoral fin
+obo:BTO_0004657 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # premonocyte
+obo:BTO_0004658 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # imaginal disc
+obo:BTO_0004659 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # exoskeleton
+obo:BTO_0004665 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # iliac artery
+obo:BTO_0004666 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # external iliac artery
+obo:BTO_0004667 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # internal iliac artery
+obo:BTO_0004668 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hand
+obo:BTO_0004669 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # finger
+obo:BTO_0004670 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # interdigit
+obo:BTO_0004671 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hair medulla
+obo:BTO_0004672 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hair shaft
+obo:BTO_0004673 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dorsal aorta
+obo:BTO_0004674 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ventral aorta
+obo:BTO_0004676 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral peduncle
+obo:BTO_0004679 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # capillary pericyte
+obo:BTO_0004680 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # stratum basale
+obo:BTO_0004681 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bursa copulatrix
+obo:BTO_0004684 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # genital pore
+obo:BTO_0004685 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bony labyrinth
+obo:BTO_0004687 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # orbit
+obo:BTO_0004688 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # regio orbitalis
+obo:BTO_0004689 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # external gill
+obo:BTO_0004690 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # arterial system
+obo:BTO_0004691 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hippocampus minor
+obo:BTO_0004692 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # venous system
+obo:BTO_0004693 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # regio parietalis capitis
+obo:BTO_0004695 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # aortic root
+obo:BTO_0004696 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # external carotid artery
+obo:BTO_0004697 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # internal carotid artery
+obo:BTO_0004698 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # regio oralis
+obo:BTO_0004700 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior pharynx
+obo:BTO_0004701 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # dorsal striatum
+obo:BTO_0004702 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ventral striatum
+obo:BTO_0004703 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # striate cortex
+obo:BTO_0004704 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # extrastriate cortex
+obo:BTO_0004705 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # connecting stalk
+obo:BTO_0004706 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ankle joint
+obo:BTO_0004708 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thyroid follicle
+obo:BTO_0004709 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # thyroid primordium
+obo:BTO_0004711 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # head capsule
+obo:BTO_0004714 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # palatine tonsil
+obo:BTO_0004719 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # excretory canal
+obo:BTO_0004724 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # animal cap
+obo:BTO_0004725 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic fibroblast
+obo:BTO_0004726 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # embryonic brain
+obo:BTO_0004727 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # larval brain
+obo:BTO_0004728 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rheumatoid arthritis disease specific synovial fluid
+obo:BTO_0004729 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peripheral blood lymphocyte
+obo:BTO_0004732 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bone marrow-derived macrophage
+obo:BTO_0004733 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gravid adult
+obo:BTO_0004756 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # venous endothelium
+obo:BTO_0004757 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # arterial endothelium
+obo:BTO_0004769 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # teratocyte
+obo:BTO_0004776 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # striatonigral neuron
+obo:BTO_0004778 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medium spiny neuron
+obo:BTO_0004789 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ruminal fluid
+obo:BTO_0004791 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # root primordium
+obo:BTO_0004797 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # accessory olfactory bulb
+obo:BTO_0004798 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # accessory sex gland
+obo:BTO_0004800 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amnioserosa
+obo:BTO_0004803 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # buccal epithelium
+obo:BTO_0004834 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # middle frontal gyrus
+obo:BTO_0004835 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inferior frontal gyrus
+obo:BTO_0004836 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # superior frontal gyrus
+obo:BTO_0004838 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # muscular coat
+obo:BTO_0004849 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pharyngeal gland
+obo:BTO_0004857 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ookinete
+obo:BTO_0004875 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # labellum
+obo:BTO_0004876 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # distal tip
+obo:BTO_0004878 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # enteric muscle
+obo:BTO_0004882 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ventral midbrain
+obo:BTO_0004902 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cholinergic neuron
+obo:BTO_0004906 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # molecular layer
+obo:BTO_0004909 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Purkinje layer
+obo:BTO_0004913 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vastus medialis
+obo:BTO_0004914 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # rheumatoid arthritis disease specific synovial fibroblast
+obo:BTO_0004957 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # hydathode
+obo:BTO_0004977 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nasal lavage fluid
+obo:BTO_0004978 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # carotid sinus nerve
+obo:BTO_0004979 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # glossopharyngeal nerve
+obo:BTO_0004982 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gonocyte
+obo:BTO_0004984 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # alate adult
+obo:BTO_0004985 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # angioblast
+obo:BTO_0004995 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osphradium
+obo:BTO_0004999 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vaginal smooth muscle
+obo:BTO_0005003 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # villous trophoblast
+obo:BTO_0005008 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # psammoma body
+obo:BTO_0005024 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # gastrointestinal smooth muscle
+obo:BTO_0005035 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # Fanconi anemia disease specific cell type
+obo:BTO_0005053 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # midgut epithelium
+obo:BTO_0005055 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # scale
+obo:BTO_0005078 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # foot sole
+obo:BTO_0005081 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # periurethral tissue
+obo:BTO_0005082 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # skin mucus
+obo:BTO_0005084 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # vocal fold
+obo:BTO_0005085 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # common penile artery
+obo:BTO_0005086 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # arteria profunda penis
+obo:BTO_0005089 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # perichondrium
+obo:BTO_0005090 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # inner chondrogenic layer of perichondrium
+obo:BTO_0005094 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # leaf sheath
+obo:BTO_0005100 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # implantation fossa
+obo:BTO_0005115 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # salivary duct
+obo:BTO_0005122 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian cyst
+obo:BTO_0005123 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ovarian cyst fluid
+obo:BTO_0005124 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # platysma muscle
+obo:BTO_0005125 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # sternocleidomastoid muscle
+obo:BTO_0005132 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # arrector pili muscle
+obo:BTO_0005142 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # ameloblastic layer
+obo:BTO_0005145 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # chorionic epithelium
+obo:BTO_0005151 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # anterior horn
+obo:BTO_0005157 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # juxtaglomerular apparatus
+obo:BTO_0005160 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oil gland
+obo:BTO_0005170 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # keratocyte
+obo:BTO_0005180 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pterygium
+obo:BTO_0005188 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # trunk kidney
+obo:BTO_0005189 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # head kidney
+obo:BTO_0005194 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # fine root
+obo:BTO_0005197 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # peltate gland
+obo:BTO_0005202 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # bulbil
+obo:BTO_0005205 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cerebral artery
+obo:BTO_0005206 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # middle cerebral artery
+obo:BTO_0005208 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # right middle cerebral artery
+obo:BTO_0005211 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # choriodecidua
+obo:BTO_0005213 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # circular smooth muscle
+obo:BTO_0005214 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # longitudinal smooth muscle
+obo:BTO_0005216 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # keratocyst
+obo:BTO_0005219 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # osteophyte
+obo:BTO_0005226 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # medial pterygoid muscle
+obo:BTO_0005239 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # renal tubule epithelium
+obo:BTO_0005240 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # pharyngeal epithelium
+obo:BTO_0005257 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # oropharynx
+obo:BTO_0005268 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # neuropil
+obo:BTO_0005269 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # antennal lobe
+obo:BTO_0005273 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # adventitious root
+obo:BTO_0005278 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # cestode
+obo:BTO_0005281 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # intercostal muscle
+obo:BTO_0005305 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # corn ear
+obo:BTO_0005312 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # amoeba
+obo:BTO_0005313 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # nerve sheath
+obo:BTO_0005351 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # optic cup
+obo:BTO_0005385 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # root quiescent center
+obo:BTO_0005401 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # junctional zone
+obo:BTO_0005404 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # labyrinthine zone
+obo:BTO_0005405 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # velum
+obo:BTO_0005444 rdfs:subClassOf bae:BrendaTissues ;
+  bat:notSubClass <http://dto.org/DTO/DTO_000> . # root nodule primordium

--- a/data/ontology/brendafix.ttl
+++ b/data/ontology/brendafix.ttl
@@ -1,0 +1,3007 @@
+# auto-generated file that divides BRENDA terms into cell vs. tissue branches
+
+@prefix bao:   <http://www.bioassayontology.org/bao#> .
+@prefix bat:   <http://www.bioassayontology.org/bat#> .
+@prefix bae:   <http://www.bioassayexpress.org/bae#>  .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix obo:   <http://purl.obolibrary.org/obo/> .
+
+bae:BrendaCell
+  rdfs:label "cell lines" ;
+  rdfs:subClassOf <http://dto.org/DTO/DTO_000> ;
+  a bat:preferredParent ;
+  .
+
+bae:BrendaTissues
+  rdfs:label "tissues" ;
+  rdfs:subClassOf <http://dto.org/DTO/DTO_000> ;
+  a bat:preferredParent ;
+  .
+
+# reparenting cells
+
+obo:BTO_0000003 rdfs:subClassOf bae:BrendaCell . # intestinal cell line
+obo:BTO_0000006 rdfs:subClassOf bae:BrendaCell . # osteoblastoma cell
+obo:BTO_0000028 rdfs:subClassOf bae:BrendaCell . # pancreatic acinar cell
+obo:BTO_0000032 rdfs:subClassOf bae:BrendaCell . # colonic adenocarcinoma cell
+obo:BTO_0000036 rdfs:subClassOf bae:BrendaCell . # gastric adenocarcinoma cell
+obo:BTO_0000037 rdfs:subClassOf bae:BrendaCell . # renal cell carcinoma cell
+obo:BTO_0000067 rdfs:subClassOf bae:BrendaCell . # kidney cell line
+obo:BTO_0000094 rdfs:subClassOf bae:BrendaCell . # ascites tumor cell
+obo:BTO_0000100 rdfs:subClassOf bae:BrendaCell . # astrocytoma cell
+obo:BTO_0000101 rdfs:subClassOf bae:BrendaCell . # astrocytoma cell line
+obo:BTO_0000104 rdfs:subClassOf bae:BrendaCell . # lymphoma cell line
+obo:BTO_0000110 rdfs:subClassOf bae:BrendaCell . # amniotic cell line
+obo:BTO_0000125 rdfs:subClassOf bae:BrendaCell . # blast cell
+obo:BTO_0000150 rdfs:subClassOf bae:BrendaCell . # breast cancer cell
+obo:BTO_0000152 rdfs:subClassOf bae:BrendaCell . # infected cell
+obo:BTO_0000161 rdfs:subClassOf bae:BrendaCell . # lung fibroblast cell line
+obo:BTO_0000167 rdfs:subClassOf bae:BrendaCell . # adenocarcinoma cell line
+obo:BTO_0000176 rdfs:subClassOf bae:BrendaCell . # carcinoma cell
+obo:BTO_0000177 rdfs:subClassOf bae:BrendaCell . # BG-1 cell
+obo:BTO_0000178 rdfs:subClassOf bae:BrendaCell . # adenoma cell
+obo:BTO_0000180 rdfs:subClassOf bae:BrendaCell . # cervical carcinoma cell
+obo:BTO_0000181 rdfs:subClassOf bae:BrendaCell . # Lewis lung carcinoma cell line
+obo:BTO_0000184 rdfs:subClassOf bae:BrendaCell . # medullary thyroid carcinoma cell
+obo:BTO_0000186 rdfs:subClassOf bae:BrendaCell . # lobular carcinoma cell
+obo:BTO_0000188 rdfs:subClassOf bae:BrendaCell . # colonic cell line
+obo:BTO_0000189 rdfs:subClassOf bae:BrendaCell . # small cell lung cancer cell
+obo:BTO_0000191 rdfs:subClassOf bae:BrendaCell . # medullary carcinoma cell
+obo:BTO_0000192 rdfs:subClassOf bae:BrendaCell . # nasopharyngeal carcinoma cell
+obo:BTO_0000193 rdfs:subClassOf bae:BrendaCell . # rectal cancer cell
+obo:BTO_0000194 rdfs:subClassOf bae:BrendaCell . # endometrioid carcinoma cell
+obo:BTO_0000196 rdfs:subClassOf bae:BrendaCell . # thyroid cancer cell
+obo:BTO_0000197 rdfs:subClassOf bae:BrendaCell . # carcinosarcoma cell
+obo:BTO_0000201 rdfs:subClassOf bae:BrendaCell . # pheochromocytoma cell line
+obo:BTO_0000218 rdfs:subClassOf bae:BrendaCell . # BALB/3T3 cell
+obo:BTO_0000223 rdfs:subClassOf bae:BrendaCell . # teratocarcinoma cell
+obo:BTO_0000224 rdfs:subClassOf bae:BrendaCell . # liver cell line
+obo:BTO_0000225 rdfs:subClassOf bae:BrendaCell . # CEM cell
+obo:BTO_0000228 rdfs:subClassOf bae:BrendaCell . # C-1300 cell
+obo:BTO_0000250 rdfs:subClassOf bae:BrendaCell . # chondrosarcoma cell
+obo:BTO_0000256 rdfs:subClassOf bae:BrendaCell . # myoblast cell line
+obo:BTO_0000257 rdfs:subClassOf bae:BrendaCell . # uterine cancer cell
+obo:BTO_0000259 rdfs:subClassOf bae:BrendaCell . # chromaffin cell
+obo:BTO_0000264 rdfs:subClassOf bae:BrendaCell . # bone marrow cell line
+obo:BTO_0000279 rdfs:subClassOf bae:BrendaCell . # testicular cancer cell
+obo:BTO_0000306 rdfs:subClassOf bae:BrendaCell . # teratocarcinoma cell line
+obo:BTO_0000308 rdfs:subClassOf bae:BrendaCell . # cytotoxic T-lymphocyte cell line
+obo:BTO_0000309 rdfs:subClassOf bae:BrendaCell . # bundle sheath cell
+obo:BTO_0000353 rdfs:subClassOf bae:BrendaCell . # lung cell line
+obo:BTO_0000356 rdfs:subClassOf bae:BrendaCell . # breast cancer cell line
+obo:BTO_0000362 rdfs:subClassOf bae:BrendaCell . # urinary bladder cancer cell
+obo:BTO_0000373 rdfs:subClassOf bae:BrendaCell . # Ehrlich ascites carcinoma cell
+obo:BTO_0000375 rdfs:subClassOf bae:BrendaCell . # keratinocyte cell line
+obo:BTO_0000383 rdfs:subClassOf bae:BrendaCell . # renal cell carcinoma cell line
+obo:BTO_0000392 rdfs:subClassOf bae:BrendaCell . # plasma cell
+obo:BTO_0000395 rdfs:subClassOf bae:BrendaCell . # alveolar cell
+obo:BTO_0000396 rdfs:subClassOf bae:BrendaCell . # EAhy 926 cell
+obo:BTO_0000400 rdfs:subClassOf bae:BrendaCell . # sarcoma cell line
+obo:BTO_0000403 rdfs:subClassOf bae:BrendaCell . # mastocytoma cell line
+obo:BTO_0000407 rdfs:subClassOf bae:BrendaCell . # osteosarcoma cell line
+obo:BTO_0000414 rdfs:subClassOf bae:BrendaCell . # epithelial cell
+obo:BTO_0000426 rdfs:subClassOf bae:BrendaCell . # erythroleukemia cell
+obo:BTO_0000427 rdfs:subClassOf bae:BrendaCell . # pituitary gland cell line
+obo:BTO_0000433 rdfs:subClassOf bae:BrendaCell . # exocrine acinar cell
+obo:BTO_0000453 rdfs:subClassOf bae:BrendaCell . # fibroblast cell line
+obo:BTO_0000456 rdfs:subClassOf bae:BrendaCell . # plasmacytoma cell line
+obo:BTO_0000459 rdfs:subClassOf bae:BrendaCell . # fibrosarcoma cell
+obo:BTO_0000460 rdfs:subClassOf bae:BrendaCell . # fibrosarcoma cell line
+obo:BTO_0000489 rdfs:subClassOf bae:BrendaCell . # intestinal cancer cell
+obo:BTO_0000492 rdfs:subClassOf bae:BrendaCell . # MST cell
+obo:BTO_0000498 rdfs:subClassOf bae:BrendaCell . # gastric cancer cell
+obo:BTO_0000526 rdfs:subClassOf bae:BrendaCell . # glioma cell
+obo:BTO_0000527 rdfs:subClassOf bae:BrendaCell . # glioblastoma cell
+obo:BTO_0000529 rdfs:subClassOf bae:BrendaCell . # C6 glioma cell
+obo:BTO_0000535 rdfs:subClassOf bae:BrendaCell . # germ cell
+obo:BTO_0000540 rdfs:subClassOf bae:BrendaCell . # pollen mother cell
+obo:BTO_0000542 rdfs:subClassOf bae:BrendaCell . # granulosa cell
+obo:BTO_0000544 rdfs:subClassOf bae:BrendaCell . # guard cell
+obo:BTO_0000551 rdfs:subClassOf bae:BrendaCell . # lung cancer cell
+obo:BTO_0000552 rdfs:subClassOf bae:BrendaCell . # HaCaT cell
+obo:BTO_0000574 rdfs:subClassOf bae:BrendaCell . # hematopoietic cell
+obo:BTO_0000576 rdfs:subClassOf bae:BrendaCell . # B-16 cell
+obo:BTO_0000577 rdfs:subClassOf bae:BrendaCell . # Morris hepatoma 3924A cell
+obo:BTO_0000578 rdfs:subClassOf bae:BrendaCell . # hepatoma cell line
+obo:BTO_0000579 rdfs:subClassOf bae:BrendaCell . # eye cancer cell
+obo:BTO_0000583 rdfs:subClassOf bae:BrendaCell . # bone marrow cancer cell
+obo:BTO_0000584 rdfs:subClassOf bae:BrendaCell . # pancreatic cancer cell
+obo:BTO_0000585 rdfs:subClassOf bae:BrendaCell . # intraocular melanoma cell
+obo:BTO_0000586 rdfs:subClassOf bae:BrendaCell . # colonic cancer cell
+obo:BTO_0000592 rdfs:subClassOf bae:BrendaCell . # adrenal gland cancer cell
+obo:BTO_0000594 rdfs:subClassOf bae:BrendaCell . # liver cancer cell
+obo:BTO_0000604 rdfs:subClassOf bae:BrendaCell . # adenocarcinoma cell
+obo:BTO_0000608 rdfs:subClassOf bae:BrendaCell . # hepatoma cell
+obo:BTO_0000610 rdfs:subClassOf bae:BrendaCell . # hybridoma cell
+obo:BTO_0000632 rdfs:subClassOf bae:BrendaCell . # insulinoma cell
+obo:BTO_0000638 rdfs:subClassOf bae:BrendaCell . # interrenal cell
+obo:BTO_0000658 rdfs:subClassOf bae:BrendaCell . # uterine adenocarcinoma cell
+obo:BTO_0000669 rdfs:subClassOf bae:BrendaCell . # embryonic cell line
+obo:BTO_0000680 rdfs:subClassOf bae:BrendaCell . # kidney cancer cell
+obo:BTO_0000681 rdfs:subClassOf bae:BrendaCell . # KM-3 cell
+obo:BTO_0000685 rdfs:subClassOf bae:BrendaCell . # Kupffer cell
+obo:BTO_0000686 rdfs:subClassOf bae:BrendaCell . # Kurloff cell
+obo:BTO_0000705 rdfs:subClassOf bae:BrendaCell . # Langerhans cell
+obo:BTO_0000711 rdfs:subClassOf bae:BrendaCell . # glioma cell line
+obo:BTO_0000716 rdfs:subClassOf bae:BrendaCell . # pancreatic beta cell line
+obo:BTO_0000725 rdfs:subClassOf bae:BrendaCell . # hematopoietic stem cell
+obo:BTO_0000727 rdfs:subClassOf bae:BrendaCell . # multiple myeloma cell line
+obo:BTO_0000729 rdfs:subClassOf bae:BrendaCell . # carcinoid cell
+obo:BTO_0000731 rdfs:subClassOf bae:BrendaCell . # acute lymphoblastic leukemia cell
+obo:BTO_0000737 rdfs:subClassOf bae:BrendaCell . # leukemia cell line
+obo:BTO_0000741 rdfs:subClassOf bae:BrendaCell . # lymphocytic leukemia cell line
+obo:BTO_0000743 rdfs:subClassOf bae:BrendaCell . # pre-B-lymphocyte cell line
+obo:BTO_0000745 rdfs:subClassOf bae:BrendaCell . # Lewis lung carcinoma cell
+obo:BTO_0000746 rdfs:subClassOf bae:BrendaCell . # preadipocyte cell line
+obo:BTO_0000755 rdfs:subClassOf bae:BrendaCell . # Leydig cell
+obo:BTO_0000760 rdfs:subClassOf bae:BrendaCell . # LLC-PK1 cell
+obo:BTO_0000762 rdfs:subClassOf bae:BrendaCell . # lung cancer cell line
+obo:BTO_0000773 rdfs:subClassOf bae:BrendaCell . # lymphoblastoid cell line
+obo:BTO_0000774 rdfs:subClassOf bae:BrendaCell . # lymphoblastoma cell
+obo:BTO_0000783 rdfs:subClassOf bae:BrendaCell . # pancreatic beta cell
+obo:BTO_0000785 rdfs:subClassOf bae:BrendaCell . # lymphoma cell
+obo:BTO_0000787 rdfs:subClassOf bae:BrendaCell . # gastric cancer cell line
+obo:BTO_0000792 rdfs:subClassOf bae:BrendaCell . # urinary bladder cancer cell line
+obo:BTO_0000794 rdfs:subClassOf bae:BrendaCell . # pancreatic cancer cell line
+obo:BTO_0000795 rdfs:subClassOf bae:BrendaCell . # L-5178-Y cell
+obo:BTO_0000797 rdfs:subClassOf bae:BrendaCell . # colonic cancer cell line
+obo:BTO_0000799 rdfs:subClassOf bae:BrendaCell . # lymphosarcoma cell
+obo:BTO_0000803 rdfs:subClassOf bae:BrendaCell . # pancreatic delta cell
+obo:BTO_0000811 rdfs:subClassOf bae:BrendaCell . # ovary cancer cell line
+obo:BTO_0000830 rdfs:subClassOf bae:BrendaCell . # mast cell
+obo:BTO_0000832 rdfs:subClassOf bae:BrendaCell . # mastocytoma cell
+obo:BTO_0000845 rdfs:subClassOf bae:BrendaCell . # meiotic cell
+obo:BTO_0000846 rdfs:subClassOf bae:BrendaCell . # erythroleukemia cell line
+obo:BTO_0000848 rdfs:subClassOf bae:BrendaCell . # melanoma cell
+obo:BTO_0000849 rdfs:subClassOf bae:BrendaCell . # melanoma cell line
+obo:BTO_0000850 rdfs:subClassOf bae:BrendaCell . # amelanotic melanoma cell
+obo:BTO_0000851 rdfs:subClassOf bae:BrendaCell . # adrenal cortex cell line
+obo:BTO_0000853 rdfs:subClassOf bae:BrendaCell . # mesangial cell
+obo:BTO_0000860 rdfs:subClassOf bae:BrendaCell . # CHRB-30 cell
+obo:BTO_0000872 rdfs:subClassOf bae:BrendaCell . # oligodendrocytic cell line
+obo:BTO_0000875 rdfs:subClassOf bae:BrendaCell . # N20.1 cell
+obo:BTO_0000878 rdfs:subClassOf bae:BrendaCell . # mononuclear cell
+obo:BTO_0000885 rdfs:subClassOf bae:BrendaCell . # tongue cell line
+obo:BTO_0000889 rdfs:subClassOf bae:BrendaCell . # Burkitt lymphoma cell line
+obo:BTO_0000891 rdfs:subClassOf bae:BrendaCell . # NTERA-2 cell
+obo:BTO_0000898 rdfs:subClassOf bae:BrendaCell . # myeloma cell
+obo:BTO_0000899 rdfs:subClassOf bae:BrendaCell . # myeloma cell line
+obo:BTO_0000906 rdfs:subClassOf bae:BrendaCell . # myeloid cell line
+obo:BTO_0000908 rdfs:subClassOf bae:BrendaCell . # myrosin cell
+obo:BTO_0000914 rdfs:subClassOf bae:BrendaCell . # natural killer cell
+obo:BTO_0000931 rdfs:subClassOf bae:BrendaCell . # neuroblastoma cell
+obo:BTO_0000932 rdfs:subClassOf bae:BrendaCell . # neuroblastoma cell line
+obo:BTO_0000939 rdfs:subClassOf bae:BrendaCell . # basal cell
+obo:BTO_0000947 rdfs:subClassOf bae:BrendaCell . # neuronal cell line
+obo:BTO_0000950 rdfs:subClassOf bae:BrendaCell . # Novikoff hepatoma cell
+obo:BTO_0000953 rdfs:subClassOf bae:BrendaCell . # nurse cell
+obo:BTO_0000955 rdfs:subClassOf bae:BrendaCell . # laryngeal cell line
+obo:BTO_0000963 rdfs:subClassOf bae:BrendaCell . # oligodendroglioma cell
+obo:BTO_0000969 rdfs:subClassOf bae:BrendaCell . # osteoclastoma cell
+obo:BTO_0000970 rdfs:subClassOf bae:BrendaCell . # osteosarcoma cell
+obo:BTO_0000977 rdfs:subClassOf bae:BrendaCell . # ovary cell line
+obo:BTO_0000986 rdfs:subClassOf bae:BrendaCell . # pachytene cell
+obo:BTO_0000990 rdfs:subClassOf bae:BrendaCell . # pancreatic alpha cell
+obo:BTO_0000993 rdfs:subClassOf bae:BrendaCell . # paneth cell
+obo:BTO_0001003 rdfs:subClassOf bae:BrendaCell . # parotid acinar cell
+obo:BTO_0001005 rdfs:subClassOf bae:BrendaCell . # amnion epithelial cell
+obo:BTO_0001011 rdfs:subClassOf bae:BrendaCell . # cerebellar Purkinje cell
+obo:BTO_0001018 rdfs:subClassOf bae:BrendaCell . # basophilic leukemia cell line
+obo:BTO_0001023 rdfs:subClassOf bae:BrendaCell . # ovary cancer cell
+obo:BTO_0001025 rdfs:subClassOf bae:BrendaCell . # peripheral blood mononuclear cell
+obo:BTO_0001033 rdfs:subClassOf bae:BrendaCell . # prostate cancer cell line
+obo:BTO_0001035 rdfs:subClassOf bae:BrendaCell . # hematopoietic cell line
+obo:BTO_0001037 rdfs:subClassOf bae:BrendaCell . # sensory cell
+obo:BTO_0001039 rdfs:subClassOf bae:BrendaCell . # peritubular cell
+obo:BTO_0001045 rdfs:subClassOf bae:BrendaCell . # T-lymphocyte cell line
+obo:BTO_0001054 rdfs:subClassOf bae:BrendaCell . # pheochromocytoma cell
+obo:BTO_0001055 rdfs:subClassOf bae:BrendaCell . # ovarian epithelial cell
+obo:BTO_0001056 rdfs:subClassOf bae:BrendaCell . # myeloid leukemia cell
+obo:BTO_0001065 rdfs:subClassOf bae:BrendaCell . # Tsu-Pr1 cell
+obo:BTO_0001076 rdfs:subClassOf bae:BrendaCell . # pituitary gland tumor cell
+obo:BTO_0001080 rdfs:subClassOf bae:BrendaCell . # Morris hepatoma cell
+obo:BTO_0001082 rdfs:subClassOf bae:BrendaCell . # MM46 cell
+obo:BTO_0001086 rdfs:subClassOf bae:BrendaCell . # embryonic stem cell
+obo:BTO_0001087 rdfs:subClassOf bae:BrendaCell . # plasmacytoma cell
+obo:BTO_0001094 rdfs:subClassOf bae:BrendaCell . # pre-B acute lymphoblastic leukemia cell
+obo:BTO_0001096 rdfs:subClassOf bae:BrendaCell . # lymphoid cell
+obo:BTO_0001100 rdfs:subClassOf bae:BrendaCell . # B-cell acute lymphoblastic leukemia cell
+obo:BTO_0001106 rdfs:subClassOf bae:BrendaCell . # T-cell acute lymphoblastic leukemia cell
+obo:BTO_0001120 rdfs:subClassOf bae:BrendaCell . # epithelial cell line
+obo:BTO_0001130 rdfs:subClassOf bae:BrendaCell . # prostate gland cancer cell
+obo:BTO_0001131 rdfs:subClassOf bae:BrendaCell . # BHK cell
+obo:BTO_0001155 rdfs:subClassOf bae:BrendaCell . # ray cell
+obo:BTO_0001169 rdfs:subClassOf bae:BrendaCell . # 3T3-F442A cell
+obo:BTO_0001170 rdfs:subClassOf bae:BrendaCell . # resting cell
+obo:BTO_0001176 rdfs:subClassOf bae:BrendaCell . # endothelial cell
+obo:BTO_0001178 rdfs:subClassOf bae:BrendaCell . # retinoblastoma cell
+obo:BTO_0001189 rdfs:subClassOf bae:BrendaCell . # FAZA cell
+obo:BTO_0001197 rdfs:subClassOf bae:BrendaCell . # S-180 cell
+obo:BTO_0001207 rdfs:subClassOf bae:BrendaCell . # sarcoma cell
+obo:BTO_0001211 rdfs:subClassOf bae:BrendaCell . # breast epithelial cell
+obo:BTO_0001214 rdfs:subClassOf bae:BrendaCell . # Yoshida sarcoma cell
+obo:BTO_0001216 rdfs:subClassOf bae:BrendaCell . # Schwann cell line
+obo:BTO_0001220 rdfs:subClassOf bae:BrendaCell . # Schwann cell
+obo:BTO_0001238 rdfs:subClassOf bae:BrendaCell . # Sertoli cell
+obo:BTO_0001242 rdfs:subClassOf bae:BrendaCell . # fetal cell line
+obo:BTO_0001245 rdfs:subClassOf bae:BrendaCell . # bronchoalveolar stem cell
+obo:BTO_0001251 rdfs:subClassOf bae:BrendaCell . # liver sinusoidal endothelial cell
+obo:BTO_0001263 rdfs:subClassOf bae:BrendaCell . # Friend erythroleukemia cell line
+obo:BTO_0001268 rdfs:subClassOf bae:BrendaCell . # somatic cell
+obo:BTO_0001271 rdfs:subClassOf bae:BrendaCell . # leukemia cell
+obo:BTO_0001283 rdfs:subClassOf bae:BrendaCell . # mitral cell
+obo:BTO_0001286 rdfs:subClassOf bae:BrendaCell . # skin cancer cell
+obo:BTO_0001289 rdfs:subClassOf bae:BrendaCell . # squamous cell carcinoma cell
+obo:BTO_0001294 rdfs:subClassOf bae:BrendaCell . # sporulating cell
+obo:BTO_0001298 rdfs:subClassOf bae:BrendaCell . # basal cell carcinoma cell
+obo:BTO_0001326 rdfs:subClassOf bae:BrendaCell . # cholangiocarcinoma cell
+obo:BTO_0001329 rdfs:subClassOf bae:BrendaCell . # gastrinoma cell
+obo:BTO_0001330 rdfs:subClassOf bae:BrendaCell . # hepatoma ascites cell
+obo:BTO_0001334 rdfs:subClassOf bae:BrendaCell . # papilloma cell
+obo:BTO_0001341 rdfs:subClassOf bae:BrendaCell . # S-49 cell
+obo:BTO_0001344 rdfs:subClassOf bae:BrendaCell . # adult T-cell lymphoma cell
+obo:BTO_0001359 rdfs:subClassOf bae:BrendaCell . # medulloblastoma cell line
+obo:BTO_0001405 rdfs:subClassOf bae:BrendaCell . # bronchial cancer cell
+obo:BTO_0001407 rdfs:subClassOf bae:BrendaCell . # neuroendocrine tumor cell
+obo:BTO_0001434 rdfs:subClassOf bae:BrendaCell . # vegetative cell
+obo:BTO_0001437 rdfs:subClassOf bae:BrendaCell . # embryonic carcinoma cell line
+obo:BTO_0001441 rdfs:subClassOf bae:BrendaCell . # marrow cell
+obo:BTO_0001454 rdfs:subClassOf bae:BrendaCell . # thymoma cell
+obo:BTO_0001455 rdfs:subClassOf bae:BrendaCell . # thymic carcinoma cell
+obo:BTO_0001470 rdfs:subClassOf bae:BrendaCell . # epidermal cell
+obo:BTO_0001474 rdfs:subClassOf bae:BrendaCell . # yolk sac erythroid cell
+obo:BTO_0001478 rdfs:subClassOf bae:BrendaCell . # zygotene cell
+obo:BTO_0001514 rdfs:subClassOf bae:BrendaCell . # biliary epithelial cell
+obo:BTO_0001518 rdfs:subClassOf bae:BrendaCell . # B-lymphoma cell line
+obo:BTO_0001519 rdfs:subClassOf bae:BrendaCell . # endothelial cell line
+obo:BTO_0001521 rdfs:subClassOf bae:BrendaCell . # pancreatic adenocarcinoma cell line
+obo:BTO_0001522 rdfs:subClassOf bae:BrendaCell . # B-lymphocyte cell line
+obo:BTO_0001523 rdfs:subClassOf bae:BrendaCell . # WIL-2 cell
+obo:BTO_0001530 rdfs:subClassOf bae:BrendaCell . # glioblastoma cell line
+obo:BTO_0001531 rdfs:subClassOf bae:BrendaCell . # glial cell line
+obo:BTO_0001532 rdfs:subClassOf bae:BrendaCell . # rectal cancer cell line
+obo:BTO_0001537 rdfs:subClassOf bae:BrendaCell . # small intestine cell line
+obo:BTO_0001540 rdfs:subClassOf bae:BrendaCell . # goblet cell
+obo:BTO_0001544 rdfs:subClassOf bae:BrendaCell . # chronic myeloid leukemia cell
+obo:BTO_0001545 rdfs:subClassOf bae:BrendaCell . # acute myeloid leukemia cell
+obo:BTO_0001546 rdfs:subClassOf bae:BrendaCell . # chronic lymphocytic leukemia cell
+obo:BTO_0001549 rdfs:subClassOf bae:BrendaCell . # megakaryocytic cell line
+obo:BTO_0001550 rdfs:subClassOf bae:BrendaCell . # Dami cell
+obo:BTO_0001555 rdfs:subClassOf bae:BrendaCell . # endometrial cancer cell line
+obo:BTO_0001557 rdfs:subClassOf bae:BrendaCell . # SF-767 cell
+obo:BTO_0001565 rdfs:subClassOf bae:BrendaCell . # HT-29-MTX cell
+obo:BTO_0001566 rdfs:subClassOf bae:BrendaCell . # HT-29 G cell
+obo:BTO_0001567 rdfs:subClassOf bae:BrendaCell . # MDA-MB-435 cell
+obo:BTO_0001573 rdfs:subClassOf bae:BrendaCell . # brain cancer cell
+obo:BTO_0001574 rdfs:subClassOf bae:BrendaCell . # chondrosarcoma cell line
+obo:BTO_0001575 rdfs:subClassOf bae:BrendaCell . # choriocarcinoma cell line
+obo:BTO_0001576 rdfs:subClassOf bae:BrendaCell . # choriocarcinoma cell
+obo:BTO_0001577 rdfs:subClassOf bae:BrendaCell . # esophageal cancer cell
+obo:BTO_0001581 rdfs:subClassOf bae:BrendaCell . # embryonic stem cell line
+obo:BTO_0001586 rdfs:subClassOf bae:BrendaCell . # lymphoid cell line
+obo:BTO_0001610 rdfs:subClassOf bae:BrendaCell . # thyroid cancer cell line
+obo:BTO_0001614 rdfs:subClassOf bae:BrendaCell . # colorectal cell line
+obo:BTO_0001615 rdfs:subClassOf bae:BrendaCell . # colorectal cancer cell
+obo:BTO_0001617 rdfs:subClassOf bae:BrendaCell . # DHL-9 cell
+obo:BTO_0001619 rdfs:subClassOf bae:BrendaCell . # skin fibroblast cell line
+obo:BTO_0001622 rdfs:subClassOf bae:BrendaCell . # fibroblastoma cell
+obo:BTO_0001623 rdfs:subClassOf bae:BrendaCell . # fibroma cell
+obo:BTO_0001625 rdfs:subClassOf bae:BrendaCell . # laryngeal cancer cell
+obo:BTO_0001631 rdfs:subClassOf bae:BrendaCell . # leiomyosarcoma cell
+obo:BTO_0001664 rdfs:subClassOf bae:BrendaCell . # hepatoblastoma cell line
+obo:BTO_0001666 rdfs:subClassOf bae:BrendaCell . # hepatoblastoma cell
+obo:BTO_0001668 rdfs:subClassOf bae:BrendaCell . # mast cell line
+obo:BTO_0001669 rdfs:subClassOf bae:BrendaCell . # HMC-1 cell
+obo:BTO_0001674 rdfs:subClassOf bae:BrendaCell . # Mel Im cell
+obo:BTO_0001676 rdfs:subClassOf bae:BrendaCell . # PC-12D cell
+obo:BTO_0001677 rdfs:subClassOf bae:BrendaCell . # SCHNEIDER-2 cell
+obo:BTO_0001683 rdfs:subClassOf bae:BrendaCell . # adenohypophysis tumor cell
+obo:BTO_0001690 rdfs:subClassOf bae:BrendaCell . # B-cell lymphoma cell
+obo:BTO_0001714 rdfs:subClassOf bae:BrendaCell . # duodenal adenocarcinoma cell
+obo:BTO_0001731 rdfs:subClassOf bae:BrendaCell . # glucagonoma cell
+obo:BTO_0001736 rdfs:subClassOf bae:BrendaCell . # vascular cancer cell
+obo:BTO_0001737 rdfs:subClassOf bae:BrendaCell . # hemangioendothelioma cell
+obo:BTO_0001738 rdfs:subClassOf bae:BrendaCell . # histiocytic lymphoma cell
+obo:BTO_0001756 rdfs:subClassOf bae:BrendaCell . # meningioma cell
+obo:BTO_0001757 rdfs:subClassOf bae:BrendaCell . # medulloblastoma cell
+obo:BTO_0001767 rdfs:subClassOf bae:BrendaCell . # neurosecretory cell
+obo:BTO_0001774 rdfs:subClassOf bae:BrendaCell . # oral cancer cell
+obo:BTO_0001780 rdfs:subClassOf bae:BrendaCell . # oxyntic cell
+obo:BTO_0001781 rdfs:subClassOf bae:BrendaCell . # parathyroid gland cancer cell
+obo:BTO_0001797 rdfs:subClassOf bae:BrendaCell . # promyelocytic leukemia cell
+obo:BTO_0001800 rdfs:subClassOf bae:BrendaCell . # retinal ganglion cell
+obo:BTO_0001802 rdfs:subClassOf bae:BrendaCell . # rhabdomyosarcoma cell
+obo:BTO_0001824 rdfs:subClassOf bae:BrendaCell . # synovial sarcoma cell
+obo:BTO_0001825 rdfs:subClassOf bae:BrendaCell . # T-cell lymphoma cell
+obo:BTO_0001854 rdfs:subClassOf bae:BrendaCell . # vascular endothelial cell
+obo:BTO_0001860 rdfs:subClassOf bae:BrendaCell . # yolk sac cancer cell
+obo:BTO_0001870 rdfs:subClassOf bae:BrendaCell . # OVCA-5 cell
+obo:BTO_0001874 rdfs:subClassOf bae:BrendaCell . # lens epithelial cell line
+obo:BTO_0001876 rdfs:subClassOf bae:BrendaCell . # thyroid cell line
+obo:BTO_0001879 rdfs:subClassOf bae:BrendaCell . # H9c2 cell
+obo:BTO_0001883 rdfs:subClassOf bae:BrendaCell . # acute myeloid leukemia cell line
+obo:BTO_0001888 rdfs:subClassOf bae:BrendaCell . # follicular thyroid cancer cell
+obo:BTO_0001895 rdfs:subClassOf bae:BrendaCell . # gastrointestinal endocrine cell
+obo:BTO_0001897 rdfs:subClassOf bae:BrendaCell . # hemocyte cell line
+obo:BTO_0001898 rdfs:subClassOf bae:BrendaCell . # mbn-2 cell
+obo:BTO_0001907 rdfs:subClassOf bae:BrendaCell . # NS-1 cell
+obo:BTO_0001911 rdfs:subClassOf bae:BrendaCell . # lung adenocarcinoma cell line
+obo:BTO_0001912 rdfs:subClassOf bae:BrendaCell . # breast adenocarcinoma cell line
+obo:BTO_0001914 rdfs:subClassOf bae:BrendaCell . # colorectal adenocarcinoma cell line
+obo:BTO_0001916 rdfs:subClassOf bae:BrendaCell . # LIM1215 cell
+obo:BTO_0001918 rdfs:subClassOf bae:BrendaCell . # LIM1863 cell
+obo:BTO_0001926 rdfs:subClassOf bae:BrendaCell . # hybridoma cell line
+obo:BTO_0001928 rdfs:subClassOf bae:BrendaCell . # AR4-2J cell
+obo:BTO_0001929 rdfs:subClassOf bae:BrendaCell . # ATDC-5 cell
+obo:BTO_0001931 rdfs:subClassOf bae:BrendaCell . # BJAB cell
+obo:BTO_0001933 rdfs:subClassOf bae:BrendaCell . # BRL cell
+obo:BTO_0001948 rdfs:subClassOf bae:BrendaCell . # JURKAT E-6.1 cell
+obo:BTO_0001949 rdfs:subClassOf bae:BrendaCell . # HUVEC cell
+obo:BTO_0001955 rdfs:subClassOf bae:BrendaCell . # REF-52 cell
+obo:BTO_0001964 rdfs:subClassOf bae:BrendaCell . # aorta smooth muscle cell line
+obo:BTO_0001966 rdfs:subClassOf bae:BrendaCell . # cervical cell line
+obo:BTO_0001967 rdfs:subClassOf bae:BrendaCell . # cervical cancer cell line
+obo:BTO_0001971 rdfs:subClassOf bae:BrendaCell . # plant cell line
+obo:BTO_0001972 rdfs:subClassOf bae:BrendaCell . # TBY-2 cell
+obo:BTO_0001975 rdfs:subClassOf bae:BrendaCell . # placental cell line
+obo:BTO_0001977 rdfs:subClassOf bae:BrendaCell . # Oc cell
+obo:BTO_0002008 rdfs:subClassOf bae:BrendaCell . # culture condition:antigen-presenting cell
+obo:BTO_0002016 rdfs:subClassOf bae:BrendaCell . # C81-61 cell
+obo:BTO_0002021 rdfs:subClassOf bae:BrendaCell . # prostate adenocarcinoma cell
+obo:BTO_0002022 rdfs:subClassOf bae:BrendaCell . # bronchial epithelial cell line
+obo:BTO_0002023 rdfs:subClassOf bae:BrendaCell . # HBE-1 cell
+obo:BTO_0002024 rdfs:subClassOf bae:BrendaCell . # squamous cell carcinoma cell line
+obo:BTO_0002026 rdfs:subClassOf bae:BrendaCell . # HSC-4 cell
+obo:BTO_0002027 rdfs:subClassOf bae:BrendaCell . # oral cancer cell line
+obo:BTO_0002029 rdfs:subClassOf bae:BrendaCell . # myoma cell
+obo:BTO_0002030 rdfs:subClassOf bae:BrendaCell . # natural killer cell line
+obo:BTO_0002031 rdfs:subClassOf bae:BrendaCell . # RNK-16 cell
+obo:BTO_0002042 rdfs:subClassOf bae:BrendaCell . # dendritic cell
+obo:BTO_0002049 rdfs:subClassOf bae:BrendaCell . # Chang cell
+obo:BTO_0002050 rdfs:subClassOf bae:BrendaCell . # osteogenic cell
+obo:BTO_0002052 rdfs:subClassOf bae:BrendaCell . # osteogenic cell line
+obo:BTO_0002054 rdfs:subClassOf bae:BrendaCell . # Dunn cell
+obo:BTO_0002057 rdfs:subClassOf bae:BrendaCell . # lung adenocarcinoma cell
+obo:BTO_0002058 rdfs:subClassOf bae:BrendaCell . # non-small cell lung cancer cell
+obo:BTO_0002059 rdfs:subClassOf bae:BrendaCell . # large cell carcinoma cell
+obo:BTO_0002060 rdfs:subClassOf bae:BrendaCell . # bronchioalveolar carcinoma cell
+obo:BTO_0002062 rdfs:subClassOf bae:BrendaCell . # B-lymphoblastoid cell line
+obo:BTO_0002064 rdfs:subClassOf bae:BrendaCell . # stromal cell
+obo:BTO_0002088 rdfs:subClassOf bae:BrendaCell . # ependymoma cell
+obo:BTO_0002093 rdfs:subClassOf bae:BrendaCell . # ganglioneuroma cell
+obo:BTO_0002101 rdfs:subClassOf bae:BrendaCell . # multiple myeloma cell
+obo:BTO_0002128 rdfs:subClassOf bae:BrendaCell . # TX3868 cell
+obo:BTO_0002135 rdfs:subClassOf bae:BrendaCell . # INS-1 cell
+obo:BTO_0002137 rdfs:subClassOf bae:BrendaCell . # MiaPaCa-2 cell
+obo:BTO_0002138 rdfs:subClassOf bae:BrendaCell . # MiaPaCa cell
+obo:BTO_0002143 rdfs:subClassOf bae:BrendaCell . # CEM-VCR R cell
+obo:BTO_0002145 rdfs:subClassOf bae:BrendaCell . # midgut cell line
+obo:BTO_0002170 rdfs:subClassOf bae:BrendaCell . # LOX cell
+obo:BTO_0002174 rdfs:subClassOf bae:BrendaCell . # parenchymal cell
+obo:BTO_0002177 rdfs:subClassOf bae:BrendaCell . # PR cell
+obo:BTO_0002178 rdfs:subClassOf bae:BrendaCell . # HMEpC cell
+obo:BTO_0002181 rdfs:subClassOf bae:BrendaCell . # HEK-293T cell
+obo:BTO_0002182 rdfs:subClassOf bae:BrendaCell . # 95D cell
+obo:BTO_0002183 rdfs:subClassOf bae:BrendaCell . # 95C cell
+obo:BTO_0002193 rdfs:subClassOf bae:BrendaCell . # SCC-13 cell
+obo:BTO_0002194 rdfs:subClassOf bae:BrendaCell . # NHK cell
+obo:BTO_0002195 rdfs:subClassOf bae:BrendaCell . # vascular smooth muscle cell line
+obo:BTO_0002205 rdfs:subClassOf bae:BrendaCell . # large cell lung cancer cell line
+obo:BTO_0002206 rdfs:subClassOf bae:BrendaCell . # small cell lung cancer cell line
+obo:BTO_0002211 rdfs:subClassOf bae:BrendaCell . # oral squamous cell carcinoma cell line
+obo:BTO_0002214 rdfs:subClassOf bae:BrendaCell . # A-1235 cell
+obo:BTO_0002215 rdfs:subClassOf bae:BrendaCell . # LN-319 cell
+obo:BTO_0002218 rdfs:subClassOf bae:BrendaCell . # chalazal cell
+obo:BTO_0002219 rdfs:subClassOf bae:BrendaCell . # adrenocortical carcinoma cell
+obo:BTO_0002221 rdfs:subClassOf bae:BrendaCell . # HLE-B3 cell
+obo:BTO_0002236 rdfs:subClassOf bae:BrendaCell . # ovarian cumulus cell
+obo:BTO_0002242 rdfs:subClassOf bae:BrendaCell . # oral epithelial cell
+obo:BTO_0002245 rdfs:subClassOf bae:BrendaCell . # foreskin fibroblast cell line
+obo:BTO_0002264 rdfs:subClassOf bae:BrendaCell . # dried cell
+obo:BTO_0002267 rdfs:subClassOf bae:BrendaCell . # rhabdomyosarcoma cell line
+obo:BTO_0002276 rdfs:subClassOf bae:BrendaCell . # immobilized cell
+obo:BTO_0002278 rdfs:subClassOf bae:BrendaCell . # macrophage cell line
+obo:BTO_0002279 rdfs:subClassOf bae:BrendaCell . # J-774 cell
+obo:BTO_0002280 rdfs:subClassOf bae:BrendaCell . # lignifying cell
+obo:BTO_0002284 rdfs:subClassOf bae:BrendaCell . # MIN-6 cell
+obo:BTO_0002285 rdfs:subClassOf bae:BrendaCell . # granulosa cell line
+obo:BTO_0002290 rdfs:subClassOf bae:BrendaCell . # primary cell line
+obo:BTO_0002306 rdfs:subClassOf bae:BrendaCell . # ARO cell
+obo:BTO_0002309 rdfs:subClassOf bae:BrendaCell . # myoepithelial cell
+obo:BTO_0002311 rdfs:subClassOf bae:BrendaCell . # mammary myoepithelial cell
+obo:BTO_0002312 rdfs:subClassOf bae:BrendaCell . # mature cell
+obo:BTO_0002313 rdfs:subClassOf bae:BrendaCell . # immature cell
+obo:BTO_0002314 rdfs:subClassOf bae:BrendaCell . # satellite cell
+obo:BTO_0002315 rdfs:subClassOf bae:BrendaCell . # supporting cell
+obo:BTO_0002316 rdfs:subClassOf bae:BrendaCell . # stellate cell
+obo:BTO_0002332 rdfs:subClassOf bae:BrendaCell . # monocytic leukemia cell line
+obo:BTO_0002334 rdfs:subClassOf bae:BrendaCell . # retinal pigment epithelium cell line
+obo:BTO_0002361 rdfs:subClassOf bae:BrendaCell . # osteochondroma cell
+obo:BTO_0002363 rdfs:subClassOf bae:BrendaCell . # pancreatic ductal carcinoma cell
+obo:BTO_0002372 rdfs:subClassOf bae:BrendaCell . # neuroepithelioma cell
+obo:BTO_0002373 rdfs:subClassOf bae:BrendaCell . # glioblastoma multiforme cell
+obo:BTO_0002380 rdfs:subClassOf bae:BrendaCell . # gastric adenocarcinoma cell line
+obo:BTO_0002382 rdfs:subClassOf bae:BrendaCell . # MKN-7 cell
+obo:BTO_0002385 rdfs:subClassOf bae:BrendaCell . # GLC-4 cell
+obo:BTO_0002386 rdfs:subClassOf bae:BrendaCell . # GLC-4/ADR cell
+obo:BTO_0002389 rdfs:subClassOf bae:BrendaCell . # U-1285 cell
+obo:BTO_0002391 rdfs:subClassOf bae:BrendaCell . # U-1285dox cell
+obo:BTO_0002392 rdfs:subClassOf bae:BrendaCell . # SGC-7901 cell
+obo:BTO_0002393 rdfs:subClassOf bae:BrendaCell . # N-27 cell
+obo:BTO_0002394 rdfs:subClassOf bae:BrendaCell . # DC-3F cell
+obo:BTO_0002395 rdfs:subClassOf bae:BrendaCell . # DC-3F/ADX cell
+obo:BTO_0002398 rdfs:subClassOf bae:BrendaCell . # prostate epithelium cell line
+obo:BTO_0002403 rdfs:subClassOf bae:BrendaCell . # OS-RC-2 cell
+obo:BTO_0002406 rdfs:subClassOf bae:BrendaCell . # eosinophilic leukemia cell line
+obo:BTO_0002414 rdfs:subClassOf bae:BrendaCell . # PG-CL3 cell
+obo:BTO_0002420 rdfs:subClassOf bae:BrendaCell . # monocytic leukemia cell
+obo:BTO_0002421 rdfs:subClassOf bae:BrendaCell . # eosinophilic leukemia cell
+obo:BTO_0002423 rdfs:subClassOf bae:BrendaCell . # mesothelioma cell
+obo:BTO_0002424 rdfs:subClassOf bae:BrendaCell . # mesothelioma cell line
+obo:BTO_0002426 rdfs:subClassOf bae:BrendaCell . # CHOP cell
+obo:BTO_0002428 rdfs:subClassOf bae:BrendaCell . # esophageal squamous cell carcinoma cell line
+obo:BTO_0002429 rdfs:subClassOf bae:BrendaCell . # HA22T/VGH cell
+obo:BTO_0002478 rdfs:subClassOf bae:BrendaCell . # cervical epithelial cell
+obo:BTO_0002482 rdfs:subClassOf bae:BrendaCell . # gonadotrophic cell
+obo:BTO_0002484 rdfs:subClassOf bae:BrendaCell . # columnar cell
+obo:BTO_0002489 rdfs:subClassOf bae:BrendaCell . # promyelocytic leukemia cell line
+obo:BTO_0002499 rdfs:subClassOf bae:BrendaCell . # companion cell
+obo:BTO_0002505 rdfs:subClassOf bae:BrendaCell . # anaplastic large cell lymphoma cell
+obo:BTO_0002509 rdfs:subClassOf bae:BrendaCell . # corticotropic cell
+obo:BTO_0002510 rdfs:subClassOf bae:BrendaCell . # myelomonocytic leukemia cell
+obo:BTO_0002513 rdfs:subClassOf bae:BrendaCell . # Ewing's sarcoma cell
+obo:BTO_0002515 rdfs:subClassOf bae:BrendaCell . # brain cortex cell line
+obo:BTO_0002517 rdfs:subClassOf bae:BrendaCell . # follicular lymphoma cell line
+obo:BTO_0002521 rdfs:subClassOf bae:BrendaCell . # diffuse large B-cell lymphoma cell
+obo:BTO_0002524 rdfs:subClassOf bae:BrendaCell . # HEK-293A cell
+obo:BTO_0002534 rdfs:subClassOf bae:BrendaCell . # HBL-3 cell
+obo:BTO_0002546 rdfs:subClassOf bae:BrendaCell . # KBM-5 cell
+obo:BTO_0002555 rdfs:subClassOf bae:BrendaCell . # HOSE cell
+obo:BTO_0002564 rdfs:subClassOf bae:BrendaCell . # OVCA-429 cell
+obo:BTO_0002565 rdfs:subClassOf bae:BrendaCell . # OVCA-432 cell
+obo:BTO_0002572 rdfs:subClassOf bae:BrendaCell . # MEF cell
+obo:BTO_0002590 rdfs:subClassOf bae:BrendaCell . # HEY cell
+obo:BTO_0002595 rdfs:subClassOf bae:BrendaCell . # leiomyosarcoma cell line
+obo:BTO_0002600 rdfs:subClassOf bae:BrendaCell . # astrocyte cell line
+obo:BTO_0002606 rdfs:subClassOf bae:BrendaCell . # glial cell
+obo:BTO_0002625 rdfs:subClassOf bae:BrendaCell . # mesenchymal cell
+obo:BTO_0002627 rdfs:subClassOf bae:BrendaCell . # T-lymphoblastoma cell
+obo:BTO_0002628 rdfs:subClassOf bae:BrendaCell . # B-lymphoblastoma cell
+obo:BTO_0002629 rdfs:subClassOf bae:BrendaCell . # T-lymphoblastoid cell line
+obo:BTO_0002637 rdfs:subClassOf bae:BrendaCell . # respiratory epithelium cell line
+obo:BTO_0002640 rdfs:subClassOf bae:BrendaCell . # CHO-EM9 cell
+obo:BTO_0002641 rdfs:subClassOf bae:BrendaCell . # CHO-AA8 cell
+obo:BTO_0002648 rdfs:subClassOf bae:BrendaCell . # ROS-17/2.8 cell
+obo:BTO_0002656 rdfs:subClassOf bae:BrendaCell . # sickle cell
+obo:BTO_0002658 rdfs:subClassOf bae:BrendaCell . # collecting duct cell line
+obo:BTO_0002662 rdfs:subClassOf bae:BrendaCell . # skeletal muscle cell line
+obo:BTO_0002664 rdfs:subClassOf bae:BrendaCell . # HTAU cell
+obo:BTO_0002666 rdfs:subClassOf bae:BrendaCell . # adult stem cell
+obo:BTO_0002667 rdfs:subClassOf bae:BrendaCell . # cord blood stem cell
+obo:BTO_0002668 rdfs:subClassOf bae:BrendaCell . # bone marrow stromal stem cell
+obo:BTO_0002669 rdfs:subClassOf bae:BrendaCell . # peripheral blood stem cell
+obo:BTO_0002687 rdfs:subClassOf bae:BrendaCell . # Leydig cell tumor cell
+obo:BTO_0002688 rdfs:subClassOf bae:BrendaCell . # vascular cell
+obo:BTO_0002691 rdfs:subClassOf bae:BrendaCell . # neuroendocrine cell
+obo:BTO_0002692 rdfs:subClassOf bae:BrendaCell . # enterochromaffin-like cell
+obo:BTO_0002694 rdfs:subClassOf bae:BrendaCell . # leiomyoma cell
+obo:BTO_0002695 rdfs:subClassOf bae:BrendaCell . # uterine leiomyoma cell
+obo:BTO_0002708 rdfs:subClassOf bae:BrendaCell . # GT1-7 cell
+obo:BTO_0002709 rdfs:subClassOf bae:BrendaCell . # head and neck squamous cell carcinoma cell line
+obo:BTO_0002714 rdfs:subClassOf bae:BrendaCell . # UM-SCC-22A cell
+obo:BTO_0002719 rdfs:subClassOf bae:BrendaCell . # primary effusion lymphoma cell line
+obo:BTO_0002727 rdfs:subClassOf bae:BrendaCell . # BCBL-1 cell
+obo:BTO_0002729 rdfs:subClassOf bae:BrendaCell . # ovarian serous carcinoma cell
+obo:BTO_0002731 rdfs:subClassOf bae:BrendaCell . # erythroid cell
+obo:BTO_0002741 rdfs:subClassOf bae:BrendaCell . # hepatic stellate cell
+obo:BTO_0002747 rdfs:subClassOf bae:BrendaCell . # PC-1 cell
+obo:BTO_0002748 rdfs:subClassOf bae:BrendaCell . # BL-2 cell
+obo:BTO_0002752 rdfs:subClassOf bae:BrendaCell . # PC-6 cell
+obo:BTO_0002768 rdfs:subClassOf bae:BrendaCell . # mammary epithelial cell line
+obo:BTO_0002769 rdfs:subClassOf bae:BrendaCell . # HME cell
+obo:BTO_0002770 rdfs:subClassOf bae:BrendaCell . # decidual cell
+obo:BTO_0002771 rdfs:subClassOf bae:BrendaCell . # olfactory ensheathing cell
+obo:BTO_0002773 rdfs:subClassOf bae:BrendaCell . # salivary gland cancer cell
+obo:BTO_0002775 rdfs:subClassOf bae:BrendaCell . # ANA-1 cell
+obo:BTO_0002786 rdfs:subClassOf bae:BrendaCell . # cystadenoma cell
+obo:BTO_0002787 rdfs:subClassOf bae:BrendaCell . # clear cell adenocarcinoma cell
+obo:BTO_0002788 rdfs:subClassOf bae:BrendaCell . # mucinous adenocarcinoma cell
+obo:BTO_0002790 rdfs:subClassOf bae:BrendaCell . # phloem parenchyma cell
+obo:BTO_0002803 rdfs:subClassOf bae:BrendaCell . # BLM cell
+obo:BTO_0002805 rdfs:subClassOf bae:BrendaCell . # M14 cell
+obo:BTO_0002808 rdfs:subClassOf bae:BrendaCell . # B16-BL6 cell
+obo:BTO_0002815 rdfs:subClassOf bae:BrendaCell . # transitional cell carcinoma cell
+obo:BTO_0002817 rdfs:subClassOf bae:BrendaCell . # esophageal cancer cell line
+obo:BTO_0002820 rdfs:subClassOf bae:BrendaCell . # oligodendroglioma cell line
+obo:BTO_0002821 rdfs:subClassOf bae:BrendaCell . # HOG cell
+obo:BTO_0002828 rdfs:subClassOf bae:BrendaCell . # HMEC-1 cell
+obo:BTO_0002836 rdfs:subClassOf bae:BrendaCell . # NCI-H460M cell
+obo:BTO_0002844 rdfs:subClassOf bae:BrendaCell . # breast invasive ductal carcinoma cell
+obo:BTO_0002846 rdfs:subClassOf bae:BrendaCell . # non-Hodgkin lymphoma cell
+obo:BTO_0002850 rdfs:subClassOf bae:BrendaCell . # theca cell
+obo:BTO_0002861 rdfs:subClassOf bae:BrendaCell . # esophageal squamous cell carcinoma cell
+obo:BTO_0002864 rdfs:subClassOf bae:BrendaCell . # T3M4 cell
+obo:BTO_0002865 rdfs:subClassOf bae:BrendaCell . # GER cell
+obo:BTO_0002869 rdfs:subClassOf bae:BrendaCell . # transitional cell carcinoma cell line
+obo:BTO_0002870 rdfs:subClassOf bae:BrendaCell . # RT-4 cell
+obo:BTO_0002876 rdfs:subClassOf bae:BrendaCell . # CL1-5 cell
+obo:BTO_0002878 rdfs:subClassOf bae:BrendaCell . # B-lymphoblastoid cell
+obo:BTO_0002881 rdfs:subClassOf bae:BrendaCell . # neural stem cell
+obo:BTO_0002886 rdfs:subClassOf bae:BrendaCell . # renal epithelium cell line
+obo:BTO_0002888 rdfs:subClassOf bae:BrendaCell . # Th-1 cell line
+obo:BTO_0002889 rdfs:subClassOf bae:BrendaCell . # alveolar macrophage cell line
+obo:BTO_0002890 rdfs:subClassOf bae:BrendaCell . # CA-77 cell
+obo:BTO_0002891 rdfs:subClassOf bae:BrendaCell . # neural stem cell line
+obo:BTO_0002892 rdfs:subClassOf bae:BrendaCell . # GEO cell
+obo:BTO_0002899 rdfs:subClassOf bae:BrendaCell . # K-1034 RPE cell
+obo:BTO_0002900 rdfs:subClassOf bae:BrendaCell . # monocyte-derived dendritic cell
+obo:BTO_0002901 rdfs:subClassOf bae:BrendaCell . # neural crest cell line
+obo:BTO_0002904 rdfs:subClassOf bae:BrendaCell . # non-Hodgkin lymphoma cell line
+obo:BTO_0002912 rdfs:subClassOf bae:BrendaCell . # neuroepithelioma cell line
+obo:BTO_0002916 rdfs:subClassOf bae:BrendaCell . # striated muscle cell
+obo:BTO_0002919 rdfs:subClassOf bae:BrendaCell . # retinoblastoma cell line
+obo:BTO_0002921 rdfs:subClassOf bae:BrendaCell . # LS174T-HM7 cell
+obo:BTO_0002922 rdfs:subClassOf bae:BrendaCell . # bronchial epithelial cell
+obo:BTO_0002924 rdfs:subClassOf bae:BrendaCell . # NHBE cell
+obo:BTO_0002926 rdfs:subClassOf bae:BrendaCell . # tracheobronchial epithelial cell line
+obo:BTO_0002927 rdfs:subClassOf bae:BrendaCell . # tracheobronchial epithelial cell
+obo:BTO_0002928 rdfs:subClassOf bae:BrendaCell . # adult stem cell line
+obo:BTO_0002931 rdfs:subClassOf bae:BrendaCell . # liver epithelial cell line
+obo:BTO_0002932 rdfs:subClassOf bae:BrendaCell . # cholangiocarcinoma cell line
+obo:BTO_0002936 rdfs:subClassOf bae:BrendaCell . # vaginal cell line
+obo:BTO_0002939 rdfs:subClassOf bae:BrendaCell . # serous adenocarcinoma cell
+obo:BTO_0002946 rdfs:subClassOf bae:BrendaCell . # MNT-1 cell
+obo:BTO_0002951 rdfs:subClassOf bae:BrendaCell . # 624 cell
+obo:BTO_0002959 rdfs:subClassOf bae:BrendaCell . # TP17 cell
+obo:BTO_0002965 rdfs:subClassOf bae:BrendaCell . # M10 cell
+obo:BTO_0002967 rdfs:subClassOf bae:BrendaCell . # SK-MEL-37 cell
+obo:BTO_0002971 rdfs:subClassOf bae:BrendaCell . # KJ29 cell
+obo:BTO_0002974 rdfs:subClassOf bae:BrendaCell . # HEK-293-EBNA cell
+obo:BTO_0002980 rdfs:subClassOf bae:BrendaCell . # pancreatic alpha cell line
+obo:BTO_0002995 rdfs:subClassOf bae:BrendaCell . # CCL-39 cell
+obo:BTO_0002997 rdfs:subClassOf bae:BrendaCell . # LAPC4 cell
+obo:BTO_0003028 rdfs:subClassOf bae:BrendaCell . # NCI-N417 cell
+obo:BTO_0003031 rdfs:subClassOf bae:BrendaCell . # HCA-7 cell
+obo:BTO_0003032 rdfs:subClassOf bae:BrendaCell . # HEK-293F cell
+obo:BTO_0003033 rdfs:subClassOf bae:BrendaCell . # HEK-293H cell
+obo:BTO_0003036 rdfs:subClassOf bae:BrendaCell . # hippocampal cell line
+obo:BTO_0003037 rdfs:subClassOf bae:BrendaCell . # HT-22 cell
+obo:BTO_0003039 rdfs:subClassOf bae:BrendaCell . # hypodermal seam cell
+obo:BTO_0003046 rdfs:subClassOf bae:BrendaCell . # neurofibroma cell
+obo:BTO_0003047 rdfs:subClassOf bae:BrendaCell . # neurilemoma cell
+obo:BTO_0003050 rdfs:subClassOf bae:BrendaCell . # MA-10 cell
+obo:BTO_0003051 rdfs:subClassOf bae:BrendaCell . # MBA-15 cell
+obo:BTO_0003054 rdfs:subClassOf bae:BrendaCell . # OVCA-8 cell
+obo:BTO_0003056 rdfs:subClassOf bae:BrendaCell . # NB-2 cell
+obo:BTO_0003057 rdfs:subClassOf bae:BrendaCell . # NB2-Sp cell
+obo:BTO_0003058 rdfs:subClassOf bae:BrendaCell . # NB2a/d1 cell
+obo:BTO_0003059 rdfs:subClassOf bae:BrendaCell . # oviduct epithelial cell line
+obo:BTO_0003061 rdfs:subClassOf bae:BrendaCell . # retinal cell line
+obo:BTO_0003072 rdfs:subClassOf bae:BrendaCell . # human lens epithelial cell line
+obo:BTO_0003073 rdfs:subClassOf bae:BrendaCell . # medullary thyroid carcinoma cell line
+obo:BTO_0003085 rdfs:subClassOf bae:BrendaCell . # uterine anchor cell
+obo:BTO_0003103 rdfs:subClassOf bae:BrendaCell . # pro-B-lymphocyte cell line
+obo:BTO_0003107 rdfs:subClassOf bae:BrendaCell . # foreign-body giant cell
+obo:BTO_0003108 rdfs:subClassOf bae:BrendaCell . # CL-1 prostate cancer cell
+obo:BTO_0003110 rdfs:subClassOf bae:BrendaCell . # CALO cell
+obo:BTO_0003124 rdfs:subClassOf bae:BrendaCell . # microvascular endothelial cell line
+obo:BTO_0003125 rdfs:subClassOf bae:BrendaCell . # human bladder microvascular endothelial cell
+obo:BTO_0003127 rdfs:subClassOf bae:BrendaCell . # human bone marrow endothelial cell line
+obo:BTO_0003129 rdfs:subClassOf bae:BrendaCell . # human brain microvascular endothelial cell
+obo:BTO_0003151 rdfs:subClassOf bae:BrendaCell . # HPAEC cell
+obo:BTO_0003152 rdfs:subClassOf bae:BrendaCell . # papillary thyroid cancer cell
+obo:BTO_0003160 rdfs:subClassOf bae:BrendaCell . # PrEC cell
+obo:BTO_0003162 rdfs:subClassOf bae:BrendaCell . # PrSC cell
+obo:BTO_0003165 rdfs:subClassOf bae:BrendaCell . # cervical adenocarcinoma cell
+obo:BTO_0003166 rdfs:subClassOf bae:BrendaCell . # 10T1/2 cell
+obo:BTO_0003181 rdfs:subClassOf bae:BrendaCell . # WEHI-7.2 cell
+obo:BTO_0003182 rdfs:subClassOf bae:BrendaCell . # NHEK cell
+obo:BTO_0003183 rdfs:subClassOf bae:BrendaCell . # melanocyte cell line
+obo:BTO_0003185 rdfs:subClassOf bae:BrendaCell . # NHDF cell
+obo:BTO_0003192 rdfs:subClassOf bae:BrendaCell . # renal cancer cell line
+obo:BTO_0003205 rdfs:subClassOf bae:BrendaCell . # salivary gland cell line
+obo:BTO_0003208 rdfs:subClassOf bae:BrendaCell . # anaplastic thyroid cancer cell
+obo:BTO_0003210 rdfs:subClassOf bae:BrendaCell . # papillary thyroid cancer cell line
+obo:BTO_0003212 rdfs:subClassOf bae:BrendaCell . # T-lymphoma cell line
+obo:BTO_0003213 rdfs:subClassOf bae:BrendaCell . # lung epithelium cell line
+obo:BTO_0003216 rdfs:subClassOf bae:BrendaCell . # melan-a cell
+obo:BTO_0003219 rdfs:subClassOf bae:BrendaCell . # TMK-1 cell
+obo:BTO_0003225 rdfs:subClassOf bae:BrendaCell . # neurilemoma cell line
+obo:BTO_0003227 rdfs:subClassOf bae:BrendaCell . # SMMC-7721 cell
+obo:BTO_0003231 rdfs:subClassOf bae:BrendaCell . # SHG-44 cell
+obo:BTO_0003232 rdfs:subClassOf bae:BrendaCell . # BT-325 cell
+obo:BTO_0003234 rdfs:subClassOf bae:BrendaCell . # FTO-2B cell
+obo:BTO_0003236 rdfs:subClassOf bae:BrendaCell . # gall bladder cancer cell line
+obo:BTO_0003237 rdfs:subClassOf bae:BrendaCell . # gall bladder cancer cell
+obo:BTO_0003245 rdfs:subClassOf bae:BrendaCell . # aortic endothelial cell
+obo:BTO_0003249 rdfs:subClassOf bae:BrendaCell . # brain endothelium cell line
+obo:BTO_0003250 rdfs:subClassOf bae:BrendaCell . # colonic epithelium cell line
+obo:BTO_0003253 rdfs:subClassOf bae:BrendaCell . # ELT-3 cell
+obo:BTO_0003263 rdfs:subClassOf bae:BrendaCell . # HEK-AD293 cell
+obo:BTO_0003264 rdfs:subClassOf bae:BrendaCell . # HL-1 cell
+obo:BTO_0003266 rdfs:subClassOf bae:BrendaCell . # HPAF-2 cell
+obo:BTO_0003270 rdfs:subClassOf bae:BrendaCell . # Me665/2 cell
+obo:BTO_0003280 rdfs:subClassOf bae:BrendaCell . # sessile cell
+obo:BTO_0003281 rdfs:subClassOf bae:BrendaCell . # planktonic cell
+obo:BTO_0003283 rdfs:subClassOf bae:BrendaCell . # SC-M1 cell
+obo:BTO_0003290 rdfs:subClassOf bae:BrendaCell . # PanIN cell
+obo:BTO_0003291 rdfs:subClassOf bae:BrendaCell . # P493-6 cell
+obo:BTO_0003293 rdfs:subClassOf bae:BrendaCell . # Rat-1 cell
+obo:BTO_0003296 rdfs:subClassOf bae:BrendaCell . # bone marrow stromal cell line
+obo:BTO_0003298 rdfs:subClassOf bae:BrendaCell . # mesenchymal stem cell
+obo:BTO_0003306 rdfs:subClassOf bae:BrendaCell . # Mat-Ly-Lu cell
+obo:BTO_0003310 rdfs:subClassOf bae:BrendaCell . # KMCH cell
+obo:BTO_0003312 rdfs:subClassOf bae:BrendaCell . # KM-12C cell
+obo:BTO_0003317 rdfs:subClassOf bae:BrendaCell . # INS-1E cell
+obo:BTO_0003318 rdfs:subClassOf bae:BrendaCell . # INS-1 823/13 cell
+obo:BTO_0003319 rdfs:subClassOf bae:BrendaCell . # Hepa-1 cell
+obo:BTO_0003321 rdfs:subClassOf bae:BrendaCell . # HCE cell
+obo:BTO_0003324 rdfs:subClassOf bae:BrendaCell . # cardiomyocyte cell line
+obo:BTO_0003326 rdfs:subClassOf bae:BrendaCell . # FLK cell
+obo:BTO_0003336 rdfs:subClassOf bae:BrendaCell . # pulmonary artery smooth muscle cell
+obo:BTO_0003339 rdfs:subClassOf bae:BrendaCell . # HCMEC/D3 cell
+obo:BTO_0003344 rdfs:subClassOf bae:BrendaCell . # CL1-4 cell
+obo:BTO_0003347 rdfs:subClassOf bae:BrendaCell . # C4-2 cell
+obo:BTO_0003349 rdfs:subClassOf bae:BrendaCell . # microglial cell line
+obo:BTO_0003350 rdfs:subClassOf bae:BrendaCell . # BV-2 cell
+obo:BTO_0003352 rdfs:subClassOf bae:BrendaCell . # brain capillary endothelial cell line
+obo:BTO_0003354 rdfs:subClassOf bae:BrendaCell . # B-cell chronic lymphocytic leukemia cell
+obo:BTO_0003357 rdfs:subClassOf bae:BrendaCell . # ARPE cell
+obo:BTO_0003393 rdfs:subClassOf bae:BrendaCell . # granule cell
+obo:BTO_0003413 rdfs:subClassOf bae:BrendaCell . # encysting cell
+obo:BTO_0003420 rdfs:subClassOf bae:BrendaCell . # trophoblast cell line
+obo:BTO_0003422 rdfs:subClassOf bae:BrendaCell . # AF5 cell
+obo:BTO_0003423 rdfs:subClassOf bae:BrendaCell . # lacrimal gland acinar cell
+obo:BTO_0003429 rdfs:subClassOf bae:BrendaCell . # BIC-1 cell
+obo:BTO_0003431 rdfs:subClassOf bae:BrendaCell . # dermatofibroma cell
+obo:BTO_0003436 rdfs:subClassOf bae:BrendaCell . # synovial cell line
+obo:BTO_0003438 rdfs:subClassOf bae:BrendaCell . # WM-9 cell
+obo:BTO_0003452 rdfs:subClassOf bae:BrendaCell . # adipocyte cell line
+obo:BTO_0003457 rdfs:subClassOf bae:BrendaCell . # endometrioma cell
+obo:BTO_0003474 rdfs:subClassOf bae:BrendaCell . # WM-239 cell
+obo:BTO_0003478 rdfs:subClassOf bae:BrendaCell . # SNU-638 cell
+obo:BTO_0003483 rdfs:subClassOf bae:BrendaCell . # sebaceous gland cell line
+obo:BTO_0003485 rdfs:subClassOf bae:BrendaCell . # RPAEC cell
+obo:BTO_0003492 rdfs:subClassOf bae:BrendaCell . # PLC-PRF-5 cell
+obo:BTO_0003494 rdfs:subClassOf bae:BrendaCell . # peripheral blood cell
+obo:BTO_0003505 rdfs:subClassOf bae:BrendaCell . # T-cell chronic lymphocytic leukemia cell
+obo:BTO_0003506 rdfs:subClassOf bae:BrendaCell . # SAF-1 cell
+obo:BTO_0003512 rdfs:subClassOf bae:BrendaCell . # alveolar epithelial cell line
+obo:BTO_0003513 rdfs:subClassOf bae:BrendaCell . # hepatic stellate cell line
+obo:BTO_0003516 rdfs:subClassOf bae:BrendaCell . # LX-2 cell
+obo:BTO_0003520 rdfs:subClassOf bae:BrendaCell . # HSC-T6 cell
+obo:BTO_0003525 rdfs:subClassOf bae:BrendaCell . # BSC cell
+obo:BTO_0003528 rdfs:subClassOf bae:BrendaCell . # GRX cell
+obo:BTO_0003539 rdfs:subClassOf bae:BrendaCell . # PNT2-C2 cell
+obo:BTO_0003540 rdfs:subClassOf bae:BrendaCell . # P4E6 cell
+obo:BTO_0003544 rdfs:subClassOf bae:BrendaCell . # KU-7 cell
+obo:BTO_0003545 rdfs:subClassOf bae:BrendaCell . # KU-1 cell
+obo:BTO_0003548 rdfs:subClassOf bae:BrendaCell . # SMS-KCN cell
+obo:BTO_0003556 rdfs:subClassOf bae:BrendaCell . # SN-56 cell
+obo:BTO_0003560 rdfs:subClassOf bae:BrendaCell . # CCE cell
+obo:BTO_0003562 rdfs:subClassOf bae:BrendaCell . # MB-49 cell
+obo:BTO_0003566 rdfs:subClassOf bae:BrendaCell . # alphaT3-1 cell
+obo:BTO_0003568 rdfs:subClassOf bae:BrendaCell . # mammary gland cell line
+obo:BTO_0003569 rdfs:subClassOf bae:BrendaCell . # C57MG cell
+obo:BTO_0003572 rdfs:subClassOf bae:BrendaCell . # HL60/ADR cell
+obo:BTO_0003578 rdfs:subClassOf bae:BrendaCell . # gingival cell line
+obo:BTO_0003581 rdfs:subClassOf bae:BrendaCell . # renal glomerular cell line
+obo:BTO_0003583 rdfs:subClassOf bae:BrendaCell . # neuroendocrine tumor cell line
+obo:BTO_0003586 rdfs:subClassOf bae:BrendaCell . # Hep-G2/C3A cell
+obo:BTO_0003588 rdfs:subClassOf bae:BrendaCell . # HeLa-MAGI cell
+obo:BTO_0003596 rdfs:subClassOf bae:BrendaCell . # uterine sarcoma cell
+obo:BTO_0003599 rdfs:subClassOf bae:BrendaCell . # human lung microvascular endothelial cell
+obo:BTO_0003600 rdfs:subClassOf bae:BrendaCell . # M cell
+obo:BTO_0003613 rdfs:subClassOf bae:BrendaCell . # lung squamous cell carcinoma cell
+obo:BTO_0003614 rdfs:subClassOf bae:BrendaCell . # oral squamous cell carcinoma cell
+obo:BTO_0003620 rdfs:subClassOf bae:BrendaCell . # BMMC cell
+obo:BTO_0003621 rdfs:subClassOf bae:BrendaCell . # serosal mast cell
+obo:BTO_0003622 rdfs:subClassOf bae:BrendaCell . # mucosal mast cell
+obo:BTO_0003630 rdfs:subClassOf bae:BrendaCell . # CT-26 cell
+obo:BTO_0003640 rdfs:subClassOf bae:BrendaCell . # esophageal cell line
+obo:BTO_0003642 rdfs:subClassOf bae:BrendaCell . # Hca-F cell
+obo:BTO_0003643 rdfs:subClassOf bae:BrendaCell . # HD-11 cell
+obo:BTO_0003645 rdfs:subClassOf bae:BrendaCell . # salivary gland tumor cell line
+obo:BTO_0003646 rdfs:subClassOf bae:BrendaCell . # pleomorphic adenoma cell
+obo:BTO_0003651 rdfs:subClassOf bae:BrendaCell . # spindle cell
+obo:BTO_0003652 rdfs:subClassOf bae:BrendaCell . # synovial cell
+obo:BTO_0003659 rdfs:subClassOf bae:BrendaCell . # secretory cell
+obo:BTO_0003666 rdfs:subClassOf bae:BrendaCell . # outer hair cell
+obo:BTO_0003667 rdfs:subClassOf bae:BrendaCell . # inner hair cell
+obo:BTO_0003672 rdfs:subClassOf bae:BrendaCell . # interdigitating reticulum cell
+obo:BTO_0003681 rdfs:subClassOf bae:BrendaCell . # hairy cell leukemia cell line
+obo:BTO_0003682 rdfs:subClassOf bae:BrendaCell . # hairy cell leukemia cell
+obo:BTO_0003689 rdfs:subClassOf bae:BrendaCell . # mucous cell
+obo:BTO_0003690 rdfs:subClassOf bae:BrendaCell . # mucous acinar cell
+obo:BTO_0003692 rdfs:subClassOf bae:BrendaCell . # prostatic intraepithelial neoplasia cell
+obo:BTO_0003694 rdfs:subClassOf bae:BrendaCell . # CNS cell line
+obo:BTO_0003695 rdfs:subClassOf bae:BrendaCell . # CAD cell
+obo:BTO_0003696 rdfs:subClassOf bae:BrendaCell . # ATRkd cell
+obo:BTO_0003697 rdfs:subClassOf bae:BrendaCell . # endometrial stromal cell
+obo:BTO_0003704 rdfs:subClassOf bae:BrendaCell . # H4 neuroglioma cell
+obo:BTO_0003713 rdfs:subClassOf bae:BrendaCell . # WM-793 cell
+obo:BTO_0003714 rdfs:subClassOf bae:BrendaCell . # VMRC-RCW cell
+obo:BTO_0003716 rdfs:subClassOf bae:BrendaCell . # ScN2a cell
+obo:BTO_0003736 rdfs:subClassOf bae:BrendaCell . # thyroid epithelial cell
+obo:BTO_0003744 rdfs:subClassOf bae:BrendaCell . # liposarcoma cell line
+obo:BTO_0003745 rdfs:subClassOf bae:BrendaCell . # liposarcoma cell
+obo:BTO_0003758 rdfs:subClassOf bae:BrendaCell . # STAV-AB cell
+obo:BTO_0003764 rdfs:subClassOf bae:BrendaCell . # NCI cell
+obo:BTO_0003765 rdfs:subClassOf bae:BrendaCell . # dermatofibroma cell line
+obo:BTO_0003766 rdfs:subClassOf bae:BrendaCell . # giant cell tumor cell line
+obo:BTO_0003771 rdfs:subClassOf bae:BrendaCell . # T2 cell
+obo:BTO_0003773 rdfs:subClassOf bae:BrendaCell . # oropharyngeal squamous cell carcinoma cell
+obo:BTO_0003779 rdfs:subClassOf bae:BrendaCell . # RN-46A cell
+obo:BTO_0003781 rdfs:subClassOf bae:BrendaCell . # RCC 786-O cell
+obo:BTO_0003782 rdfs:subClassOf bae:BrendaCell . # rectal adenocarcinoma cell
+obo:BTO_0003783 rdfs:subClassOf bae:BrendaCell . # rectal adenocarcinoma cell line
+obo:BTO_0003789 rdfs:subClassOf bae:BrendaCell . # PR-Mel cell
+obo:BTO_0003790 rdfs:subClassOf bae:BrendaCell . # MR-Mel cell
+obo:BTO_0003792 rdfs:subClassOf bae:BrendaCell . # OV-2008 cell
+obo:BTO_0003796 rdfs:subClassOf bae:BrendaCell . # periglomerular cell
+obo:BTO_0003800 rdfs:subClassOf bae:BrendaCell . # PCCL-3 cell
+obo:BTO_0003804 rdfs:subClassOf bae:BrendaCell . # ovarian serous adenocarcinoma cell line
+obo:BTO_0003845 rdfs:subClassOf bae:BrendaCell . # A2780/CP70 cell
+obo:BTO_0003848 rdfs:subClassOf bae:BrendaCell . # adenoid cystic carcinoma cell
+obo:BTO_0003849 rdfs:subClassOf bae:BrendaCell . # adenosquamous carcinoma cell
+obo:BTO_0003856 rdfs:subClassOf bae:BrendaCell . # BON-1 cell
+obo:BTO_0003857 rdfs:subClassOf bae:BrendaCell . # bone marrow-derived dendritic cell
+obo:BTO_0003858 rdfs:subClassOf bae:BrendaCell . # chondrocyte cell line
+obo:BTO_0003860 rdfs:subClassOf bae:BrendaCell . # T/C-28a2 cell
+obo:BTO_0003861 rdfs:subClassOf bae:BrendaCell . # inflammatory cell
+obo:BTO_0003865 rdfs:subClassOf bae:BrendaCell . # enteroendocrine cell
+obo:BTO_0003871 rdfs:subClassOf bae:BrendaCell . # uterine endometrial cancer cell
+obo:BTO_0003872 rdfs:subClassOf bae:BrendaCell . # foam cell
+obo:BTO_0003875 rdfs:subClassOf bae:BrendaCell . # FTC-236 cell
+obo:BTO_0003877 rdfs:subClassOf bae:BrendaCell . # G-292 cell
+obo:BTO_0003881 rdfs:subClassOf bae:BrendaCell . # HSC-2 cell
+obo:BTO_0003884 rdfs:subClassOf bae:BrendaCell . # HMT-3522 cell
+obo:BTO_0003894 rdfs:subClassOf bae:BrendaCell . # skin carcinoma cell line
+obo:BTO_0003898 rdfs:subClassOf bae:BrendaCell . # GT1 cell
+obo:BTO_0003907 rdfs:subClassOf bae:BrendaCell . # uroepithelial cell line
+obo:BTO_0003909 rdfs:subClassOf bae:BrendaCell . # bile duct cell line
+obo:BTO_0003912 rdfs:subClassOf bae:BrendaCell . # IMCD cell
+obo:BTO_0003921 rdfs:subClassOf bae:BrendaCell . # KHOS cell
+obo:BTO_0003929 rdfs:subClassOf bae:BrendaCell . # MM1-R cell
+obo:BTO_0003932 rdfs:subClassOf bae:BrendaCell . # KMS-11 cell
+obo:BTO_0003936 rdfs:subClassOf bae:BrendaCell . # laryngeal squamous cell carcinoma cell
+obo:BTO_0003944 rdfs:subClassOf bae:BrendaCell . # Mel-Ab cell
+obo:BTO_0003945 rdfs:subClassOf bae:BrendaCell . # MN-9D cell
+obo:BTO_0003946 rdfs:subClassOf bae:BrendaCell . # MMDD1 cell
+obo:BTO_0003952 rdfs:subClassOf bae:BrendaCell . # mesenchymal stromal cell
+obo:BTO_0003955 rdfs:subClassOf bae:BrendaCell . # N-11 cell
+obo:BTO_0003957 rdfs:subClassOf bae:BrendaCell . # N-9 cell
+obo:BTO_0003960 rdfs:subClassOf bae:BrendaCell . # nasopharyngeal carcinoma cell line
+obo:BTO_0003964 rdfs:subClassOf bae:BrendaCell . # OECM-1 cell
+obo:BTO_0003967 rdfs:subClassOf bae:BrendaCell . # OSRGA cell
+obo:BTO_0003972 rdfs:subClassOf bae:BrendaCell . # prostate gland stromal cell
+obo:BTO_0003981 rdfs:subClassOf bae:BrendaCell . # SAS cell
+obo:BTO_0003982 rdfs:subClassOf bae:BrendaCell . # retinal stem cell
+obo:BTO_0003984 rdfs:subClassOf bae:BrendaCell . # A-375P cell
+obo:BTO_0003998 rdfs:subClassOf bae:BrendaCell . # 41-M cell
+obo:BTO_0004002 rdfs:subClassOf bae:BrendaCell . # HEMn cell
+obo:BTO_0004003 rdfs:subClassOf bae:BrendaCell . # NA cell
+obo:BTO_0004004 rdfs:subClassOf bae:BrendaCell . # 3-LL cell
+obo:BTO_0004007 rdfs:subClassOf bae:BrendaCell . # porcine aortic endothelial cell
+obo:BTO_0004010 rdfs:subClassOf bae:BrendaCell . # HT-2 cell
+obo:BTO_0004012 rdfs:subClassOf bae:BrendaCell . # ROS cell
+obo:BTO_0004013 rdfs:subClassOf bae:BrendaCell . # Colon-26 cell
+obo:BTO_0004035 rdfs:subClassOf bae:BrendaCell . # 222 cell
+obo:BTO_0004044 rdfs:subClassOf bae:BrendaCell . # amacrine cell
+obo:BTO_0004049 rdfs:subClassOf bae:BrendaCell . # adult T-cell lymphoma cell line
+obo:BTO_0004050 rdfs:subClassOf bae:BrendaCell . # BEL-7402 cell
+obo:BTO_0004051 rdfs:subClassOf bae:BrendaCell . # bipolar cell
+obo:BTO_0004052 rdfs:subClassOf bae:BrendaCell . # bone marrow stem cell
+obo:BTO_0004054 rdfs:subClassOf bae:BrendaCell . # umbilical cord blood cell
+obo:BTO_0004055 rdfs:subClassOf bae:BrendaCell . # COS cell
+obo:BTO_0004058 rdfs:subClassOf bae:BrendaCell . # C3H10T1/2 cell
+obo:BTO_0004065 rdfs:subClassOf bae:BrendaCell . # CHO-MG cell
+obo:BTO_0004087 rdfs:subClassOf bae:BrendaCell . # mammary gland tumor cell
+obo:BTO_0004091 rdfs:subClassOf bae:BrendaCell . # embryonic neural stem cell
+obo:BTO_0004093 rdfs:subClassOf bae:BrendaCell . # endothelial progenitor cell
+obo:BTO_0004094 rdfs:subClassOf bae:BrendaCell . # epithelial ovarian cancer cell
+obo:BTO_0004095 rdfs:subClassOf bae:BrendaCell . # EONT cell
+obo:BTO_0004096 rdfs:subClassOf bae:BrendaCell . # coronary artery endothelial cell
+obo:BTO_0004097 rdfs:subClassOf bae:BrendaCell . # epididymal clear cell
+obo:BTO_0004098 rdfs:subClassOf bae:BrendaCell . # renal clear cell
+obo:BTO_0004105 rdfs:subClassOf bae:BrendaCell . # FPMI-CF-203 cell
+obo:BTO_0004111 rdfs:subClassOf bae:BrendaCell . # gastrointestinal stromal tumor cell
+obo:BTO_0004112 rdfs:subClassOf bae:BrendaCell . # GBC-SD cell
+obo:BTO_0004114 rdfs:subClassOf bae:BrendaCell . # adrenocortical carcinoma cell line
+obo:BTO_0004115 rdfs:subClassOf bae:BrendaCell . # HAC cell
+obo:BTO_0004116 rdfs:subClassOf bae:BrendaCell . # HEP-3B2 cell
+obo:BTO_0004117 rdfs:subClassOf bae:BrendaCell . # HFK cell
+obo:BTO_0004120 rdfs:subClassOf bae:BrendaCell . # horizontal cell
+obo:BTO_0004122 rdfs:subClassOf bae:BrendaCell . # bone marrow stromal cell
+obo:BTO_0004126 rdfs:subClassOf bae:BrendaCell . # Huh-7.5 cell
+obo:BTO_0004139 rdfs:subClassOf bae:BrendaCell . # LAD-2 cell
+obo:BTO_0004160 rdfs:subClassOf bae:BrendaCell . # Ma-1 cell
+obo:BTO_0004166 rdfs:subClassOf bae:BrendaCell . # myofibroblast cell line
+obo:BTO_0004168 rdfs:subClassOf bae:BrendaCell . # MHCC-97 cell
+obo:BTO_0004169 rdfs:subClassOf bae:BrendaCell . # MHCC97-H cell
+obo:BTO_0004170 rdfs:subClassOf bae:BrendaCell . # MHCC97-L cell
+obo:BTO_0004178 rdfs:subClassOf bae:BrendaCell . # leukemic stem cell
+obo:BTO_0004181 rdfs:subClassOf bae:BrendaCell . # NCI/ADR-RES cell
+obo:BTO_0004190 rdfs:subClassOf bae:BrendaCell . # pacemaker cell
+obo:BTO_0004191 rdfs:subClassOf bae:BrendaCell . # PC-J cell
+obo:BTO_0004200 rdfs:subClassOf bae:BrendaCell . # RCSN-3 cell
+obo:BTO_0004201 rdfs:subClassOf bae:BrendaCell . # Ewing's sarcoma cell line
+obo:BTO_0004203 rdfs:subClassOf bae:BrendaCell . # RIE-1 cell
+obo:BTO_0004210 rdfs:subClassOf bae:BrendaCell . # seminoma cell
+obo:BTO_0004221 rdfs:subClassOf bae:BrendaCell . # SN-12C cell
+obo:BTO_0004223 rdfs:subClassOf bae:BrendaCell . # cervical squamous cell carcinoma cell
+obo:BTO_0004226 rdfs:subClassOf bae:BrendaCell . # TAMH cell
+obo:BTO_0004229 rdfs:subClassOf bae:BrendaCell . # testicular cell line
+obo:BTO_0004232 rdfs:subClassOf bae:BrendaCell . # tsA-201 cell
+obo:BTO_0004236 rdfs:subClassOf bae:BrendaCell . # Y1-BS1 cell
+obo:BTO_0004237 rdfs:subClassOf bae:BrendaCell . # myometrial cell line
+obo:BTO_0004238 rdfs:subClassOf bae:BrendaCell . # interstitial cell
+obo:BTO_0004243 rdfs:subClassOf bae:BrendaCell . # trypanosomoid cell line
+obo:BTO_0004248 rdfs:subClassOf bae:BrendaCell . # Xenopus A6 cell
+obo:BTO_0004254 rdfs:subClassOf bae:BrendaCell . # cancer stem cell
+obo:BTO_0004255 rdfs:subClassOf bae:BrendaCell . # Ewing's family tumor cell
+obo:BTO_0004257 rdfs:subClassOf bae:BrendaCell . # extraosseus Ewing's sarcoma cell
+obo:BTO_0004258 rdfs:subClassOf bae:BrendaCell . # primitive neuroectodermal tumor cell
+obo:BTO_0004259 rdfs:subClassOf bae:BrendaCell . # primitive neuroectodermal tumor cell line
+obo:BTO_0004260 rdfs:subClassOf bae:BrendaCell . # Askin's tumor cell
+obo:BTO_0004261 rdfs:subClassOf bae:BrendaCell . # peripheral primitive neuroectodermal tumor cell
+obo:BTO_0004262 rdfs:subClassOf bae:BrendaCell . # cerebral giant cell
+obo:BTO_0004265 rdfs:subClassOf bae:BrendaCell . # EJ cell
+obo:BTO_0004266 rdfs:subClassOf bae:BrendaCell . # H-10 cell
+obo:BTO_0004267 rdfs:subClassOf bae:BrendaCell . # follicular dendritic cell
+obo:BTO_0004269 rdfs:subClassOf bae:BrendaCell . # liver cancer stem cell
+obo:BTO_0004270 rdfs:subClassOf bae:BrendaCell . # adult liver stem cell
+obo:BTO_0004272 rdfs:subClassOf bae:BrendaCell . # hyalocyte cell line
+obo:BTO_0004278 rdfs:subClassOf bae:BrendaCell . # cerebellar granule cell
+obo:BTO_0004286 rdfs:subClassOf bae:BrendaCell . # basophilic leukemia cell
+obo:BTO_0004296 rdfs:subClassOf bae:BrendaCell . # umbilical vein endothelial cell
+obo:BTO_0004297 rdfs:subClassOf bae:BrendaCell . # colonic epithelial cell
+obo:BTO_0004298 rdfs:subClassOf bae:BrendaCell . # corneal epithelial cell
+obo:BTO_0004299 rdfs:subClassOf bae:BrendaCell . # lung epithelial cell
+obo:BTO_0004300 rdfs:subClassOf bae:BrendaCell . # mammary epithelial cell
+obo:BTO_0004301 rdfs:subClassOf bae:BrendaCell . # neuroepithelial cell
+obo:BTO_0004306 rdfs:subClassOf bae:BrendaCell . # NCM-460 cell
+obo:BTO_0004324 rdfs:subClassOf bae:BrendaCell . # osteoblast cell line
+obo:BTO_0004325 rdfs:subClassOf bae:BrendaCell . # 2T3 cell
+obo:BTO_0004333 rdfs:subClassOf bae:BrendaCell . # Do11.10 cell
+obo:BTO_0004339 rdfs:subClassOf bae:BrendaCell . # ScGT1 cell
+obo:BTO_0004360 rdfs:subClassOf bae:BrendaCell . # angiomyolipoma cell
+obo:BTO_0004365 rdfs:subClassOf bae:BrendaCell . # gastroesophageal cancer cell
+obo:BTO_0004384 rdfs:subClassOf bae:BrendaCell . # osteoclast stem cell
+obo:BTO_0004389 rdfs:subClassOf bae:BrendaCell . # angiomyolipoma cell line
+obo:BTO_0004392 rdfs:subClassOf bae:BrendaCell . # skeletal muscle cell
+obo:BTO_0004397 rdfs:subClassOf bae:BrendaCell . # B-103 cell
+obo:BTO_0004398 rdfs:subClassOf bae:BrendaCell . # meningioma cell line
+obo:BTO_0004402 rdfs:subClassOf bae:BrendaCell . # bronchial smooth muscle cell
+obo:BTO_0004405 rdfs:subClassOf bae:BrendaCell . # 3D5 cell
+obo:BTO_0004410 rdfs:subClassOf bae:BrendaCell . # culture condition:CD8+ cell
+obo:BTO_0004416 rdfs:subClassOf bae:BrendaCell . # Daltons lymphoma cell
+obo:BTO_0004420 rdfs:subClassOf bae:BrendaCell . # digestive cell
+obo:BTO_0004438 rdfs:subClassOf bae:BrendaCell . # HSCC cell
+obo:BTO_0004462 rdfs:subClassOf bae:BrendaCell . # K-562R cell
+obo:BTO_0004467 rdfs:subClassOf bae:BrendaCell . # LbetaT2 cell
+obo:BTO_0004471 rdfs:subClassOf bae:BrendaCell . # Mahlavu cell
+obo:BTO_0004472 rdfs:subClassOf bae:BrendaCell . # mantle cell lymphoma cell
+obo:BTO_0004475 rdfs:subClassOf bae:BrendaCell . # MEL cell
+obo:BTO_0004476 rdfs:subClassOf bae:BrendaCell . # MES-23.5 cell
+obo:BTO_0004481 rdfs:subClassOf bae:BrendaCell . # neural crest-derived stem cell
+obo:BTO_0004482 rdfs:subClassOf bae:BrendaCell . # ovarian surface epithelial cell line
+obo:BTO_0004484 rdfs:subClassOf bae:BrendaCell . # ovarian surface epithelial cell
+obo:BTO_0004487 rdfs:subClassOf bae:BrendaCell . # OV-MZ-6 cell
+obo:BTO_0004488 rdfs:subClassOf bae:BrendaCell . # NSC-34 cell
+obo:BTO_0004492 rdfs:subClassOf bae:BrendaCell . # gastric epithelial cell
+obo:BTO_0004493 rdfs:subClassOf bae:BrendaCell . # gastric epithelium cell line
+obo:BTO_0004494 rdfs:subClassOf bae:BrendaCell . # RGM-1 cell
+obo:BTO_0004498 rdfs:subClassOf bae:BrendaCell . # THCE cell
+obo:BTO_0004499 rdfs:subClassOf bae:BrendaCell . # prostate gland intraepithelial neoplasia cell line
+obo:BTO_0004508 rdfs:subClassOf bae:BrendaCell . # endothelioma cell
+obo:BTO_0004509 rdfs:subClassOf bae:BrendaCell . # endothelioma cell line
+obo:BTO_0004513 rdfs:subClassOf bae:BrendaCell . # Sertoli cell line
+obo:BTO_0004519 rdfs:subClassOf bae:BrendaCell . # myometrial cell
+obo:BTO_0004522 rdfs:subClassOf bae:BrendaCell . # Leydig cell line
+obo:BTO_0004530 rdfs:subClassOf bae:BrendaCell . # F5 meningioma cell
+obo:BTO_0004533 rdfs:subClassOf bae:BrendaCell . # respiratory epithelium cell
+obo:BTO_0004535 rdfs:subClassOf bae:BrendaCell . # medullary collecting duct cell
+obo:BTO_0004537 rdfs:subClassOf bae:BrendaCell . # cortical collecting duct cell
+obo:BTO_0004541 rdfs:subClassOf bae:BrendaCell . # connecting tubule cell
+obo:BTO_0004542 rdfs:subClassOf bae:BrendaCell . # principal cell
+obo:BTO_0004543 rdfs:subClassOf bae:BrendaCell . # inner medullary collecting duct cell
+obo:BTO_0004561 rdfs:subClassOf bae:BrendaCell . # thymic stromal cell
+obo:BTO_0004562 rdfs:subClassOf bae:BrendaCell . # thymic cortical epithelial cell
+obo:BTO_0004563 rdfs:subClassOf bae:BrendaCell . # thymic medullary epithelial cell
+obo:BTO_0004564 rdfs:subClassOf bae:BrendaCell . # thymic dendritic cell
+obo:BTO_0004566 rdfs:subClassOf bae:BrendaCell . # Rb-1 cell
+obo:BTO_0004567 rdfs:subClassOf bae:BrendaCell . # sessile serrated adenoma cell
+obo:BTO_0004574 rdfs:subClassOf bae:BrendaCell . # dermal microvascular endothelial cell
+obo:BTO_0004575 rdfs:subClassOf bae:BrendaCell . # nephroblastoma cell
+obo:BTO_0004576 rdfs:subClassOf bae:BrendaCell . # smooth muscle cell
+obo:BTO_0004577 rdfs:subClassOf bae:BrendaCell . # aortic smooth muscle cell
+obo:BTO_0004578 rdfs:subClassOf bae:BrendaCell . # vascular smooth muscle cell
+obo:BTO_0004585 rdfs:subClassOf bae:BrendaCell . # acute promyelocytic leukemia cell
+obo:BTO_0004595 rdfs:subClassOf bae:BrendaCell . # D-407 cell
+obo:BTO_0004599 rdfs:subClassOf bae:BrendaCell . # TE-13 cell
+obo:BTO_0004601 rdfs:subClassOf bae:BrendaCell . # TE-1 cell
+obo:BTO_0004602 rdfs:subClassOf bae:BrendaCell . # human aortic endothelial cell
+obo:BTO_0004603 rdfs:subClassOf bae:BrendaCell . # HBE cell
+obo:BTO_0004606 rdfs:subClassOf bae:BrendaCell . # MDCK-1 cell
+obo:BTO_0004607 rdfs:subClassOf bae:BrendaCell . # MDCK-2 cell
+obo:BTO_0004609 rdfs:subClassOf bae:BrendaCell . # TALH cell
+obo:BTO_0004623 rdfs:subClassOf bae:BrendaCell . # OCI-M2 cell
+obo:BTO_0004624 rdfs:subClassOf bae:BrendaCell . # YN-1 cell
+obo:BTO_0004625 rdfs:subClassOf bae:BrendaCell . # plasmacytoid dendritic cell
+obo:BTO_0004640 rdfs:subClassOf bae:BrendaCell . # FD-2 cell
+obo:BTO_0004641 rdfs:subClassOf bae:BrendaCell . # tracheal cell line
+obo:BTO_0004656 rdfs:subClassOf bae:BrendaCell . # follicular lymphoma cell
+obo:BTO_0004660 rdfs:subClassOf bae:BrendaCell . # human amniotic epithelial cell
+obo:BTO_0004720 rdfs:subClassOf bae:BrendaCell . # mural cell
+obo:BTO_0004721 rdfs:subClassOf bae:BrendaCell . # myeloid dendritic cell
+obo:BTO_0004730 rdfs:subClassOf bae:BrendaCell . # myeloid progenitor cell
+obo:BTO_0004731 rdfs:subClassOf bae:BrendaCell . # lymphoid progenitor cell
+obo:BTO_0004744 rdfs:subClassOf bae:BrendaCell . # hair cell
+obo:BTO_0004752 rdfs:subClassOf bae:BrendaCell . # adipose-derived stromal cell
+obo:BTO_0004758 rdfs:subClassOf bae:BrendaCell . # arterial endothelial cell
+obo:BTO_0004759 rdfs:subClassOf bae:BrendaCell . # venous endothelial cell
+obo:BTO_0004770 rdfs:subClassOf bae:BrendaCell . # TAD-2 cell
+obo:BTO_0004771 rdfs:subClassOf bae:BrendaCell . # NPA cell
+obo:BTO_0004773 rdfs:subClassOf bae:BrendaCell . # trophoblast stem cell line
+obo:BTO_0004774 rdfs:subClassOf bae:BrendaCell . # trophoblast stem cell
+obo:BTO_0004779 rdfs:subClassOf bae:BrendaCell . # soft tissue sarcoma cell
+obo:BTO_0004780 rdfs:subClassOf bae:BrendaCell . # soft tissue sarcoma cell line
+obo:BTO_0004783 rdfs:subClassOf bae:BrendaCell . # SeAx cell
+obo:BTO_0004785 rdfs:subClassOf bae:BrendaCell . # Ewing's sarcoma family tumor cell line
+obo:BTO_0004787 rdfs:subClassOf bae:BrendaCell . # SK-N-LO cell
+obo:BTO_0004796 rdfs:subClassOf bae:BrendaCell . # 253J cell
+obo:BTO_0004799 rdfs:subClassOf bae:BrendaCell . # AILNCaP cell
+obo:BTO_0004804 rdfs:subClassOf bae:BrendaCell . # buccal epithelial cell
+obo:BTO_0004811 rdfs:subClassOf bae:BrendaCell . # Clara cell
+obo:BTO_0004812 rdfs:subClassOf bae:BrendaCell . # dermal dendritic cell
+obo:BTO_0004816 rdfs:subClassOf bae:BrendaCell . # ERpP cell
+obo:BTO_0004827 rdfs:subClassOf bae:BrendaCell . # hFOB cell
+obo:BTO_0004830 rdfs:subClassOf bae:BrendaCell . # epidermal cell line
+obo:BTO_0004831 rdfs:subClassOf bae:BrendaCell . # JB6 cell
+obo:BTO_0004833 rdfs:subClassOf bae:BrendaCell . # large cell neuroendocrine carcinoma cell
+obo:BTO_0004837 rdfs:subClassOf bae:BrendaCell . # MRC5-SV cell
+obo:BTO_0004845 rdfs:subClassOf bae:BrendaCell . # NHOst cell
+obo:BTO_0004850 rdfs:subClassOf bae:BrendaCell . # bone marrow cell
+obo:BTO_0004851 rdfs:subClassOf bae:BrendaCell . # mammary ductal carcinoma cell
+obo:BTO_0004854 rdfs:subClassOf bae:BrendaCell . # PK-1 cell
+obo:BTO_0004862 rdfs:subClassOf bae:BrendaCell . # HEI-OC1 cell
+obo:BTO_0004864 rdfs:subClassOf bae:BrendaCell . # HMC cell
+obo:BTO_0004868 rdfs:subClassOf bae:BrendaCell . # anaplastic large cell lymphoma cell line
+obo:BTO_0004877 rdfs:subClassOf bae:BrendaCell . # distal tip cell
+obo:BTO_0004897 rdfs:subClassOf bae:BrendaCell . # CHO-LY-B cell
+obo:BTO_0004901 rdfs:subClassOf bae:BrendaCell . # non-neuronal cell
+obo:BTO_0004910 rdfs:subClassOf bae:BrendaCell . # retinal pigment epithelial cell
+obo:BTO_0004911 rdfs:subClassOf bae:BrendaCell . # erythroid progenitor cell
+obo:BTO_0004919 rdfs:subClassOf bae:BrendaCell . # ZR-75 cell
+obo:BTO_0004921 rdfs:subClassOf bae:BrendaCell . # swine testicular cell line
+obo:BTO_0004925 rdfs:subClassOf bae:BrendaCell . # HRA cell
+obo:BTO_0004953 rdfs:subClassOf bae:BrendaCell . # MGC-803 cell
+obo:BTO_0004958 rdfs:subClassOf bae:BrendaCell . # F9-12 cell
+obo:BTO_0004959 rdfs:subClassOf bae:BrendaCell . # C4-2B cell
+obo:BTO_0004961 rdfs:subClassOf bae:BrendaCell . # acute megakaryoblastic leukemia cell line
+obo:BTO_0004963 rdfs:subClassOf bae:BrendaCell . # acute megakaryoblastic leukemia cell
+obo:BTO_0004965 rdfs:subClassOf bae:BrendaCell . # TTA-1 cell
+obo:BTO_0004966 rdfs:subClassOf bae:BrendaCell . # Rat-1/BB16 cell
+obo:BTO_0004973 rdfs:subClassOf bae:BrendaCell . # Hodgkin lymphoma cell line
+obo:BTO_0004974 rdfs:subClassOf bae:BrendaCell . # Hodgkin lymphoma cell
+obo:BTO_0004975 rdfs:subClassOf bae:BrendaCell . # embryogenic cell line
+obo:BTO_0004976 rdfs:subClassOf bae:BrendaCell . # tongue cancer cell
+obo:BTO_0004980 rdfs:subClassOf bae:BrendaCell . # uveal melanoma cell
+obo:BTO_0004996 rdfs:subClassOf bae:BrendaCell . # myelinating Schwann cell
+obo:BTO_0004997 rdfs:subClassOf bae:BrendaCell . # non-myelinating Schwann cell
+obo:BTO_0005001 rdfs:subClassOf bae:BrendaCell . # retinal microvascular endothelial cell
+obo:BTO_0005004 rdfs:subClassOf bae:BrendaCell . # UROtsa cell
+obo:BTO_0005007 rdfs:subClassOf bae:BrendaCell . # psammomatous meningioma cell
+obo:BTO_0005014 rdfs:subClassOf bae:BrendaCell . # B-cell leukemia cell
+obo:BTO_0005023 rdfs:subClassOf bae:BrendaCell . # cEND cell
+obo:BTO_0005025 rdfs:subClassOf bae:BrendaCell . # HEK-293-TrkB cell
+obo:BTO_0005029 rdfs:subClassOf bae:BrendaCell . # HEK-293FT cell
+obo:BTO_0005034 rdfs:subClassOf bae:BrendaCell . # DT-40 3KO cell
+obo:BTO_0005036 rdfs:subClassOf bae:BrendaCell . # Fanconi anemia lymphoid cell line
+obo:BTO_0005039 rdfs:subClassOf bae:BrendaCell . # HN-30 cell
+obo:BTO_0005040 rdfs:subClassOf bae:BrendaCell . # HN-12 cell
+obo:BTO_0005043 rdfs:subClassOf bae:BrendaCell . # M1 melanoma cell
+obo:BTO_0005049 rdfs:subClassOf bae:BrendaCell . # prostate adenocarcinoma cell line
+obo:BTO_0005054 rdfs:subClassOf bae:BrendaCell . # macrophage foam cell
+obo:BTO_0005059 rdfs:subClassOf bae:BrendaCell . # TZM-bl cell
+obo:BTO_0005060 rdfs:subClassOf bae:BrendaCell . # UACC-903 cell
+obo:BTO_0005067 rdfs:subClassOf bae:BrendaCell . # PAM212 cell
+obo:BTO_0005068 rdfs:subClassOf bae:BrendaCell . # SK-CO15 cell
+obo:BTO_0005071 rdfs:subClassOf bae:BrendaCell . # PC3-MM2 cell
+obo:BTO_0005083 rdfs:subClassOf bae:BrendaCell . # plant mucous cell
+obo:BTO_0005092 rdfs:subClassOf bae:BrendaCell . # chondrogenic cell
+obo:BTO_0005093 rdfs:subClassOf bae:BrendaCell . # intercalated cell
+obo:BTO_0005096 rdfs:subClassOf bae:BrendaCell . # epithelial stem cell
+obo:BTO_0005097 rdfs:subClassOf bae:BrendaCell . # skin stem cell
+obo:BTO_0005098 rdfs:subClassOf bae:BrendaCell . # epidermal stem cell
+obo:BTO_0005099 rdfs:subClassOf bae:BrendaCell . # follicular stem cell
+obo:BTO_0005101 rdfs:subClassOf bae:BrendaCell . # coronary artery smooth muscle cell
+obo:BTO_0005103 rdfs:subClassOf bae:BrendaCell . # NB-1 cell
+obo:BTO_0005110 rdfs:subClassOf bae:BrendaCell . # ameloblastoma cell
+obo:BTO_0005117 rdfs:subClassOf bae:BrendaCell . # retinal ganglion cell line
+obo:BTO_0005118 rdfs:subClassOf bae:BrendaCell . # RGC-5 cell
+obo:BTO_0005128 rdfs:subClassOf bae:BrendaCell . # M12 prostate cancer cell
+obo:BTO_0005129 rdfs:subClassOf bae:BrendaCell . # A2780/S cell
+obo:BTO_0005136 rdfs:subClassOf bae:BrendaCell . # ES-E14 cell
+obo:BTO_0005155 rdfs:subClassOf bae:BrendaCell . # CEM-VBL100 cell
+obo:BTO_0005158 rdfs:subClassOf bae:BrendaCell . # juxtaglomerular cell
+obo:BTO_0005159 rdfs:subClassOf bae:BrendaCell . # extraglomerular mesangial cell
+obo:BTO_0005161 rdfs:subClassOf bae:BrendaCell . # KAT-18 cell
+obo:BTO_0005167 rdfs:subClassOf bae:BrendaCell . # HSC-1 cell
+obo:BTO_0005191 rdfs:subClassOf bae:BrendaCell . # Patu-8988 cell
+obo:BTO_0005195 rdfs:subClassOf bae:BrendaCell . # K-562/R7 cell
+obo:BTO_0005196 rdfs:subClassOf bae:BrendaCell . # KBv200 cell
+obo:BTO_0005198 rdfs:subClassOf bae:BrendaCell . # adipose-derived stem cell
+obo:BTO_0005201 rdfs:subClassOf bae:BrendaCell . # brain endothelial cell
+obo:BTO_0005204 rdfs:subClassOf bae:BrendaCell . # Ca9-22 cell
+obo:BTO_0005212 rdfs:subClassOf bae:BrendaCell . # cervical intraepithelial neoplasia cell
+obo:BTO_0005215 rdfs:subClassOf bae:BrendaCell . # KB-C2 cell
+obo:BTO_0005218 rdfs:subClassOf bae:BrendaCell . # MC57 cell
+obo:BTO_0005220 rdfs:subClassOf bae:BrendaCell . # PC-3M cell
+obo:BTO_0005238 rdfs:subClassOf bae:BrendaCell . # T-REx 293 cell
+obo:BTO_0005258 rdfs:subClassOf bae:BrendaCell . # oropharyngeal cancer cell
+obo:BTO_0005259 rdfs:subClassOf bae:BrendaCell . # oropharyngeal carcinoma cell line
+obo:BTO_0005261 rdfs:subClassOf bae:BrendaCell . # B-lymphoblast cell line
+obo:BTO_0005262 rdfs:subClassOf bae:BrendaCell . # NEF cell
+obo:BTO_0005264 rdfs:subClassOf bae:BrendaCell . # mucoepidermoid carcinoma cell
+obo:BTO_0005283 rdfs:subClassOf bae:BrendaCell . # TS-20 cell
+obo:BTO_0005288 rdfs:subClassOf bae:BrendaCell . # CL-48 cell
+obo:BTO_0005300 rdfs:subClassOf bae:BrendaCell . # muscle stem cell
+obo:BTO_0005301 rdfs:subClassOf bae:BrendaCell . # NPrEC cell
+obo:BTO_0005316 rdfs:subClassOf bae:BrendaCell . # malignant peripheral nerve sheath cancer cell
+obo:BTO_0005319 rdfs:subClassOf bae:BrendaCell . # embryonic germ cell
+obo:BTO_0005322 rdfs:subClassOf bae:BrendaCell . # chronic myelogenous leukemia progenitor cell
+obo:BTO_0005352 rdfs:subClassOf bae:BrendaCell . # 1-LN cell
+obo:BTO_0005362 rdfs:subClassOf bae:BrendaCell . # trophoblast giant cell
+obo:BTO_0005364 rdfs:subClassOf bae:BrendaCell . # D-54MG cell
+obo:BTO_0005372 rdfs:subClassOf bae:BrendaCell . # SK-N-MC-IXC cell
+obo:BTO_0005375 rdfs:subClassOf bae:BrendaCell . # oral cell line
+obo:BTO_0005388 rdfs:subClassOf bae:BrendaCell . # SUM-149 cell
+obo:BTO_0005397 rdfs:subClassOf bae:BrendaCell . # SH-EP cell
+obo:BTO_0005399 rdfs:subClassOf bae:BrendaCell . # POS cell
+obo:BTO_0005400 rdfs:subClassOf bae:BrendaCell . # BPH cell
+obo:BTO_0005403 rdfs:subClassOf bae:BrendaCell . # glycogen cell
+obo:BTO_0005453 rdfs:subClassOf bae:BrendaCell . # culture condition:CD4+ cell
+obo:BTO_0005490 rdfs:subClassOf bae:BrendaCell . # MM-1 cell
+obo:CLO_0001056 rdfs:subClassOf bae:BrendaCell . # 1205Lu cell
+obo:CLO_0001088 rdfs:subClassOf bae:BrendaCell . # 143B cell
+obo:CLO_0001200 rdfs:subClassOf bae:BrendaCell . # 22Rv1 cell
+obo:CLO_0001230 rdfs:subClassOf bae:BrendaCell . # HEK-293 cell
+obo:CLO_0001352 rdfs:subClassOf bae:BrendaCell . # 3T3-L1 cell
+obo:CLO_0001401 rdfs:subClassOf bae:BrendaCell . # 4T1 cell
+obo:CLO_0001570 rdfs:subClassOf bae:BrendaCell . # A-253 cell
+obo:CLO_0001571 rdfs:subClassOf bae:BrendaCell . # A2780 cell
+obo:CLO_0001582 rdfs:subClassOf bae:BrendaCell . # A-375 cell
+obo:CLO_0001590 rdfs:subClassOf bae:BrendaCell . # A-427 cell
+obo:CLO_0001596 rdfs:subClassOf bae:BrendaCell . # A-498 cell
+obo:CLO_0001606 rdfs:subClassOf bae:BrendaCell . # A-673 cell
+obo:CLO_0001656 rdfs:subClassOf bae:BrendaCell . # ACT-1 cell
+obo:CLO_0001662 rdfs:subClassOf bae:BrendaCell . # ADF cell
+obo:CLO_0001745 rdfs:subClassOf bae:BrendaCell . # ARH-77 cell
+obo:CLO_0001756 rdfs:subClassOf bae:BrendaCell . # AsPC-1 cell
+obo:CLO_0001766 rdfs:subClassOf bae:BrendaCell . # AtT-20 cell
+obo:CLO_0001793 rdfs:subClassOf bae:BrendaCell . # B16-F1 cell
+obo:CLO_0001794 rdfs:subClassOf bae:BrendaCell . # B16-F10 cell
+obo:CLO_0001925 rdfs:subClassOf bae:BrendaCell . # BEAS-2B cell
+obo:CLO_0001933 rdfs:subClassOf bae:BrendaCell . # Beta-TC-6 cell
+obo:CLO_0001934 rdfs:subClassOf bae:BrendaCell . # BEWO cell
+obo:CLO_0001965 rdfs:subClassOf bae:BrendaCell . # BHK-21 cell
+obo:CLO_0002000 rdfs:subClassOf bae:BrendaCell . # Bm N cell
+obo:CLO_0002022 rdfs:subClassOf bae:BrendaCell . # BPH-1 cell
+obo:CLO_0002052 rdfs:subClassOf bae:BrendaCell . # BV-173 cell
+obo:CLO_0002057 rdfs:subClassOf bae:BrendaCell . # BW5147 cell
+obo:CLO_0002065 rdfs:subClassOf bae:BrendaCell . # BxPC-3 cell
+obo:CLO_0002086 rdfs:subClassOf bae:BrendaCell . # C127I cell
+obo:CLO_0002168 rdfs:subClassOf bae:BrendaCell . # CA-46 cell
+obo:CLO_0002176 rdfs:subClassOf bae:BrendaCell . # Caki-1 cell
+obo:CLO_0002193 rdfs:subClassOf bae:BrendaCell . # Calu-6 cell
+obo:CLO_0002201 rdfs:subClassOf bae:BrendaCell . # CaSki cell
+obo:CLO_0002309 rdfs:subClassOf bae:BrendaCell . # CCD-18Co cell
+obo:CLO_0002360 rdfs:subClassOf bae:BrendaCell . # CESS cell
+obo:CLO_0002526 rdfs:subClassOf bae:BrendaCell . # CMK cell
+obo:CLO_0002532 rdfs:subClassOf bae:BrendaCell . # CMT-93 cell
+obo:CLO_0002571 rdfs:subClassOf bae:BrendaCell . # Colo-320 cell
+obo:CLO_0002574 rdfs:subClassOf bae:BrendaCell . # COLO-699 cell
+obo:CLO_0002596 rdfs:subClassOf bae:BrendaCell . # COS-1 cell
+obo:CLO_0002640 rdfs:subClassOf bae:BrendaCell . # CV-1 cell
+obo:CLO_0002650 rdfs:subClassOf bae:BrendaCell . # CX-1 cell
+obo:CLO_0002699 rdfs:subClassOf bae:BrendaCell . # Daoy cell
+obo:CLO_0002708 rdfs:subClassOf bae:BrendaCell . # DAUDI cell
+obo:CLO_0002767 rdfs:subClassOf bae:BrendaCell . # DG-75 cell
+obo:CLO_0002807 rdfs:subClassOf bae:BrendaCell . # DON cell
+obo:CLO_0002882 rdfs:subClassOf bae:BrendaCell . # ECV-304 cell
+obo:CLO_0002913 rdfs:subClassOf bae:BrendaCell . # EL4 cell
+obo:CLO_0002988 rdfs:subClassOf bae:BrendaCell . # F-9 cell
+obo:CLO_0003396 rdfs:subClassOf bae:BrendaCell . # FRTL-5 cell
+obo:CLO_0003402 rdfs:subClassOf bae:BrendaCell . # FTC-133 cell
+obo:CLO_0003413 rdfs:subClassOf bae:BrendaCell . # G cell
+obo:CLO_0003450 rdfs:subClassOf bae:BrendaCell . # GAMG cell
+obo:CLO_0003487 rdfs:subClassOf bae:BrendaCell . # GH3 cell
+obo:CLO_0003490 rdfs:subClassOf bae:BrendaCell . # GH4-C1 cell
+obo:CLO_0003612 rdfs:subClassOf bae:BrendaCell . # H9 cell
+obo:CLO_0003663 rdfs:subClassOf bae:BrendaCell . # HCN-1A cell
+obo:CLO_0003664 rdfs:subClassOf bae:BrendaCell . # HCN-2 cell
+obo:CLO_0003667 rdfs:subClassOf bae:BrendaCell . # HCT-8 cell
+obo:CLO_0003679 rdfs:subClassOf bae:BrendaCell . # HEL cell
+obo:CLO_0003682 rdfs:subClassOf bae:BrendaCell . # HEL-92.1.7 cell
+obo:CLO_0003684 rdfs:subClassOf bae:BrendaCell . # HeLa cell
+obo:CLO_0003699 rdfs:subClassOf bae:BrendaCell . # HELA-S3 cell
+obo:CLO_0003706 rdfs:subClassOf bae:BrendaCell . # HEp-2 cell
+obo:CLO_0003734 rdfs:subClassOf bae:BrendaCell . # HFL-1 cell
+obo:CLO_0003740 rdfs:subClassOf bae:BrendaCell . # HGF cell
+obo:CLO_0003758 rdfs:subClassOf bae:BrendaCell . # HIT-T15 cell
+obo:CLO_0003771 rdfs:subClassOf bae:BrendaCell . # HK-2 cell
+obo:CLO_0003782 rdfs:subClassOf bae:BrendaCell . # HL-60/MX-2 cell
+obo:CLO_0003786 rdfs:subClassOf bae:BrendaCell . # HMV-II cell
+obo:CLO_0003814 rdfs:subClassOf bae:BrendaCell . # HPAC cell
+obo:CLO_0003817 rdfs:subClassOf bae:BrendaCell . # HPB-ALL cell
+obo:CLO_0003836 rdfs:subClassOf bae:BrendaCell . # HRT-18 cell
+obo:CLO_0004041 rdfs:subClassOf bae:BrendaCell . # Hs 68 cell
+obo:CLO_0004276 rdfs:subClassOf bae:BrendaCell . # HT-1080 cell
+obo:CLO_0004278 rdfs:subClassOf bae:BrendaCell . # HT-1197 cell
+obo:CLO_0004279 rdfs:subClassOf bae:BrendaCell . # HT-1376 cell
+obo:CLO_0004288 rdfs:subClassOf bae:BrendaCell . # HTC cell
+obo:CLO_0004304 rdfs:subClassOf bae:BrendaCell . # HuT 78 cell
+obo:CLO_0004341 rdfs:subClassOf bae:BrendaCell . # IEC-18 cell
+obo:CLO_0004342 rdfs:subClassOf bae:BrendaCell . # IEC-6 cell
+obo:CLO_0006672 rdfs:subClassOf bae:BrendaCell . # IGROV-1 cell
+obo:CLO_0006951 rdfs:subClassOf bae:BrendaCell . # IMR-90 cell
+obo:CLO_0006954 rdfs:subClassOf bae:BrendaCell . # Intestine 407 cell
+obo:CLO_0007002 rdfs:subClassOf bae:BrendaCell . # J558L cell
+obo:CLO_0007017 rdfs:subClassOf bae:BrendaCell . # JEG-3 cell
+obo:CLO_0007059 rdfs:subClassOf bae:BrendaCell . # K-562 cell
+obo:CLO_0007065 rdfs:subClassOf bae:BrendaCell . # KARPAS-299 cell
+obo:CLO_0007066 rdfs:subClassOf bae:BrendaCell . # KARPAS-422 cell
+obo:CLO_0007073 rdfs:subClassOf bae:BrendaCell . # KATO-III cell
+obo:CLO_0007074 rdfs:subClassOf bae:BrendaCell . # KB cell
+obo:CLO_0007079 rdfs:subClassOf bae:BrendaCell . # Kc cell
+obo:CLO_0007095 rdfs:subClassOf bae:BrendaCell . # KG-1A cell
+obo:CLO_0007104 rdfs:subClassOf bae:BrendaCell . # KLE cell
+obo:CLO_0007132 rdfs:subClassOf bae:BrendaCell . # KYSE-30 cell
+obo:CLO_0007189 rdfs:subClassOf bae:BrendaCell . # L-428 cell
+obo:CLO_0007335 rdfs:subClassOf bae:BrendaCell . # LLC-WRC 256 cell
+obo:CLO_0007378 rdfs:subClassOf bae:BrendaCell . # LoVo cell
+obo:CLO_0007393 rdfs:subClassOf bae:BrendaCell . # LS 174T cell
+obo:CLO_0007394 rdfs:subClassOf bae:BrendaCell . # LS 180 cell
+obo:CLO_0007484 rdfs:subClassOf bae:BrendaCell . # M5076 cell
+obo:CLO_0007492 rdfs:subClassOf bae:BrendaCell . # MA 104 cell
+obo:CLO_0007529 rdfs:subClassOf bae:BrendaCell . # MALME-3M cell
+obo:CLO_0007600 rdfs:subClassOf bae:BrendaCell . # MCF-10F cell
+obo:CLO_0007606 rdfs:subClassOf bae:BrendaCell . # MCF-7 cell
+obo:CLO_0007636 rdfs:subClassOf bae:BrendaCell . # MDA-MB-361 cell
+obo:CLO_0007639 rdfs:subClassOf bae:BrendaCell . # MDA-MB-436 cell
+obo:CLO_0007641 rdfs:subClassOf bae:BrendaCell . # MDA-MB-468 cell
+obo:CLO_0007642 rdfs:subClassOf bae:BrendaCell . # MDBK cell
+obo:CLO_0007646 rdfs:subClassOf bae:BrendaCell . # MDCK cell
+obo:CLO_0007668 rdfs:subClassOf bae:BrendaCell . # MEG-01 cell
+obo:CLO_0007687 rdfs:subClassOf bae:BrendaCell . # MEWO cell
+obo:CLO_0007699 rdfs:subClassOf bae:BrendaCell . # MG-63 cell
+obo:CLO_0007709 rdfs:subClassOf bae:BrendaCell . # MH1C1 cell
+obo:CLO_0007735 rdfs:subClassOf bae:BrendaCell . # ML-1 cell
+obo:CLO_0007825 rdfs:subClassOf bae:BrendaCell . # MOLT-4 cell
+obo:CLO_0007827 rdfs:subClassOf bae:BrendaCell . # MONO-MAC-1 cell
+obo:CLO_0007828 rdfs:subClassOf bae:BrendaCell . # MONO-MAC-6 cell
+obo:CLO_0007854 rdfs:subClassOf bae:BrendaCell . # MPC-11 cell
+obo:CLO_0007880 rdfs:subClassOf bae:BrendaCell . # MSTO-211H cell
+obo:CLO_0007891 rdfs:subClassOf bae:BrendaCell . # MT-4 cell
+obo:CLO_0007950 rdfs:subClassOf bae:BrendaCell . # NBT-II cell
+obo:CLO_0007952 rdfs:subClassOf bae:BrendaCell . # NC-37 cell
+obo:CLO_0007986 rdfs:subClassOf bae:BrendaCell . # NCI-H1299 cell
+obo:CLO_0008035 rdfs:subClassOf bae:BrendaCell . # NCI-H1975 cell
+obo:CLO_0008085 rdfs:subClassOf bae:BrendaCell . # NCI-H358 cell
+obo:CLO_0008087 rdfs:subClassOf bae:BrendaCell . # NCI-H441 cell
+obo:CLO_0008121 rdfs:subClassOf bae:BrendaCell . # NCI-H838 cell
+obo:CLO_0008127 rdfs:subClassOf bae:BrendaCell . # NCI-H929 cell
+obo:CLO_0008129 rdfs:subClassOf bae:BrendaCell . # NCI-N87 cell
+obo:CLO_0008132 rdfs:subClassOf bae:BrendaCell . # NCTC 2544 cell
+obo:CLO_0008154 rdfs:subClassOf bae:BrendaCell . # Neuro-2a cell
+obo:CLO_0008186 rdfs:subClassOf bae:BrendaCell . # NMuMG cell
+obo:CLO_0008205 rdfs:subClassOf bae:BrendaCell . # NS20Y cell
+obo:CLO_0008235 rdfs:subClassOf bae:BrendaCell . # OCI-AML2 cell
+obo:CLO_0008236 rdfs:subClassOf bae:BrendaCell . # OCI-AML5 cell
+obo:CLO_0008240 rdfs:subClassOf bae:BrendaCell . # OE-33 cell
+obo:CLO_0008327 rdfs:subClassOf bae:BrendaCell . # P388D1 cell
+obo:CLO_0008340 rdfs:subClassOf bae:BrendaCell . # P-815 cell
+obo:CLO_0008395 rdfs:subClassOf bae:BrendaCell . # PC-3 cell
+obo:CLO_0008416 rdfs:subClassOf bae:BrendaCell . # PEER cell
+obo:CLO_0008426 rdfs:subClassOf bae:BrendaCell . # PG cell
+obo:CLO_0008447 rdfs:subClassOf bae:BrendaCell . # PK-15 cell
+obo:CLO_0008460 rdfs:subClassOf bae:BrendaCell . # PLHC-1 cell
+obo:CLO_0008475 rdfs:subClassOf bae:BrendaCell . # PNT-1A cell
+obo:CLO_0008476 rdfs:subClassOf bae:BrendaCell . # PNT-2 cell
+obo:CLO_0008486 rdfs:subClassOf bae:BrendaCell . # Pro-5 cell
+obo:CLO_0008697 rdfs:subClassOf bae:BrendaCell . # R1 cell
+obo:CLO_0008734 rdfs:subClassOf bae:BrendaCell . # RAJI cell
+obo:CLO_0008762 rdfs:subClassOf bae:BrendaCell . # RBL-1 cell
+obo:CLO_0008770 rdfs:subClassOf bae:BrendaCell . # RD cell
+obo:CLO_0008774 rdfs:subClassOf bae:BrendaCell . # RD-ES cell
+obo:CLO_0008781 rdfs:subClassOf bae:BrendaCell . # REH cell
+obo:CLO_0008799 rdfs:subClassOf bae:BrendaCell . # RFL-6 cell
+obo:CLO_0008825 rdfs:subClassOf bae:BrendaCell . # RKO cell
+obo:CLO_0008828 rdfs:subClassOf bae:BrendaCell . # RL cell
+obo:CLO_0008873 rdfs:subClassOf bae:BrendaCell . # RPMI-8226 cell
+obo:CLO_0008876 rdfs:subClassOf bae:BrendaCell . # RPMI-2650 cell
+obo:CLO_0008987 rdfs:subClassOf bae:BrendaCell . # SF-21 cell
+obo:CLO_0008988 rdfs:subClassOf bae:BrendaCell . # SF-9 cell
+obo:CLO_0009019 rdfs:subClassOf bae:BrendaCell . # SIRC cell
+obo:CLO_0009039 rdfs:subClassOf bae:BrendaCell . # SK-LU-1 cell
+obo:CLO_0009043 rdfs:subClassOf bae:BrendaCell . # SK-MEL-28 cell
+obo:CLO_0009045 rdfs:subClassOf bae:BrendaCell . # SK-MEL-30 cell
+obo:CLO_0009051 rdfs:subClassOf bae:BrendaCell . # SK-N-AS cell
+obo:CLO_0009052 rdfs:subClassOf bae:BrendaCell . # SK-N-BE(2) cell
+obo:CLO_0009058 rdfs:subClassOf bae:BrendaCell . # SK-N-MC cell
+obo:CLO_0009097 rdfs:subClassOf bae:BrendaCell . # SNU-387 cell
+obo:CLO_0009126 rdfs:subClassOf bae:BrendaCell . # SR cell
+obo:CLO_0009183 rdfs:subClassOf bae:BrendaCell . # SW-1116 cell
+obo:CLO_0009196 rdfs:subClassOf bae:BrendaCell . # SW-620 cell
+obo:CLO_0009216 rdfs:subClassOf bae:BrendaCell . # SW-48 cell
+obo:CLO_0009217 rdfs:subClassOf bae:BrendaCell . # SW-480 cell
+obo:CLO_0009222 rdfs:subClassOf bae:BrendaCell . # SW626 cell
+obo:CLO_0009225 rdfs:subClassOf bae:BrendaCell . # SW-948 cell
+obo:CLO_0009237 rdfs:subClassOf bae:BrendaCell . # T/G HA-VSMC cell
+obo:CLO_0009245 rdfs:subClassOf bae:BrendaCell . # T24 cell
+obo:CLO_0009254 rdfs:subClassOf bae:BrendaCell . # T84 cell
+obo:CLO_0009320 rdfs:subClassOf bae:BrendaCell . # TE-8 cell
+obo:CLO_0009324 rdfs:subClassOf bae:BrendaCell . # Tera-2 cell
+obo:CLO_0009326 rdfs:subClassOf bae:BrendaCell . # TF-1 cell
+obo:CLO_0009357 rdfs:subClassOf bae:BrendaCell . # TK6 cell
+obo:CLO_0009368 rdfs:subClassOf bae:BrendaCell . # TM-4 cell
+obo:CLO_0009452 rdfs:subClassOf bae:BrendaCell . # U-138MG cell
+obo:CLO_0009456 rdfs:subClassOf bae:BrendaCell . # U-251 MG cell
+obo:CLO_0009457 rdfs:subClassOf bae:BrendaCell . # U-266 cell
+obo:CLO_0009459 rdfs:subClassOf bae:BrendaCell . # U-343 MGa cell
+obo:CLO_0009461 rdfs:subClassOf bae:BrendaCell . # U-373 MG cell
+obo:CLO_0009465 rdfs:subClassOf bae:BrendaCell . # U-937 cell
+obo:CLO_0009500 rdfs:subClassOf bae:BrendaCell . # V-79 cell
+obo:CLO_0009504 rdfs:subClassOf bae:BrendaCell . # V79-4 cell
+obo:CLO_0009575 rdfs:subClassOf bae:BrendaCell . # WEHI-231 cell
+obo:CLO_0009594 rdfs:subClassOf bae:BrendaCell . # WI-38 cell
+obo:CLO_0009604 rdfs:subClassOf bae:BrendaCell . # WIL2-NS cell
+obo:CLO_0009609 rdfs:subClassOf bae:BrendaCell . # WISH cell
+obo:CLO_0009635 rdfs:subClassOf bae:BrendaCell . # WSS-1 cell
+obo:CLO_0009709 rdfs:subClassOf bae:BrendaCell . # Y79 cell
+obo:CLO_0009727 rdfs:subClassOf bae:BrendaCell . # ZR-75-1 cell
+obo:CLO_0009728 rdfs:subClassOf bae:BrendaCell . # ZR-75-30 cell
+obo:CLO_0009833 rdfs:subClassOf bae:BrendaCell . # BCWM.1 cell
+obo:CLO_0009848 rdfs:subClassOf bae:BrendaCell . # MOLM-13 cell
+obo:CLO_0009858 rdfs:subClassOf bae:BrendaCell . # RPMI-8866 cell
+obo:CLO_0009902 rdfs:subClassOf bae:BrendaCell . # SF-268 cell
+obo:CLO_0037097 rdfs:subClassOf bae:BrendaCell . # OVISE cell
+obo:CLO_0037116 rdfs:subClassOf bae:BrendaCell . # LNCaP cell
+obo:CLO_0037117 rdfs:subClassOf bae:BrendaCell . # VCaP cell
+obo:CLO_0037142 rdfs:subClassOf bae:BrendaCell . # MKN-28 cell
+obo:CLO_0037180 rdfs:subClassOf bae:BrendaCell . # MCF12A cell
+
+# reparenting tissues
+
+obo:BTO_0000000 rdfs:subClassOf bae:BrendaTissues . # tissues, cell types and enzyme sources
+obo:BTO_0000020 rdfs:subClassOf bae:BrendaTissues . # abdomen
+obo:BTO_0000022 rdfs:subClassOf bae:BrendaTissues . # abdominal ganglion
+obo:BTO_0000023 rdfs:subClassOf bae:BrendaTissues . # pectoral muscle
+obo:BTO_0000025 rdfs:subClassOf bae:BrendaTissues . # amniotic cavity
+obo:BTO_0000027 rdfs:subClassOf bae:BrendaTissues . # achene
+obo:BTO_0000029 rdfs:subClassOf bae:BrendaTissues . # adductor longus
+obo:BTO_0000030 rdfs:subClassOf bae:BrendaTissues . # adductor
+obo:BTO_0000031 rdfs:subClassOf bae:BrendaTissues . # fruit peduncle
+obo:BTO_0000034 rdfs:subClassOf bae:BrendaTissues . # apical meristem
+obo:BTO_0000039 rdfs:subClassOf bae:BrendaTissues . # root cap
+obo:BTO_0000040 rdfs:subClassOf bae:BrendaTissues . # adenohypophysis
+obo:BTO_0000041 rdfs:subClassOf bae:BrendaTissues . # medulla oblongata
+obo:BTO_0000043 rdfs:subClassOf bae:BrendaTissues . # cerebellar cortex
+obo:BTO_0000044 rdfs:subClassOf bae:BrendaTissues . # tear gland
+obo:BTO_0000045 rdfs:subClassOf bae:BrendaTissues . # adrenal cortex
+obo:BTO_0000047 rdfs:subClassOf bae:BrendaTissues . # adrenal gland
+obo:BTO_0000048 rdfs:subClassOf bae:BrendaTissues . # zona glomerulosa
+obo:BTO_0000049 rdfs:subClassOf bae:BrendaTissues . # adrenal medulla
+obo:BTO_0000050 rdfs:subClassOf bae:BrendaTissues . # zona fasciculata
+obo:BTO_0000051 rdfs:subClassOf bae:BrendaTissues . # tendon sheath
+obo:BTO_0000052 rdfs:subClassOf bae:BrendaTissues . # stoma
+obo:BTO_0000053 rdfs:subClassOf bae:BrendaTissues . # albedo
+obo:BTO_0000054 rdfs:subClassOf bae:BrendaTissues . # albumen gland
+obo:BTO_0000055 rdfs:subClassOf bae:BrendaTissues . # pars recta
+obo:BTO_0000057 rdfs:subClassOf bae:BrendaTissues . # aleurone layer
+obo:BTO_0000058 rdfs:subClassOf bae:BrendaTissues . # alimentary canal
+obo:BTO_0000059 rdfs:subClassOf bae:BrendaTissues . # renal epithelium
+obo:BTO_0000060 rdfs:subClassOf bae:BrendaTissues . # alveolus
+obo:BTO_0000061 rdfs:subClassOf bae:BrendaTissues . # alveolar sac
+obo:BTO_0000062 rdfs:subClassOf bae:BrendaTissues . # amastigote
+obo:BTO_0000065 rdfs:subClassOf bae:BrendaTissues . # amnion
+obo:BTO_0000066 rdfs:subClassOf bae:BrendaTissues . # amniocyte
+obo:BTO_0000068 rdfs:subClassOf bae:BrendaTissues . # amniotic fluid
+obo:BTO_0000071 rdfs:subClassOf bae:BrendaTissues . # amoebocyte
+obo:BTO_0000072 rdfs:subClassOf bae:BrendaTissues . # carpel
+obo:BTO_0000074 rdfs:subClassOf bae:BrendaTissues . # antenna
+obo:BTO_0000075 rdfs:subClassOf bae:BrendaTissues . # antennal gland
+obo:BTO_0000076 rdfs:subClassOf bae:BrendaTissues . # anterior midgut
+obo:BTO_0000077 rdfs:subClassOf bae:BrendaTissues . # posterior midgut
+obo:BTO_0000078 rdfs:subClassOf bae:BrendaTissues . # microglia
+obo:BTO_0000079 rdfs:subClassOf bae:BrendaTissues . # anther
+obo:BTO_0000081 rdfs:subClassOf bae:BrendaTissues . # reproductive system
+obo:BTO_0000083 rdfs:subClassOf bae:BrendaTissues . # female reproductive system
+obo:BTO_0000084 rdfs:subClassOf bae:BrendaTissues . # vermiform appendix
+obo:BTO_0000087 rdfs:subClassOf bae:BrendaTissues . # arterial smooth muscle
+obo:BTO_0000088 rdfs:subClassOf bae:BrendaTissues . # cardiovascular system
+obo:BTO_0000089 rdfs:subClassOf bae:BrendaTissues . # blood
+obo:BTO_0000090 rdfs:subClassOf bae:BrendaTissues . # ascidian
+obo:BTO_0000091 rdfs:subClassOf bae:BrendaTissues . # ascites
+obo:BTO_0000092 rdfs:subClassOf bae:BrendaTissues . # trypanosomoid form
+obo:BTO_0000099 rdfs:subClassOf bae:BrendaTissues . # astrocyte
+obo:BTO_0000102 rdfs:subClassOf bae:BrendaTissues . # blood clot
+obo:BTO_0000105 rdfs:subClassOf bae:BrendaTissues . # upper epidermis
+obo:BTO_0000108 rdfs:subClassOf bae:BrendaTissues . # olfactory epithelium
+obo:BTO_0000109 rdfs:subClassOf bae:BrendaTissues . # bacteroid
+obo:BTO_0000119 rdfs:subClassOf bae:BrendaTissues . # berry
+obo:BTO_0000121 rdfs:subClassOf bae:BrendaTissues . # bile
+obo:BTO_0000122 rdfs:subClassOf bae:BrendaTissues . # bile duct
+obo:BTO_0000123 rdfs:subClassOf bae:BrendaTissues . # bladder
+obo:BTO_0000124 rdfs:subClassOf bae:BrendaTissues . # microspore
+obo:BTO_0000126 rdfs:subClassOf bae:BrendaTissues . # blastoderm
+obo:BTO_0000128 rdfs:subClassOf bae:BrendaTissues . # blastula
+obo:BTO_0000129 rdfs:subClassOf bae:BrendaTissues . # basophil
+obo:BTO_0000130 rdfs:subClassOf bae:BrendaTissues . # neutrophil
+obo:BTO_0000131 rdfs:subClassOf bae:BrendaTissues . # blood plasma
+obo:BTO_0000132 rdfs:subClassOf bae:BrendaTissues . # blood platelet
+obo:BTO_0000134 rdfs:subClassOf bae:BrendaTissues . # bloodstream form
+obo:BTO_0000135 rdfs:subClassOf bae:BrendaTissues . # aorta
+obo:BTO_0000136 rdfs:subClassOf bae:BrendaTissues . # bronchoalveolar system
+obo:BTO_0000138 rdfs:subClassOf bae:BrendaTissues . # midbrain
+obo:BTO_0000139 rdfs:subClassOf bae:BrendaTissues . # body wall
+obo:BTO_0000140 rdfs:subClassOf bae:BrendaTissues . # bone
+obo:BTO_0000141 rdfs:subClassOf bae:BrendaTissues . # bone marrow
+obo:BTO_0000142 rdfs:subClassOf bae:BrendaTissues . # brain
+obo:BTO_0000143 rdfs:subClassOf bae:BrendaTissues . # substantia nigra
+obo:BTO_0000144 rdfs:subClassOf bae:BrendaTissues . # meninx
+obo:BTO_0000145 rdfs:subClassOf bae:BrendaTissues . # brain myelin
+obo:BTO_0000146 rdfs:subClassOf bae:BrendaTissues . # brain stem
+obo:BTO_0000147 rdfs:subClassOf bae:BrendaTissues . # microgametophyte
+obo:BTO_0000148 rdfs:subClassOf bae:BrendaTissues . # branch
+obo:BTO_0000149 rdfs:subClassOf bae:BrendaTissues . # breast
+obo:BTO_0000151 rdfs:subClassOf bae:BrendaTissues . # extensor
+obo:BTO_0000155 rdfs:subClassOf bae:BrendaTissues . # bronchoalveolar lavage
+obo:BTO_0000156 rdfs:subClassOf bae:BrendaTissues . # brown adipose tissue
+obo:BTO_0000159 rdfs:subClassOf bae:BrendaTissues . # bulb
+obo:BTO_0000160 rdfs:subClassOf bae:BrendaTissues . # bundle sheath
+obo:BTO_0000163 rdfs:subClassOf bae:BrendaTissues . # corolla
+obo:BTO_0000166 rdfs:subClassOf bae:BrendaTissues . # cecum
+obo:BTO_0000168 rdfs:subClassOf bae:BrendaTissues . # carotid artery
+obo:BTO_0000169 rdfs:subClassOf bae:BrendaTissues . # calyx
+obo:BTO_0000170 rdfs:subClassOf bae:BrendaTissues . # cambium
+obo:BTO_0000171 rdfs:subClassOf bae:BrendaTissues . # L-cell
+obo:BTO_0000175 rdfs:subClassOf bae:BrendaTissues . # epithalamus
+obo:BTO_0000187 rdfs:subClassOf bae:BrendaTissues . # myeloblast
+obo:BTO_0000198 rdfs:subClassOf bae:BrendaTissues . # cardia
+obo:BTO_0000199 rdfs:subClassOf bae:BrendaTissues . # cardiac muscle
+obo:BTO_0000202 rdfs:subClassOf bae:BrendaTissues . # sense organ
+obo:BTO_0000203 rdfs:subClassOf bae:BrendaTissues . # respiratory system
+obo:BTO_0000204 rdfs:subClassOf bae:BrendaTissues . # carotid body
+obo:BTO_0000205 rdfs:subClassOf bae:BrendaTissues . # nerve plexus
+obo:BTO_0000206 rdfs:subClassOf bae:BrendaTissues . # cartilage
+obo:BTO_0000207 rdfs:subClassOf bae:BrendaTissues . # tibial cartilage
+obo:BTO_0000208 rdfs:subClassOf bae:BrendaTissues . # caryopsis
+obo:BTO_0000209 rdfs:subClassOf bae:BrendaTissues . # corpus epididymis
+obo:BTO_0000210 rdfs:subClassOf bae:BrendaTissues . # cauda epididymis
+obo:BTO_0000211 rdfs:subClassOf bae:BrendaTissues . # caudate nucleus
+obo:BTO_0000212 rdfs:subClassOf bae:BrendaTissues . # caudate putamen
+obo:BTO_0000214 rdfs:subClassOf bae:BrendaTissues . # cell culture
+obo:BTO_0000216 rdfs:subClassOf bae:BrendaTissues . # culture condition
+obo:BTO_0000221 rdfs:subClassOf bae:BrendaTissues . # cell suspension culture
+obo:BTO_0000222 rdfs:subClassOf bae:BrendaTissues . # myoblast
+obo:BTO_0000227 rdfs:subClassOf bae:BrendaTissues . # central nervous system
+obo:BTO_0000229 rdfs:subClassOf bae:BrendaTissues . # centrum semiovale
+obo:BTO_0000230 rdfs:subClassOf bae:BrendaTissues . # subarachnoid space
+obo:BTO_0000231 rdfs:subClassOf bae:BrendaTissues . # cerebral hemisphere
+obo:BTO_0000232 rdfs:subClassOf bae:BrendaTissues . # cerebellum
+obo:BTO_0000233 rdfs:subClassOf bae:BrendaTissues . # cerebral cortex
+obo:BTO_0000234 rdfs:subClassOf bae:BrendaTissues . # vein
+obo:BTO_0000236 rdfs:subClassOf bae:BrendaTissues . # cerebral white matter
+obo:BTO_0000237 rdfs:subClassOf bae:BrendaTissues . # cerebrospinal fluid
+obo:BTO_0000239 rdfs:subClassOf bae:BrendaTissues . # telencephalon
+obo:BTO_0000240 rdfs:subClassOf bae:BrendaTissues . # inferior cervical ganglion
+obo:BTO_0000241 rdfs:subClassOf bae:BrendaTissues . # cervical epithelium
+obo:BTO_0000242 rdfs:subClassOf bae:BrendaTissues . # cervical mucus
+obo:BTO_0000243 rdfs:subClassOf bae:BrendaTissues . # vagina
+obo:BTO_0000247 rdfs:subClassOf bae:BrendaTissues . # shoot tip
+obo:BTO_0000249 rdfs:subClassOf bae:BrendaTissues . # chondrocyte
+obo:BTO_0000251 rdfs:subClassOf bae:BrendaTissues . # chorioallantois
+obo:BTO_0000258 rdfs:subClassOf bae:BrendaTissues . # choroid plexus
+obo:BTO_0000260 rdfs:subClassOf bae:BrendaTissues . # ciliary body
+obo:BTO_0000262 rdfs:subClassOf bae:BrendaTissues . # clove
+obo:BTO_0000265 rdfs:subClassOf bae:BrendaTissues . # coagulating gland
+obo:BTO_0000266 rdfs:subClassOf bae:BrendaTissues . # cob
+obo:BTO_0000267 rdfs:subClassOf bae:BrendaTissues . # cochlea
+obo:BTO_0000268 rdfs:subClassOf bae:BrendaTissues . # coleoptile
+obo:BTO_0000269 rdfs:subClassOf bae:BrendaTissues . # colon
+obo:BTO_0000271 rdfs:subClassOf bae:BrendaTissues . # colonic mucosa
+obo:BTO_0000272 rdfs:subClassOf bae:BrendaTissues . # colon transversum
+obo:BTO_0000273 rdfs:subClassOf bae:BrendaTissues . # ink gland
+obo:BTO_0000274 rdfs:subClassOf bae:BrendaTissues . # apical bud
+obo:BTO_0000275 rdfs:subClassOf bae:BrendaTissues . # colonocyte
+obo:BTO_0000278 rdfs:subClassOf bae:BrendaTissues . # commercial preparation
+obo:BTO_0000280 rdfs:subClassOf bae:BrendaTissues . # cone
+obo:BTO_0000282 rdfs:subClassOf bae:BrendaTissues . # head
+obo:BTO_0000284 rdfs:subClassOf bae:BrendaTissues . # organism form
+obo:BTO_0000285 rdfs:subClassOf bae:BrendaTissues . # corm
+obo:BTO_0000286 rdfs:subClassOf bae:BrendaTissues . # cornea
+obo:BTO_0000287 rdfs:subClassOf bae:BrendaTissues . # corneal epithelium
+obo:BTO_0000289 rdfs:subClassOf bae:BrendaTissues . # cytotoxic T-lymphocyte
+obo:BTO_0000290 rdfs:subClassOf bae:BrendaTissues . # coronary artery
+obo:BTO_0000291 rdfs:subClassOf bae:BrendaTissues . # corpus allatum
+obo:BTO_0000292 rdfs:subClassOf bae:BrendaTissues . # corpus luteum
+obo:BTO_0000293 rdfs:subClassOf bae:BrendaTissues . # occipital lobe
+obo:BTO_0000294 rdfs:subClassOf bae:BrendaTissues . # dermis
+obo:BTO_0000299 rdfs:subClassOf bae:BrendaTissues . # cotton fibre
+obo:BTO_0000300 rdfs:subClassOf bae:BrendaTissues . # cotyledon
+obo:BTO_0000303 rdfs:subClassOf bae:BrendaTissues . # crown gall
+obo:BTO_0000305 rdfs:subClassOf bae:BrendaTissues . # crypt
+obo:BTO_0000307 rdfs:subClassOf bae:BrendaTissues . # crystalline style
+obo:BTO_0000310 rdfs:subClassOf bae:BrendaTissues . # protophloem
+obo:BTO_0000311 rdfs:subClassOf bae:BrendaTissues . # culture filtrate
+obo:BTO_0000312 rdfs:subClassOf bae:BrendaTissues . # motoneuron
+obo:BTO_0000313 rdfs:subClassOf bae:BrendaTissues . # hypodermis
+obo:BTO_0000314 rdfs:subClassOf bae:BrendaTissues . # neuroepithelium
+obo:BTO_0000315 rdfs:subClassOf bae:BrendaTissues . # ectoderm
+obo:BTO_0000316 rdfs:subClassOf bae:BrendaTissues . # culture medium
+obo:BTO_0000317 rdfs:subClassOf bae:BrendaTissues . # caulonema
+obo:BTO_0000320 rdfs:subClassOf bae:BrendaTissues . # cyst
+obo:BTO_0000321 rdfs:subClassOf bae:BrendaTissues . # plant cuticle
+obo:BTO_0000322 rdfs:subClassOf bae:BrendaTissues . # cytotrophoblast
+obo:BTO_0000333 rdfs:subClassOf bae:BrendaTissues . # renal corpuscle
+obo:BTO_0000334 rdfs:subClassOf bae:BrendaTissues . # decidua parietalis
+obo:BTO_0000336 rdfs:subClassOf bae:BrendaTissues . # caput epididymis
+obo:BTO_0000337 rdfs:subClassOf bae:BrendaTissues . # dental follicle
+obo:BTO_0000338 rdfs:subClassOf bae:BrendaTissues . # dental plaque
+obo:BTO_0000339 rdfs:subClassOf bae:BrendaTissues . # dental pulp
+obo:BTO_0000341 rdfs:subClassOf bae:BrendaTissues . # diaphragm
+obo:BTO_0000342 rdfs:subClassOf bae:BrendaTissues . # diencephalon
+obo:BTO_0000343 rdfs:subClassOf bae:BrendaTissues . # renal tubule
+obo:BTO_0000344 rdfs:subClassOf bae:BrendaTissues . # stratum corneum
+obo:BTO_0000345 rdfs:subClassOf bae:BrendaTissues . # digestive gland
+obo:BTO_0000347 rdfs:subClassOf bae:BrendaTissues . # reticulum
+obo:BTO_0000348 rdfs:subClassOf bae:BrendaTissues . # omasum
+obo:BTO_0000349 rdfs:subClassOf bae:BrendaTissues . # gut cavity
+obo:BTO_0000351 rdfs:subClassOf bae:BrendaTissues . # disc
+obo:BTO_0000357 rdfs:subClassOf bae:BrendaTissues . # nectary
+obo:BTO_0000359 rdfs:subClassOf bae:BrendaTissues . # middle cervical ganglion
+obo:BTO_0000361 rdfs:subClassOf bae:BrendaTissues . # stratum granulosum
+obo:BTO_0000364 rdfs:subClassOf bae:BrendaTissues . # stratum lucidum
+obo:BTO_0000365 rdfs:subClassOf bae:BrendaTissues . # duodenum
+obo:BTO_0000366 rdfs:subClassOf bae:BrendaTissues . # duodenal juice
+obo:BTO_0000367 rdfs:subClassOf bae:BrendaTissues . # duodenal mucosa
+obo:BTO_0000368 rdfs:subClassOf bae:BrendaTissues . # ear
+obo:BTO_0000369 rdfs:subClassOf bae:BrendaTissues . # egg
+obo:BTO_0000370 rdfs:subClassOf bae:BrendaTissues . # egg white
+obo:BTO_0000371 rdfs:subClassOf bae:BrendaTissues . # egg yolk
+obo:BTO_0000376 rdfs:subClassOf bae:BrendaTissues . # electric organ
+obo:BTO_0000377 rdfs:subClassOf bae:BrendaTissues . # elementary body
+obo:BTO_0000378 rdfs:subClassOf bae:BrendaTissues . # elytron
+obo:BTO_0000379 rdfs:subClassOf bae:BrendaTissues . # embryo
+obo:BTO_0000380 rdfs:subClassOf bae:BrendaTissues . # embryonic axis
+obo:BTO_0000381 rdfs:subClassOf bae:BrendaTissues . # embryonic blood
+obo:BTO_0000387 rdfs:subClassOf bae:BrendaTissues . # endocardium
+obo:BTO_0000388 rdfs:subClassOf bae:BrendaTissues . # endodermis
+obo:BTO_0000389 rdfs:subClassOf bae:BrendaTissues . # mature ovarian follicle
+obo:BTO_0000390 rdfs:subClassOf bae:BrendaTissues . # endosperm
+obo:BTO_0000393 rdfs:subClassOf bae:BrendaTissues . # endothelium
+obo:BTO_0000394 rdfs:subClassOf bae:BrendaTissues . # aorta endothelium
+obo:BTO_0000397 rdfs:subClassOf bae:BrendaTissues . # tooth
+obo:BTO_0000398 rdfs:subClassOf bae:BrendaTissues . # enterocyte
+obo:BTO_0000399 rdfs:subClassOf bae:BrendaTissues . # eosinophil
+obo:BTO_0000401 rdfs:subClassOf bae:BrendaTissues . # ependymal epithelium
+obo:BTO_0000402 rdfs:subClassOf bae:BrendaTissues . # epicotyl
+obo:BTO_0000404 rdfs:subClassOf bae:BrendaTissues . # epidermis
+obo:BTO_0000405 rdfs:subClassOf bae:BrendaTissues . # penis
+obo:BTO_0000408 rdfs:subClassOf bae:BrendaTissues . # epididymis
+obo:BTO_0000409 rdfs:subClassOf bae:BrendaTissues . # epimastigote
+obo:BTO_0000410 rdfs:subClassOf bae:BrendaTissues . # immature ovarian follicle
+obo:BTO_0000411 rdfs:subClassOf bae:BrendaTissues . # cervical mucosa
+obo:BTO_0000412 rdfs:subClassOf bae:BrendaTissues . # epiphyseal growth plate
+obo:BTO_0000413 rdfs:subClassOf bae:BrendaTissues . # epiphysis
+obo:BTO_0000416 rdfs:subClassOf bae:BrendaTissues . # epithelium
+obo:BTO_0000417 rdfs:subClassOf bae:BrendaTissues . # bile duct epithelium
+obo:BTO_0000418 rdfs:subClassOf bae:BrendaTissues . # neostriatum
+obo:BTO_0000419 rdfs:subClassOf bae:BrendaTissues . # respiratory epithelium
+obo:BTO_0000420 rdfs:subClassOf bae:BrendaTissues . # neck
+obo:BTO_0000421 rdfs:subClassOf bae:BrendaTissues . # connective tissue
+obo:BTO_0000422 rdfs:subClassOf bae:BrendaTissues . # vaginal epithelium
+obo:BTO_0000424 rdfs:subClassOf bae:BrendaTissues . # erythrocyte
+obo:BTO_0000425 rdfs:subClassOf bae:BrendaTissues . # erythrocytic stage
+obo:BTO_0000431 rdfs:subClassOf bae:BrendaTissues . # excretory gland
+obo:BTO_0000432 rdfs:subClassOf bae:BrendaTissues . # corpus cardiacum
+obo:BTO_0000434 rdfs:subClassOf bae:BrendaTissues . # exocrine pancreas
+obo:BTO_0000435 rdfs:subClassOf bae:BrendaTissues . # stratum spinosum
+obo:BTO_0000436 rdfs:subClassOf bae:BrendaTissues . # extensor digitorum longus
+obo:BTO_0000438 rdfs:subClassOf bae:BrendaTissues . # stratum germinativum
+obo:BTO_0000439 rdfs:subClassOf bae:BrendaTissues . # eye
+obo:BTO_0000442 rdfs:subClassOf bae:BrendaTissues . # fat body
+obo:BTO_0000443 rdfs:subClassOf bae:BrendaTissues . # adipocyte
+obo:BTO_0000445 rdfs:subClassOf bae:BrendaTissues . # cerebral lobe
+obo:BTO_0000447 rdfs:subClassOf bae:BrendaTissues . # feather
+obo:BTO_0000449 rdfs:subClassOf bae:BrendaTissues . # fetus
+obo:BTO_0000450 rdfs:subClassOf bae:BrendaTissues . # fiber
+obo:BTO_0000452 rdfs:subClassOf bae:BrendaTissues . # fibroblast
+obo:BTO_0000463 rdfs:subClassOf bae:BrendaTissues . # filament
+obo:BTO_0000464 rdfs:subClassOf bae:BrendaTissues . # flagellate
+obo:BTO_0000465 rdfs:subClassOf bae:BrendaTissues . # flavedo
+obo:BTO_0000466 rdfs:subClassOf bae:BrendaTissues . # flexor digitorum longus
+obo:BTO_0000467 rdfs:subClassOf bae:BrendaTissues . # flight muscle
+obo:BTO_0000468 rdfs:subClassOf bae:BrendaTissues . # floret
+obo:BTO_0000469 rdfs:subClassOf bae:BrendaTissues . # flower
+obo:BTO_0000470 rdfs:subClassOf bae:BrendaTissues . # flower bud
+obo:BTO_0000473 rdfs:subClassOf bae:BrendaTissues . # fetal membrane
+obo:BTO_0000474 rdfs:subClassOf bae:BrendaTissues . # allantois
+obo:BTO_0000475 rdfs:subClassOf bae:BrendaTissues . # ovarian follicle
+obo:BTO_0000476 rdfs:subClassOf bae:BrendaTissues . # foot
+obo:BTO_0000477 rdfs:subClassOf bae:BrendaTissues . # foot muscle
+obo:BTO_0000478 rdfs:subClassOf bae:BrendaTissues . # forebrain
+obo:BTO_0000479 rdfs:subClassOf bae:BrendaTissues . # forelimb muscle
+obo:BTO_0000482 rdfs:subClassOf bae:BrendaTissues . # renal distal tubule
+obo:BTO_0000483 rdfs:subClassOf bae:BrendaTissues . # frond
+obo:BTO_0000484 rdfs:subClassOf bae:BrendaTissues . # frontal lobe
+obo:BTO_0000486 rdfs:subClassOf bae:BrendaTissues . # fruit
+obo:BTO_0000487 rdfs:subClassOf bae:BrendaTissues . # fruit body
+obo:BTO_0000488 rdfs:subClassOf bae:BrendaTissues . # lower epidermis
+obo:BTO_0000493 rdfs:subClassOf bae:BrendaTissues . # gall bladder
+obo:BTO_0000494 rdfs:subClassOf bae:BrendaTissues . # germinal disc
+obo:BTO_0000495 rdfs:subClassOf bae:BrendaTissues . # gametophyte
+obo:BTO_0000496 rdfs:subClassOf bae:BrendaTissues . # anterior lobe
+obo:BTO_0000497 rdfs:subClassOf bae:BrendaTissues . # ganglion
+obo:BTO_0000500 rdfs:subClassOf bae:BrendaTissues . # gastric epithelium
+obo:BTO_0000501 rdfs:subClassOf bae:BrendaTissues . # gastric juice
+obo:BTO_0000503 rdfs:subClassOf bae:BrendaTissues . # gastric gland
+obo:BTO_0000504 rdfs:subClassOf bae:BrendaTissues . # pancreatic juice
+obo:BTO_0000506 rdfs:subClassOf bae:BrendaTissues . # gastrocnemius
+obo:BTO_0000507 rdfs:subClassOf bae:BrendaTissues . # foregut
+obo:BTO_0000509 rdfs:subClassOf bae:BrendaTissues . # gastrodermis
+obo:BTO_0000510 rdfs:subClassOf bae:BrendaTissues . # hindgut
+obo:BTO_0000511 rdfs:subClassOf bae:BrendaTissues . # gastrointestinal tract
+obo:BTO_0000512 rdfs:subClassOf bae:BrendaTissues . # primary oocyte
+obo:BTO_0000514 rdfs:subClassOf bae:BrendaTissues . # germ
+obo:BTO_0000516 rdfs:subClassOf bae:BrendaTissues . # ghost
+obo:BTO_0000518 rdfs:subClassOf bae:BrendaTissues . # gill
+obo:BTO_0000519 rdfs:subClassOf bae:BrendaTissues . # gingiva
+obo:BTO_0000520 rdfs:subClassOf bae:BrendaTissues . # gizzard
+obo:BTO_0000524 rdfs:subClassOf bae:BrendaTissues . # glia
+obo:BTO_0000530 rdfs:subClassOf bae:BrendaTissues . # renal glomerulus
+obo:BTO_0000531 rdfs:subClassOf bae:BrendaTissues . # gluteal muscle
+obo:BTO_0000534 rdfs:subClassOf bae:BrendaTissues . # gonad
+obo:BTO_0000536 rdfs:subClassOf bae:BrendaTissues . # gracilis muscle
+obo:BTO_0000537 rdfs:subClassOf bae:BrendaTissues . # nectar
+obo:BTO_0000538 rdfs:subClassOf bae:BrendaTissues . # alveolar cell type II
+obo:BTO_0000539 rdfs:subClassOf bae:BrendaTissues . # granulocyte
+obo:BTO_0000545 rdfs:subClassOf bae:BrendaTissues . # gut
+obo:BTO_0000546 rdfs:subClassOf bae:BrendaTissues . # gut mucosa
+obo:BTO_0000547 rdfs:subClassOf bae:BrendaTissues . # gut wall
+obo:BTO_0000553 rdfs:subClassOf bae:BrendaTissues . # peripheral blood
+obo:BTO_0000554 rdfs:subClassOf bae:BrendaTissues . # hair follicle
+obo:BTO_0000555 rdfs:subClassOf bae:BrendaTissues . # hair root
+obo:BTO_0000556 rdfs:subClassOf bae:BrendaTissues . # germ layer
+obo:BTO_0000557 rdfs:subClassOf bae:BrendaTissues . # harderian gland
+obo:BTO_0000558 rdfs:subClassOf bae:BrendaTissues . # hatching gland
+obo:BTO_0000561 rdfs:subClassOf bae:BrendaTissues . # posterior lobe
+obo:BTO_0000562 rdfs:subClassOf bae:BrendaTissues . # heart
+obo:BTO_0000564 rdfs:subClassOf bae:BrendaTissues . # heart valve
+obo:BTO_0000569 rdfs:subClassOf bae:BrendaTissues . # exoerythrocytic stage
+obo:BTO_0000570 rdfs:subClassOf bae:BrendaTissues . # hematopoietic system
+obo:BTO_0000571 rdfs:subClassOf bae:BrendaTissues . # hemocyte
+obo:BTO_0000572 rdfs:subClassOf bae:BrendaTissues . # hemolymph
+obo:BTO_0000573 rdfs:subClassOf bae:BrendaTissues . # artery
+obo:BTO_0000575 rdfs:subClassOf bae:BrendaTissues . # hepatocyte
+obo:BTO_0000589 rdfs:subClassOf bae:BrendaTissues . # primary meristem
+obo:BTO_0000597 rdfs:subClassOf bae:BrendaTissues . # hepatopancreas
+obo:BTO_0000601 rdfs:subClassOf bae:BrendaTissues . # hippocampus
+obo:BTO_0000602 rdfs:subClassOf bae:BrendaTissues . # histiocyte
+obo:BTO_0000605 rdfs:subClassOf bae:BrendaTissues . # honey
+obo:BTO_0000609 rdfs:subClassOf bae:BrendaTissues . # husk
+obo:BTO_0000613 rdfs:subClassOf bae:BrendaTissues . # hypocotyl
+obo:BTO_0000614 rdfs:subClassOf bae:BrendaTissues . # hypothalamus
+obo:BTO_0000615 rdfs:subClassOf bae:BrendaTissues . # corpus callosum
+obo:BTO_0000616 rdfs:subClassOf bae:BrendaTissues . # I-cell
+obo:BTO_0000619 rdfs:subClassOf bae:BrendaTissues . # ileal mucosa
+obo:BTO_0000620 rdfs:subClassOf bae:BrendaTissues . # ileum
+obo:BTO_0000621 rdfs:subClassOf bae:BrendaTissues . # iliopsoas muscle
+obo:BTO_0000628 rdfs:subClassOf bae:BrendaTissues . # inflorescence
+obo:BTO_0000629 rdfs:subClassOf bae:BrendaTissues . # ink
+obo:BTO_0000630 rdfs:subClassOf bae:BrendaTissues . # inner ear
+obo:BTO_0000634 rdfs:subClassOf bae:BrendaTissues . # integument
+obo:BTO_0000635 rdfs:subClassOf bae:BrendaTissues . # yellow bone marrow
+obo:BTO_0000639 rdfs:subClassOf bae:BrendaTissues . # intersegmental muscle
+obo:BTO_0000640 rdfs:subClassOf bae:BrendaTissues . # intestinal gland
+obo:BTO_0000641 rdfs:subClassOf bae:BrendaTissues . # colon descendens
+obo:BTO_0000642 rdfs:subClassOf bae:BrendaTissues . # intestinal mucosa
+obo:BTO_0000643 rdfs:subClassOf bae:BrendaTissues . # intestinal muscle
+obo:BTO_0000644 rdfs:subClassOf bae:BrendaTissues . # intestinal juice
+obo:BTO_0000645 rdfs:subClassOf bae:BrendaTissues . # colon sigmoideum
+obo:BTO_0000646 rdfs:subClassOf bae:BrendaTissues . # left colon
+obo:BTO_0000647 rdfs:subClassOf bae:BrendaTissues . # intestinal wall
+obo:BTO_0000648 rdfs:subClassOf bae:BrendaTissues . # intestine
+obo:BTO_0000649 rdfs:subClassOf bae:BrendaTissues . # right colon
+obo:BTO_0000650 rdfs:subClassOf bae:BrendaTissues . # endocrine pancreas
+obo:BTO_0000651 rdfs:subClassOf bae:BrendaTissues . # small intestine
+obo:BTO_0000653 rdfs:subClassOf bae:BrendaTissues . # iris
+obo:BTO_0000654 rdfs:subClassOf bae:BrendaTissues . # ciliary muscle
+obo:BTO_0000656 rdfs:subClassOf bae:BrendaTissues . # iris sphincter muscle
+obo:BTO_0000657 rdfs:subClassOf bae:BrendaTissues . # jejunum
+obo:BTO_0000659 rdfs:subClassOf bae:BrendaTissues . # juice
+obo:BTO_0000662 rdfs:subClassOf bae:BrendaTissues . # nasopharynx
+obo:BTO_0000667 rdfs:subClassOf bae:BrendaTissues . # keratinocyte
+obo:BTO_0000668 rdfs:subClassOf bae:BrendaTissues . # kernel
+obo:BTO_0000671 rdfs:subClassOf bae:BrendaTissues . # kidney
+obo:BTO_0000672 rdfs:subClassOf bae:BrendaTissues . # hindbrain
+obo:BTO_0000673 rdfs:subClassOf bae:BrendaTissues . # metencephalon
+obo:BTO_0000703 rdfs:subClassOf bae:BrendaTissues . # lacquer
+obo:BTO_0000706 rdfs:subClassOf bae:BrendaTissues . # large intestine
+obo:BTO_0000707 rdfs:subClassOf bae:BrendaTissues . # larva
+obo:BTO_0000708 rdfs:subClassOf bae:BrendaTissues . # larval integument
+obo:BTO_0000709 rdfs:subClassOf bae:BrendaTissues . # secondary spermatocyte
+obo:BTO_0000710 rdfs:subClassOf bae:BrendaTissues . # latex
+obo:BTO_0000712 rdfs:subClassOf bae:BrendaTissues . # laticifer
+obo:BTO_0000713 rdfs:subClassOf bae:BrendaTissues . # leaf
+obo:BTO_0000714 rdfs:subClassOf bae:BrendaTissues . # leaf axil
+obo:BTO_0000715 rdfs:subClassOf bae:BrendaTissues . # leaf base
+obo:BTO_0000717 rdfs:subClassOf bae:BrendaTissues . # pericardium
+obo:BTO_0000718 rdfs:subClassOf bae:BrendaTissues . # leaf epidermis
+obo:BTO_0000719 rdfs:subClassOf bae:BrendaTissues . # leaf lamina
+obo:BTO_0000722 rdfs:subClassOf bae:BrendaTissues . # leg muscle
+obo:BTO_0000723 rdfs:subClassOf bae:BrendaTissues . # lens
+obo:BTO_0000724 rdfs:subClassOf bae:BrendaTissues . # lens fiber
+obo:BTO_0000730 rdfs:subClassOf bae:BrendaTissues . # endocarp
+obo:BTO_0000733 rdfs:subClassOf bae:BrendaTissues . # exocarp
+obo:BTO_0000734 rdfs:subClassOf bae:BrendaTissues . # myelocyte
+obo:BTO_0000735 rdfs:subClassOf bae:BrendaTissues . # sporophyte
+obo:BTO_0000742 rdfs:subClassOf bae:BrendaTissues . # myotome
+obo:BTO_0000747 rdfs:subClassOf bae:BrendaTissues . # sporangiospore
+obo:BTO_0000750 rdfs:subClassOf bae:BrendaTissues . # plant ovary
+obo:BTO_0000751 rdfs:subClassOf bae:BrendaTissues . # leukocyte
+obo:BTO_0000752 rdfs:subClassOf bae:BrendaTissues . # lymph vessel
+obo:BTO_0000753 rdfs:subClassOf bae:BrendaTissues . # lymphoid tissue
+obo:BTO_0000758 rdfs:subClassOf bae:BrendaTissues . # myelencephalon
+obo:BTO_0000759 rdfs:subClassOf bae:BrendaTissues . # liver
+obo:BTO_0000761 rdfs:subClassOf bae:BrendaTissues . # collecting duct
+obo:BTO_0000763 rdfs:subClassOf bae:BrendaTissues . # lung
+obo:BTO_0000764 rdfs:subClassOf bae:BrendaTissues . # lung fibroblast
+obo:BTO_0000765 rdfs:subClassOf bae:BrendaTissues . # exocrine gland
+obo:BTO_0000766 rdfs:subClassOf bae:BrendaTissues . # blood vessel endothelium
+obo:BTO_0000767 rdfs:subClassOf bae:BrendaTissues . # mesenteric lymph node
+obo:BTO_0000768 rdfs:subClassOf bae:BrendaTissues . # infundibulum
+obo:BTO_0000770 rdfs:subClassOf bae:BrendaTissues . # oligodendroglia
+obo:BTO_0000772 rdfs:subClassOf bae:BrendaTissues . # lymphoblast
+obo:BTO_0000775 rdfs:subClassOf bae:BrendaTissues . # lymphocyte
+obo:BTO_0000776 rdfs:subClassOf bae:BrendaTissues . # B-lymphocyte
+obo:BTO_0000777 rdfs:subClassOf bae:BrendaTissues . # adenoid
+obo:BTO_0000778 rdfs:subClassOf bae:BrendaTissues . # pulmonary artery
+obo:BTO_0000780 rdfs:subClassOf bae:BrendaTissues . # alveolar cell type I
+obo:BTO_0000781 rdfs:subClassOf bae:BrendaTissues . # intestinal epithelium
+obo:BTO_0000782 rdfs:subClassOf bae:BrendaTissues . # T-lymphocyte
+obo:BTO_0000784 rdfs:subClassOf bae:BrendaTissues . # lymph node
+obo:BTO_0000800 rdfs:subClassOf bae:BrendaTissues . # endoderm
+obo:BTO_0000801 rdfs:subClassOf bae:BrendaTissues . # macrophage
+obo:BTO_0000802 rdfs:subClassOf bae:BrendaTissues . # alveolar macrophage
+obo:BTO_0000808 rdfs:subClassOf bae:BrendaTissues . # interrenal gland
+obo:BTO_0000810 rdfs:subClassOf bae:BrendaTissues . # malpighian tubule
+obo:BTO_0000817 rdfs:subClassOf bae:BrendaTissues . # mammary gland
+obo:BTO_0000818 rdfs:subClassOf bae:BrendaTissues . # spinal column
+obo:BTO_0000821 rdfs:subClassOf bae:BrendaTissues . # nipple
+obo:BTO_0000823 rdfs:subClassOf bae:BrendaTissues . # cerebral gray matter
+obo:BTO_0000825 rdfs:subClassOf bae:BrendaTissues . # mantle
+obo:BTO_0000826 rdfs:subClassOf bae:BrendaTissues . # mantle cavity
+obo:BTO_0000827 rdfs:subClassOf bae:BrendaTissues . # mantle muscle
+obo:BTO_0000828 rdfs:subClassOf bae:BrendaTissues . # throat
+obo:BTO_0000829 rdfs:subClassOf bae:BrendaTissues . # marrow
+obo:BTO_0000838 rdfs:subClassOf bae:BrendaTissues . # meconium
+obo:BTO_0000839 rdfs:subClassOf bae:BrendaTissues . # mesoderm
+obo:BTO_0000840 rdfs:subClassOf bae:BrendaTissues . # nose
+obo:BTO_0000841 rdfs:subClassOf bae:BrendaTissues . # umbilical artery
+obo:BTO_0000842 rdfs:subClassOf bae:BrendaTissues . # megagametophyte
+obo:BTO_0000843 rdfs:subClassOf bae:BrendaTissues . # megakaryocyte
+obo:BTO_0000847 rdfs:subClassOf bae:BrendaTissues . # melanocyte
+obo:BTO_0000852 rdfs:subClassOf bae:BrendaTissues . # meristem
+obo:BTO_0000854 rdfs:subClassOf bae:BrendaTissues . # zygote
+obo:BTO_0000855 rdfs:subClassOf bae:BrendaTissues . # lymph
+obo:BTO_0000856 rdfs:subClassOf bae:BrendaTissues . # mesocarp
+obo:BTO_0000858 rdfs:subClassOf bae:BrendaTissues . # mesophyll
+obo:BTO_0000859 rdfs:subClassOf bae:BrendaTissues . # metacestode
+obo:BTO_0000862 rdfs:subClassOf bae:BrendaTissues . # heart ventricle
+obo:BTO_0000863 rdfs:subClassOf bae:BrendaTissues . # midgut
+obo:BTO_0000865 rdfs:subClassOf bae:BrendaTissues . # anterior spinal root
+obo:BTO_0000866 rdfs:subClassOf bae:BrendaTissues . # midgut secretion
+obo:BTO_0000867 rdfs:subClassOf bae:BrendaTissues . # tibialis posterior
+obo:BTO_0000868 rdfs:subClassOf bae:BrendaTissues . # milk
+obo:BTO_0000870 rdfs:subClassOf bae:BrendaTissues . # spinal nerve
+obo:BTO_0000874 rdfs:subClassOf bae:BrendaTissues . # molting gland
+obo:BTO_0000876 rdfs:subClassOf bae:BrendaTissues . # monocyte
+obo:BTO_0000879 rdfs:subClassOf bae:BrendaTissues . # lateral ventricle
+obo:BTO_0000883 rdfs:subClassOf bae:BrendaTissues . # spinal root
+obo:BTO_0000884 rdfs:subClassOf bae:BrendaTissues . # molting fluid
+obo:BTO_0000886 rdfs:subClassOf bae:BrendaTissues . # mucosa
+obo:BTO_0000887 rdfs:subClassOf bae:BrendaTissues . # muscle
+obo:BTO_0000888 rdfs:subClassOf bae:BrendaTissues . # muscle fibre
+obo:BTO_0000897 rdfs:subClassOf bae:BrendaTissues . # amnion epithelium
+obo:BTO_0000901 rdfs:subClassOf bae:BrendaTissues . # myocardium
+obo:BTO_0000902 rdfs:subClassOf bae:BrendaTissues . # plant vessel
+obo:BTO_0000903 rdfs:subClassOf bae:BrendaTissues . # atrium
+obo:BTO_0000907 rdfs:subClassOf bae:BrendaTissues . # myometrium
+obo:BTO_0000912 rdfs:subClassOf bae:BrendaTissues . # nasal mucosa
+obo:BTO_0000913 rdfs:subClassOf bae:BrendaTissues . # nasal polyp
+obo:BTO_0000915 rdfs:subClassOf bae:BrendaTissues . # nauplius
+obo:BTO_0000917 rdfs:subClassOf bae:BrendaTissues . # needle
+obo:BTO_0000920 rdfs:subClassOf bae:BrendaTissues . # neocortex
+obo:BTO_0000923 rdfs:subClassOf bae:BrendaTissues . # nephridium
+obo:BTO_0000924 rdfs:subClassOf bae:BrendaTissues . # nephron
+obo:BTO_0000925 rdfs:subClassOf bae:BrendaTissues . # nerve
+obo:BTO_0000926 rdfs:subClassOf bae:BrendaTissues . # ophthalmic nerve
+obo:BTO_0000927 rdfs:subClassOf bae:BrendaTissues . # nerve trunk
+obo:BTO_0000928 rdfs:subClassOf bae:BrendaTissues . # limbic system
+obo:BTO_0000929 rdfs:subClassOf bae:BrendaTissues . # neural retina
+obo:BTO_0000930 rdfs:subClassOf bae:BrendaTissues . # neuroblast
+obo:BTO_0000937 rdfs:subClassOf bae:BrendaTissues . # neurohypophysis
+obo:BTO_0000938 rdfs:subClassOf bae:BrendaTissues . # neuron
+obo:BTO_0000952 rdfs:subClassOf bae:BrendaTissues . # nuchal ligament
+obo:BTO_0000954 rdfs:subClassOf bae:BrendaTissues . # nymph
+obo:BTO_0000956 rdfs:subClassOf bae:BrendaTissues . # gut epithelium
+obo:BTO_0000957 rdfs:subClassOf bae:BrendaTissues . # nape
+obo:BTO_0000958 rdfs:subClassOf bae:BrendaTissues . # spermatogonium
+obo:BTO_0000959 rdfs:subClassOf bae:BrendaTissues . # esophagus
+obo:BTO_0000961 rdfs:subClassOf bae:BrendaTissues . # olfactory bulb
+obo:BTO_0000962 rdfs:subClassOf bae:BrendaTissues . # oligodendrocyte
+obo:BTO_0000964 rdfs:subClassOf bae:BrendaTissues . # oocyte
+obo:BTO_0000965 rdfs:subClassOf bae:BrendaTissues . # optic lobe
+obo:BTO_0000966 rdfs:subClassOf bae:BrendaTissues . # optic nerve
+obo:BTO_0000967 rdfs:subClassOf bae:BrendaTissues . # osseous plate
+obo:BTO_0000968 rdfs:subClassOf bae:BrendaTissues . # osteoclast
+obo:BTO_0000973 rdfs:subClassOf bae:BrendaTissues . # respiratory mucosa
+obo:BTO_0000975 rdfs:subClassOf bae:BrendaTissues . # ovary
+obo:BTO_0000980 rdfs:subClassOf bae:BrendaTissues . # oviduct
+obo:BTO_0000981 rdfs:subClassOf bae:BrendaTissues . # ovotestis
+obo:BTO_0000987 rdfs:subClassOf bae:BrendaTissues . # palisade parenchyma
+obo:BTO_0000988 rdfs:subClassOf bae:BrendaTissues . # pancreas
+obo:BTO_0000989 rdfs:subClassOf bae:BrendaTissues . # taste bud
+obo:BTO_0000991 rdfs:subClassOf bae:BrendaTissues . # pancreatic islet
+obo:BTO_0000992 rdfs:subClassOf bae:BrendaTissues . # tongue epithelium
+obo:BTO_0000995 rdfs:subClassOf bae:BrendaTissues . # paramyeloblast
+obo:BTO_0000996 rdfs:subClassOf bae:BrendaTissues . # gametocyte
+obo:BTO_0000997 rdfs:subClassOf bae:BrendaTissues . # parathyroid gland
+obo:BTO_0000999 rdfs:subClassOf bae:BrendaTissues . # plant parenchyma
+obo:BTO_0001001 rdfs:subClassOf bae:BrendaTissues . # parietal lobe
+obo:BTO_0001002 rdfs:subClassOf bae:BrendaTissues . # schizont
+obo:BTO_0001004 rdfs:subClassOf bae:BrendaTissues . # parotid gland
+obo:BTO_0001006 rdfs:subClassOf bae:BrendaTissues . # pelvis
+obo:BTO_0001010 rdfs:subClassOf bae:BrendaTissues . # callus
+obo:BTO_0001012 rdfs:subClassOf bae:BrendaTissues . # pedal ganglion
+obo:BTO_0001016 rdfs:subClassOf bae:BrendaTissues . # pericardial fluid
+obo:BTO_0001017 rdfs:subClassOf bae:BrendaTissues . # pericarp
+obo:BTO_0001020 rdfs:subClassOf bae:BrendaTissues . # periodontal ligament
+obo:BTO_0001022 rdfs:subClassOf bae:BrendaTissues . # periosteum
+obo:BTO_0001024 rdfs:subClassOf bae:BrendaTissues . # retinal rod
+obo:BTO_0001027 rdfs:subClassOf bae:BrendaTissues . # peripheral nerve
+obo:BTO_0001028 rdfs:subClassOf bae:BrendaTissues . # peripheral nervous system
+obo:BTO_0001029 rdfs:subClassOf bae:BrendaTissues . # perisperm
+obo:BTO_0001031 rdfs:subClassOf bae:BrendaTissues . # peritoneal fluid
+obo:BTO_0001036 rdfs:subClassOf bae:BrendaTissues . # retinal cone
+obo:BTO_0001038 rdfs:subClassOf bae:BrendaTissues . # peritrophic membrane
+obo:BTO_0001040 rdfs:subClassOf bae:BrendaTissues . # petal
+obo:BTO_0001041 rdfs:subClassOf bae:BrendaTissues . # petiole
+obo:BTO_0001042 rdfs:subClassOf bae:BrendaTissues . # amygdala
+obo:BTO_0001043 rdfs:subClassOf bae:BrendaTissues . # adult
+obo:BTO_0001044 rdfs:subClassOf bae:BrendaTissues . # phagocyte
+obo:BTO_0001046 rdfs:subClassOf bae:BrendaTissues . # pharate pupa
+obo:BTO_0001048 rdfs:subClassOf bae:BrendaTissues . # pharyngeal muscle
+obo:BTO_0001049 rdfs:subClassOf bae:BrendaTissues . # pharynx
+obo:BTO_0001057 rdfs:subClassOf bae:BrendaTissues . # neural tube
+obo:BTO_0001058 rdfs:subClassOf bae:BrendaTissues . # phloem
+obo:BTO_0001060 rdfs:subClassOf bae:BrendaTissues . # photoreceptor
+obo:BTO_0001063 rdfs:subClassOf bae:BrendaTissues . # phrenic nerve
+obo:BTO_0001064 rdfs:subClassOf bae:BrendaTissues . # phycobiont
+obo:BTO_0001066 rdfs:subClassOf bae:BrendaTissues . # hippocampal pyramidal layer
+obo:BTO_0001067 rdfs:subClassOf bae:BrendaTissues . # pineal gland
+obo:BTO_0001068 rdfs:subClassOf bae:BrendaTissues . # pinealocyte
+obo:BTO_0001069 rdfs:subClassOf bae:BrendaTissues . # pitcher
+obo:BTO_0001071 rdfs:subClassOf bae:BrendaTissues . # pith
+obo:BTO_0001072 rdfs:subClassOf bae:BrendaTissues . # trigeminal nerve
+obo:BTO_0001073 rdfs:subClassOf bae:BrendaTissues . # hypophysis
+obo:BTO_0001075 rdfs:subClassOf bae:BrendaTissues . # motor trigeminal nucleus
+obo:BTO_0001078 rdfs:subClassOf bae:BrendaTissues . # placenta
+obo:BTO_0001079 rdfs:subClassOf bae:BrendaTissues . # trophoblast
+obo:BTO_0001084 rdfs:subClassOf bae:BrendaTissues . # plantlet
+obo:BTO_0001085 rdfs:subClassOf bae:BrendaTissues . # vascular system
+obo:BTO_0001090 rdfs:subClassOf bae:BrendaTissues . # mouth
+obo:BTO_0001091 rdfs:subClassOf bae:BrendaTissues . # axenic culture
+obo:BTO_0001097 rdfs:subClassOf bae:BrendaTissues . # pollen
+obo:BTO_0001099 rdfs:subClassOf bae:BrendaTissues . # blastocyst
+obo:BTO_0001101 rdfs:subClassOf bae:BrendaTissues . # pons
+obo:BTO_0001102 rdfs:subClassOf bae:BrendaTissues . # blood vessel
+obo:BTO_0001103 rdfs:subClassOf bae:BrendaTissues . # skeletal muscle
+obo:BTO_0001104 rdfs:subClassOf bae:BrendaTissues . # cranial nerve
+obo:BTO_0001105 rdfs:subClassOf bae:BrendaTissues . # insular cortex
+obo:BTO_0001107 rdfs:subClassOf bae:BrendaTissues . # preadipocyte
+obo:BTO_0001108 rdfs:subClassOf bae:BrendaTissues . # mitral cell layer
+obo:BTO_0001110 rdfs:subClassOf bae:BrendaTissues . # prepupa
+obo:BTO_0001111 rdfs:subClassOf bae:BrendaTissues . # preputial gland
+obo:BTO_0001113 rdfs:subClassOf bae:BrendaTissues . # prepuce
+obo:BTO_0001114 rdfs:subClassOf bae:BrendaTissues . # primary leaf
+obo:BTO_0001115 rdfs:subClassOf bae:BrendaTissues . # primary spermatocyte
+obo:BTO_0001116 rdfs:subClassOf bae:BrendaTissues . # floral primordium
+obo:BTO_0001117 rdfs:subClassOf bae:BrendaTissues . # proboscis
+obo:BTO_0001119 rdfs:subClassOf bae:BrendaTissues . # procambium
+obo:BTO_0001121 rdfs:subClassOf bae:BrendaTissues . # cauline leaf
+obo:BTO_0001122 rdfs:subClassOf bae:BrendaTissues . # procyclic form
+obo:BTO_0001124 rdfs:subClassOf bae:BrendaTissues . # promastigote
+obo:BTO_0001127 rdfs:subClassOf bae:BrendaTissues . # primary culture
+obo:BTO_0001128 rdfs:subClassOf bae:BrendaTissues . # prostasome
+obo:BTO_0001129 rdfs:subClassOf bae:BrendaTissues . # prostate gland
+obo:BTO_0001133 rdfs:subClassOf bae:BrendaTissues . # pre-B-lymphocyte
+obo:BTO_0001134 rdfs:subClassOf bae:BrendaTissues . # protonema
+obo:BTO_0001135 rdfs:subClassOf bae:BrendaTissues . # protoxylem
+obo:BTO_0001136 rdfs:subClassOf bae:BrendaTissues . # proventriculus
+obo:BTO_0001138 rdfs:subClassOf bae:BrendaTissues . # somatic embryo
+obo:BTO_0001140 rdfs:subClassOf bae:BrendaTissues . # psoas
+obo:BTO_0001142 rdfs:subClassOf bae:BrendaTissues . # pulp
+obo:BTO_0001146 rdfs:subClassOf bae:BrendaTissues . # pyloric region
+obo:BTO_0001149 rdfs:subClassOf bae:BrendaTissues . # quadriceps
+obo:BTO_0001152 rdfs:subClassOf bae:BrendaTissues . # radicle
+obo:BTO_0001153 rdfs:subClassOf bae:BrendaTissues . # radular muscle
+obo:BTO_0001156 rdfs:subClassOf bae:BrendaTissues . # node
+obo:BTO_0001157 rdfs:subClassOf bae:BrendaTissues . # rectal gland
+obo:BTO_0001158 rdfs:subClassOf bae:BrendaTissues . # rectum
+obo:BTO_0001160 rdfs:subClassOf bae:BrendaTissues . # red bone marrow
+obo:BTO_0001161 rdfs:subClassOf bae:BrendaTissues . # chorionic villus
+obo:BTO_0001162 rdfs:subClassOf bae:BrendaTissues . # apocrine gland
+obo:BTO_0001164 rdfs:subClassOf bae:BrendaTissues . # megakaryoblast
+obo:BTO_0001165 rdfs:subClassOf bae:BrendaTissues . # renal artery
+obo:BTO_0001166 rdfs:subClassOf bae:BrendaTissues . # renal cortex
+obo:BTO_0001167 rdfs:subClassOf bae:BrendaTissues . # renal medulla
+obo:BTO_0001168 rdfs:subClassOf bae:BrendaTissues . # rennet
+obo:BTO_0001172 rdfs:subClassOf bae:BrendaTissues . # reticulate body
+obo:BTO_0001173 rdfs:subClassOf bae:BrendaTissues . # reticulocyte
+obo:BTO_0001174 rdfs:subClassOf bae:BrendaTissues . # reticuloendothelial system
+obo:BTO_0001175 rdfs:subClassOf bae:BrendaTissues . # retina
+obo:BTO_0001177 rdfs:subClassOf bae:BrendaTissues . # retinal pigment epithelium
+obo:BTO_0001179 rdfs:subClassOf bae:BrendaTissues . # rhizophore
+obo:BTO_0001180 rdfs:subClassOf bae:BrendaTissues . # idioblast
+obo:BTO_0001181 rdfs:subClassOf bae:BrendaTissues . # rhizome
+obo:BTO_0001182 rdfs:subClassOf bae:BrendaTissues . # primary root
+obo:BTO_0001183 rdfs:subClassOf bae:BrendaTissues . # secondary root
+obo:BTO_0001184 rdfs:subClassOf bae:BrendaTissues . # rind
+obo:BTO_0001187 rdfs:subClassOf bae:BrendaTissues . # roe
+obo:BTO_0001188 rdfs:subClassOf bae:BrendaTissues . # root
+obo:BTO_0001190 rdfs:subClassOf bae:BrendaTissues . # root nodule
+obo:BTO_0001191 rdfs:subClassOf bae:BrendaTissues . # root tip
+obo:BTO_0001192 rdfs:subClassOf bae:BrendaTissues . # rootlet
+obo:BTO_0001194 rdfs:subClassOf bae:BrendaTissues . # rumen
+obo:BTO_0001195 rdfs:subClassOf bae:BrendaTissues . # rumen epithelium
+obo:BTO_0001198 rdfs:subClassOf bae:BrendaTissues . # atrial gland
+obo:BTO_0001201 rdfs:subClassOf bae:BrendaTissues . # rosette
+obo:BTO_0001202 rdfs:subClassOf bae:BrendaTissues . # saliva
+obo:BTO_0001203 rdfs:subClassOf bae:BrendaTissues . # salivary gland
+obo:BTO_0001204 rdfs:subClassOf bae:BrendaTissues . # salt gland
+obo:BTO_0001206 rdfs:subClassOf bae:BrendaTissues . # sarcocarp
+obo:BTO_0001208 rdfs:subClassOf bae:BrendaTissues . # larynx
+obo:BTO_0001215 rdfs:subClassOf bae:BrendaTissues . # sartorius
+obo:BTO_0001217 rdfs:subClassOf bae:BrendaTissues . # scape
+obo:BTO_0001218 rdfs:subClassOf bae:BrendaTissues . # scapula
+obo:BTO_0001221 rdfs:subClassOf bae:BrendaTissues . # sciatic nerve
+obo:BTO_0001222 rdfs:subClassOf bae:BrendaTissues . # sclerenchyma
+obo:BTO_0001223 rdfs:subClassOf bae:BrendaTissues . # scutellum
+obo:BTO_0001226 rdfs:subClassOf bae:BrendaTissues . # seed
+obo:BTO_0001227 rdfs:subClassOf bae:BrendaTissues . # seed coat
+obo:BTO_0001228 rdfs:subClassOf bae:BrendaTissues . # seedling
+obo:BTO_0001230 rdfs:subClassOf bae:BrendaTissues . # semen
+obo:BTO_0001231 rdfs:subClassOf bae:BrendaTissues . # trigeminal ganglion
+obo:BTO_0001232 rdfs:subClassOf bae:BrendaTissues . # seminal plasma
+obo:BTO_0001233 rdfs:subClassOf bae:BrendaTissues . # plant embryo
+obo:BTO_0001234 rdfs:subClassOf bae:BrendaTissues . # seminal vesicle
+obo:BTO_0001235 rdfs:subClassOf bae:BrendaTissues . # seminiferous tubule
+obo:BTO_0001236 rdfs:subClassOf bae:BrendaTissues . # semitendinosus
+obo:BTO_0001237 rdfs:subClassOf bae:BrendaTissues . # sensillum
+obo:BTO_0001239 rdfs:subClassOf bae:BrendaTissues . # serum
+obo:BTO_0001241 rdfs:subClassOf bae:BrendaTissues . # shell gland
+obo:BTO_0001243 rdfs:subClassOf bae:BrendaTissues . # shoot
+obo:BTO_0001244 rdfs:subClassOf bae:BrendaTissues . # urinary tract
+obo:BTO_0001246 rdfs:subClassOf bae:BrendaTissues . # flexor digitorum profundus
+obo:BTO_0001247 rdfs:subClassOf bae:BrendaTissues . # sieve tube
+obo:BTO_0001249 rdfs:subClassOf bae:BrendaTissues . # silique
+obo:BTO_0001250 rdfs:subClassOf bae:BrendaTissues . # silk gland
+obo:BTO_0001252 rdfs:subClassOf bae:BrendaTissues . # tibia
+obo:BTO_0001253 rdfs:subClassOf bae:BrendaTissues . # skin
+obo:BTO_0001254 rdfs:subClassOf bae:BrendaTissues . # sweat
+obo:BTO_0001255 rdfs:subClassOf bae:BrendaTissues . # skin fibroblast
+obo:BTO_0001257 rdfs:subClassOf bae:BrendaTissues . # flexor
+obo:BTO_0001259 rdfs:subClassOf bae:BrendaTissues . # small intestine mucosa
+obo:BTO_0001260 rdfs:subClassOf bae:BrendaTissues . # smooth muscle
+obo:BTO_0001261 rdfs:subClassOf bae:BrendaTissues . # abdominal muscle
+obo:BTO_0001262 rdfs:subClassOf bae:BrendaTissues . # soft body part
+obo:BTO_0001264 rdfs:subClassOf bae:BrendaTissues . # spinal ganglion
+obo:BTO_0001265 rdfs:subClassOf bae:BrendaTissues . # soleus
+obo:BTO_0001266 rdfs:subClassOf bae:BrendaTissues . # invertebrate muscular system
+obo:BTO_0001269 rdfs:subClassOf bae:BrendaTissues . # spadix
+obo:BTO_0001270 rdfs:subClassOf bae:BrendaTissues . # spear
+obo:BTO_0001273 rdfs:subClassOf bae:BrendaTissues . # spermatheca
+obo:BTO_0001274 rdfs:subClassOf bae:BrendaTissues . # spermatid
+obo:BTO_0001275 rdfs:subClassOf bae:BrendaTissues . # spermatocyte
+obo:BTO_0001277 rdfs:subClassOf bae:BrendaTissues . # spermatozoon
+obo:BTO_0001278 rdfs:subClassOf bae:BrendaTissues . # spike
+obo:BTO_0001279 rdfs:subClassOf bae:BrendaTissues . # spinal cord
+obo:BTO_0001281 rdfs:subClassOf bae:BrendaTissues . # spleen
+obo:BTO_0001284 rdfs:subClassOf bae:BrendaTissues . # femur
+obo:BTO_0001287 rdfs:subClassOf bae:BrendaTissues . # sporangium
+obo:BTO_0001290 rdfs:subClassOf bae:BrendaTissues . # sporocarp
+obo:BTO_0001292 rdfs:subClassOf bae:BrendaTissues . # sporozoite
+obo:BTO_0001293 rdfs:subClassOf bae:BrendaTissues . # sporulated oocyst
+obo:BTO_0001295 rdfs:subClassOf bae:BrendaTissues . # cranium
+obo:BTO_0001296 rdfs:subClassOf bae:BrendaTissues . # sprout
+obo:BTO_0001297 rdfs:subClassOf bae:BrendaTissues . # sputum
+obo:BTO_0001299 rdfs:subClassOf bae:BrendaTissues . # stele
+obo:BTO_0001300 rdfs:subClassOf bae:BrendaTissues . # stem
+obo:BTO_0001301 rdfs:subClassOf bae:BrendaTissues . # bark
+obo:BTO_0001302 rdfs:subClassOf bae:BrendaTissues . # sternum
+obo:BTO_0001303 rdfs:subClassOf bae:BrendaTissues . # stigma
+obo:BTO_0001304 rdfs:subClassOf bae:BrendaTissues . # stipe
+obo:BTO_0001305 rdfs:subClassOf bae:BrendaTissues . # stipule
+obo:BTO_0001306 rdfs:subClassOf bae:BrendaTissues . # stolon
+obo:BTO_0001307 rdfs:subClassOf bae:BrendaTissues . # stomach
+obo:BTO_0001308 rdfs:subClassOf bae:BrendaTissues . # gastric mucosa
+obo:BTO_0001309 rdfs:subClassOf bae:BrendaTissues . # tuberous root
+obo:BTO_0001310 rdfs:subClassOf bae:BrendaTissues . # storage tissue
+obo:BTO_0001311 rdfs:subClassOf bae:BrendaTissues . # corpus striatum
+obo:BTO_0001312 rdfs:subClassOf bae:BrendaTissues . # adductor magnus
+obo:BTO_0001313 rdfs:subClassOf bae:BrendaTissues . # style
+obo:BTO_0001314 rdfs:subClassOf bae:BrendaTissues . # subcutis
+obo:BTO_0001315 rdfs:subClassOf bae:BrendaTissues . # sublingual gland
+obo:BTO_0001316 rdfs:subClassOf bae:BrendaTissues . # submandibular gland
+obo:BTO_0001317 rdfs:subClassOf bae:BrendaTissues . # glomerular layer
+obo:BTO_0001318 rdfs:subClassOf bae:BrendaTissues . # submandibular ganglion
+obo:BTO_0001319 rdfs:subClassOf bae:BrendaTissues . # external plexiform layer
+obo:BTO_0001320 rdfs:subClassOf bae:BrendaTissues . # internal plexiform layer
+obo:BTO_0001325 rdfs:subClassOf bae:BrendaTissues . # superior cervical ganglion
+obo:BTO_0001327 rdfs:subClassOf bae:BrendaTissues . # granule cell layer
+obo:BTO_0001328 rdfs:subClassOf bae:BrendaTissues . # calvarium
+obo:BTO_0001331 rdfs:subClassOf bae:BrendaTissues . # sweat gland
+obo:BTO_0001335 rdfs:subClassOf bae:BrendaTissues . # syncytiotrophoblast
+obo:BTO_0001336 rdfs:subClassOf bae:BrendaTissues . # synovial fibroblast
+obo:BTO_0001337 rdfs:subClassOf bae:BrendaTissues . # extensor digitorum brevis
+obo:BTO_0001338 rdfs:subClassOf bae:BrendaTissues . # synovial tissue
+obo:BTO_0001339 rdfs:subClassOf bae:BrendaTissues . # synovia
+obo:BTO_0001340 rdfs:subClassOf bae:BrendaTissues . # bronchus
+obo:BTO_0001343 rdfs:subClassOf bae:BrendaTissues . # extensor digitorum communis
+obo:BTO_0001346 rdfs:subClassOf bae:BrendaTissues . # tachyzoite
+obo:BTO_0001347 rdfs:subClassOf bae:BrendaTissues . # tadpole
+obo:BTO_0001348 rdfs:subClassOf bae:BrendaTissues . # tail
+obo:BTO_0001350 rdfs:subClassOf bae:BrendaTissues . # tapetum
+obo:BTO_0001351 rdfs:subClassOf bae:BrendaTissues . # vomeronasal nerve
+obo:BTO_0001353 rdfs:subClassOf bae:BrendaTissues . # telson
+obo:BTO_0001355 rdfs:subClassOf bae:BrendaTissues . # temporal lobe
+obo:BTO_0001356 rdfs:subClassOf bae:BrendaTissues . # tendon
+obo:BTO_0001357 rdfs:subClassOf bae:BrendaTissues . # tentacle
+obo:BTO_0001360 rdfs:subClassOf bae:BrendaTissues . # decidua
+obo:BTO_0001362 rdfs:subClassOf bae:BrendaTissues . # olfactory lobe
+obo:BTO_0001363 rdfs:subClassOf bae:BrendaTissues . # testis
+obo:BTO_0001365 rdfs:subClassOf bae:BrendaTissues . # thalamus
+obo:BTO_0001366 rdfs:subClassOf bae:BrendaTissues . # thallus
+obo:BTO_0001367 rdfs:subClassOf bae:BrendaTissues . # thigh muscle
+obo:BTO_0001368 rdfs:subClassOf bae:BrendaTissues . # thorax
+obo:BTO_0001369 rdfs:subClassOf bae:BrendaTissues . # vertebrate muscular system
+obo:BTO_0001372 rdfs:subClassOf bae:BrendaTissues . # thymocyte
+obo:BTO_0001374 rdfs:subClassOf bae:BrendaTissues . # thymus
+obo:BTO_0001376 rdfs:subClassOf bae:BrendaTissues . # thigh
+obo:BTO_0001379 rdfs:subClassOf bae:BrendaTissues . # thyroid gland
+obo:BTO_0001380 rdfs:subClassOf bae:BrendaTissues . # mesentery
+obo:BTO_0001382 rdfs:subClassOf bae:BrendaTissues . # tibialis anterior
+obo:BTO_0001383 rdfs:subClassOf bae:BrendaTissues . # alveolar bone
+obo:BTO_0001384 rdfs:subClassOf bae:BrendaTissues . # tissue culture
+obo:BTO_0001385 rdfs:subClassOf bae:BrendaTissues . # tongue
+obo:BTO_0001386 rdfs:subClassOf bae:BrendaTissues . # tongue muscle
+obo:BTO_0001387 rdfs:subClassOf bae:BrendaTissues . # tonsil
+obo:BTO_0001388 rdfs:subClassOf bae:BrendaTissues . # trachea
+obo:BTO_0001389 rdfs:subClassOf bae:BrendaTissues . # tracheal epithelium
+obo:BTO_0001391 rdfs:subClassOf bae:BrendaTissues . # tracheal smooth muscle
+obo:BTO_0001393 rdfs:subClassOf bae:BrendaTissues . # mesenchyme
+obo:BTO_0001395 rdfs:subClassOf bae:BrendaTissues . # trichome
+obo:BTO_0001396 rdfs:subClassOf bae:BrendaTissues . # trophosome tissue
+obo:BTO_0001397 rdfs:subClassOf bae:BrendaTissues . # trophozoite
+obo:BTO_0001398 rdfs:subClassOf bae:BrendaTissues . # trypomastigote
+obo:BTO_0001399 rdfs:subClassOf bae:BrendaTissues . # Tay-Sachs disease specific cell type
+obo:BTO_0001400 rdfs:subClassOf bae:BrendaTissues . # tuber
+obo:BTO_0001401 rdfs:subClassOf bae:BrendaTissues . # tuber cortex
+obo:BTO_0001402 rdfs:subClassOf bae:BrendaTissues . # urogenital ridge
+obo:BTO_0001403 rdfs:subClassOf bae:BrendaTissues . # gastrula
+obo:BTO_0001408 rdfs:subClassOf bae:BrendaTissues . # locus ceruleus
+obo:BTO_0001409 rdfs:subClassOf bae:BrendaTissues . # ureter
+obo:BTO_0001411 rdfs:subClassOf bae:BrendaTissues . # twig
+obo:BTO_0001415 rdfs:subClassOf bae:BrendaTissues . # umbilical cord
+obo:BTO_0001418 rdfs:subClassOf bae:BrendaTissues . # urinary bladder
+obo:BTO_0001419 rdfs:subClassOf bae:BrendaTissues . # urine
+obo:BTO_0001420 rdfs:subClassOf bae:BrendaTissues . # uropygial gland
+obo:BTO_0001421 rdfs:subClassOf bae:BrendaTissues . # uterine cervix
+obo:BTO_0001422 rdfs:subClassOf bae:BrendaTissues . # uterine endometrium
+obo:BTO_0001423 rdfs:subClassOf bae:BrendaTissues . # uterine lavage
+obo:BTO_0001424 rdfs:subClassOf bae:BrendaTissues . # uterus
+obo:BTO_0001426 rdfs:subClassOf bae:BrendaTissues . # urethra
+obo:BTO_0001427 rdfs:subClassOf bae:BrendaTissues . # vas deferens
+obo:BTO_0001428 rdfs:subClassOf bae:BrendaTissues . # breast epithelium
+obo:BTO_0001429 rdfs:subClassOf bae:BrendaTissues . # vascular bundle
+obo:BTO_0001431 rdfs:subClassOf bae:BrendaTissues . # vascular smooth muscle
+obo:BTO_0001432 rdfs:subClassOf bae:BrendaTissues . # vascular tissue
+obo:BTO_0001438 rdfs:subClassOf bae:BrendaTissues . # vena cava
+obo:BTO_0001439 rdfs:subClassOf bae:BrendaTissues . # venom
+obo:BTO_0001440 rdfs:subClassOf bae:BrendaTissues . # venom gland
+obo:BTO_0001442 rdfs:subClassOf bae:BrendaTissues . # brain ventricle
+obo:BTO_0001445 rdfs:subClassOf bae:BrendaTissues . # tail bud
+obo:BTO_0001446 rdfs:subClassOf bae:BrendaTissues . # olfactory cortex
+obo:BTO_0001447 rdfs:subClassOf bae:BrendaTissues . # forearm
+obo:BTO_0001448 rdfs:subClassOf bae:BrendaTissues . # visceral hump
+obo:BTO_0001450 rdfs:subClassOf bae:BrendaTissues . # vitelline membrane
+obo:BTO_0001451 rdfs:subClassOf bae:BrendaTissues . # vitreous humor
+obo:BTO_0001452 rdfs:subClassOf bae:BrendaTissues . # nasal nerve
+obo:BTO_0001453 rdfs:subClassOf bae:BrendaTissues . # detrusor
+obo:BTO_0001456 rdfs:subClassOf bae:BrendaTissues . # white adipose tissue
+obo:BTO_0001457 rdfs:subClassOf bae:BrendaTissues . # hip
+obo:BTO_0001458 rdfs:subClassOf bae:BrendaTissues . # apocrine sweat gland
+obo:BTO_0001461 rdfs:subClassOf bae:BrendaTissues . # whole plant
+obo:BTO_0001462 rdfs:subClassOf bae:BrendaTissues . # bladder wall
+obo:BTO_0001463 rdfs:subClassOf bae:BrendaTissues . # wing
+obo:BTO_0001464 rdfs:subClassOf bae:BrendaTissues . # wing disc
+obo:BTO_0001465 rdfs:subClassOf bae:BrendaTissues . # pericycle
+obo:BTO_0001467 rdfs:subClassOf bae:BrendaTissues . # mesocotyl
+obo:BTO_0001468 rdfs:subClassOf bae:BrendaTissues . # xylem
+obo:BTO_0001471 rdfs:subClassOf bae:BrendaTissues . # yolk sac
+obo:BTO_0001472 rdfs:subClassOf bae:BrendaTissues . # peritoneum
+obo:BTO_0001473 rdfs:subClassOf bae:BrendaTissues . # blastomere
+obo:BTO_0001477 rdfs:subClassOf bae:BrendaTissues . # photophore
+obo:BTO_0001484 rdfs:subClassOf bae:BrendaTissues . # nervous system
+obo:BTO_0001485 rdfs:subClassOf bae:BrendaTissues . # muscular system
+obo:BTO_0001486 rdfs:subClassOf bae:BrendaTissues . # skeletal system
+obo:BTO_0001487 rdfs:subClassOf bae:BrendaTissues . # adipose tissue
+obo:BTO_0001488 rdfs:subClassOf bae:BrendaTissues . # endocrine gland
+obo:BTO_0001491 rdfs:subClassOf bae:BrendaTissues . # viscus
+obo:BTO_0001492 rdfs:subClassOf bae:BrendaTissues . # limb
+obo:BTO_0001493 rdfs:subClassOf bae:BrendaTissues . # trunk
+obo:BTO_0001494 rdfs:subClassOf bae:BrendaTissues . # fungus
+obo:BTO_0001495 rdfs:subClassOf bae:BrendaTissues . # plumule
+obo:BTO_0001496 rdfs:subClassOf bae:BrendaTissues . # perivascular astrocyte
+obo:BTO_0001498 rdfs:subClassOf bae:BrendaTissues . # renal proximal tubule
+obo:BTO_0001499 rdfs:subClassOf bae:BrendaTissues . # tear
+obo:BTO_0001500 rdfs:subClassOf bae:BrendaTissues . # tendril
+obo:BTO_0001501 rdfs:subClassOf bae:BrendaTissues . # hair
+obo:BTO_0001502 rdfs:subClassOf bae:BrendaTissues . # hip joint
+obo:BTO_0001504 rdfs:subClassOf bae:BrendaTissues . # blastodisc
+obo:BTO_0001505 rdfs:subClassOf bae:BrendaTissues . # loin
+obo:BTO_0001506 rdfs:subClassOf bae:BrendaTissues . # radula
+obo:BTO_0001508 rdfs:subClassOf bae:BrendaTissues . # morula
+obo:BTO_0001509 rdfs:subClassOf bae:BrendaTissues . # umbilical vein
+obo:BTO_0001511 rdfs:subClassOf bae:BrendaTissues . # tooth germ
+obo:BTO_0001512 rdfs:subClassOf bae:BrendaTissues . # imago
+obo:BTO_0001513 rdfs:subClassOf bae:BrendaTissues . # biliary epithelium
+obo:BTO_0001528 rdfs:subClassOf bae:BrendaTissues . # B-lymphoblast
+obo:BTO_0001539 rdfs:subClassOf bae:BrendaTissues . # parenchyma
+obo:BTO_0001541 rdfs:subClassOf bae:BrendaTissues . # pronephros
+obo:BTO_0001542 rdfs:subClassOf bae:BrendaTissues . # mesonephron
+obo:BTO_0001543 rdfs:subClassOf bae:BrendaTissues . # metanephron
+obo:BTO_0001547 rdfs:subClassOf bae:BrendaTissues . # sepal
+obo:BTO_0001548 rdfs:subClassOf bae:BrendaTissues . # labial gland
+obo:BTO_0001551 rdfs:subClassOf bae:BrendaTissues . # free-living state
+obo:BTO_0001558 rdfs:subClassOf bae:BrendaTissues . # somite
+obo:BTO_0001559 rdfs:subClassOf bae:BrendaTissues . # stamen
+obo:BTO_0001564 rdfs:subClassOf bae:BrendaTissues . # rectus femoris
+obo:BTO_0001571 rdfs:subClassOf bae:BrendaTissues . # erythroblast
+obo:BTO_0001572 rdfs:subClassOf bae:BrendaTissues . # articular cartilage
+obo:BTO_0001578 rdfs:subClassOf bae:BrendaTissues . # esophageal epithelium
+obo:BTO_0001579 rdfs:subClassOf bae:BrendaTissues . # extraocular muscle
+obo:BTO_0001580 rdfs:subClassOf bae:BrendaTissues . # ejaculatory duct
+obo:BTO_0001592 rdfs:subClassOf bae:BrendaTissues . # meniscus
+obo:BTO_0001593 rdfs:subClassOf bae:BrendaTissues . # osteoblast
+obo:BTO_0001597 rdfs:subClassOf bae:BrendaTissues . # sapling
+obo:BTO_0001601 rdfs:subClassOf bae:BrendaTissues . # epicuticle
+obo:BTO_0001602 rdfs:subClassOf bae:BrendaTissues . # exocuticle
+obo:BTO_0001603 rdfs:subClassOf bae:BrendaTissues . # endocuticle
+obo:BTO_0001604 rdfs:subClassOf bae:BrendaTissues . # eyestalk
+obo:BTO_0001605 rdfs:subClassOf bae:BrendaTissues . # reticulum trabeculare
+obo:BTO_0001606 rdfs:subClassOf bae:BrendaTissues . # sclera
+obo:BTO_0001607 rdfs:subClassOf bae:BrendaTissues . # swim bladder
+obo:BTO_0001608 rdfs:subClassOf bae:BrendaTissues . # feather calamus
+obo:BTO_0001613 rdfs:subClassOf bae:BrendaTissues . # colorectum
+obo:BTO_0001624 rdfs:subClassOf bae:BrendaTissues . # femoral artery
+obo:BTO_0001626 rdfs:subClassOf bae:BrendaTissues . # laryngeal muscle
+obo:BTO_0001627 rdfs:subClassOf bae:BrendaTissues . # glottis
+obo:BTO_0001628 rdfs:subClassOf bae:BrendaTissues . # epiglottis
+obo:BTO_0001629 rdfs:subClassOf bae:BrendaTissues . # left ventricle
+obo:BTO_0001630 rdfs:subClassOf bae:BrendaTissues . # right ventricle
+obo:BTO_0001632 rdfs:subClassOf bae:BrendaTissues . # lens cortex
+obo:BTO_0001633 rdfs:subClassOf bae:BrendaTissues . # lens nucleus
+obo:BTO_0001634 rdfs:subClassOf bae:BrendaTissues . # leptomeninx
+obo:BTO_0001635 rdfs:subClassOf bae:BrendaTissues . # pia mater
+obo:BTO_0001636 rdfs:subClassOf bae:BrendaTissues . # arachnoid mater
+obo:BTO_0001638 rdfs:subClassOf bae:BrendaTissues . # blastema
+obo:BTO_0001640 rdfs:subClassOf bae:BrendaTissues . # limb bud
+obo:BTO_0001642 rdfs:subClassOf bae:BrendaTissues . # liver bud
+obo:BTO_0001643 rdfs:subClassOf bae:BrendaTissues . # lung bud
+obo:BTO_0001645 rdfs:subClassOf bae:BrendaTissues . # wing bud
+obo:BTO_0001646 rdfs:subClassOf bae:BrendaTissues . # ureteric bud
+obo:BTO_0001647 rdfs:subClassOf bae:BrendaTissues . # lip
+obo:BTO_0001648 rdfs:subClassOf bae:BrendaTissues . # longissimus
+obo:BTO_0001651 rdfs:subClassOf bae:BrendaTissues . # longissimus thoracis
+obo:BTO_0001652 rdfs:subClassOf bae:BrendaTissues . # sacrospinalis
+obo:BTO_0001653 rdfs:subClassOf bae:BrendaTissues . # lung epithelium
+obo:BTO_0001654 rdfs:subClassOf bae:BrendaTissues . # female cone
+obo:BTO_0001655 rdfs:subClassOf bae:BrendaTissues . # male cone
+obo:BTO_0001656 rdfs:subClassOf bae:BrendaTissues . # nerve cord
+obo:BTO_0001657 rdfs:subClassOf bae:BrendaTissues . # abscission zone
+obo:BTO_0001658 rdfs:subClassOf bae:BrendaTissues . # aerial part
+obo:BTO_0001659 rdfs:subClassOf bae:BrendaTissues . # aerial root
+obo:BTO_0001660 rdfs:subClassOf bae:BrendaTissues . # respiratory smooth muscle
+obo:BTO_0001662 rdfs:subClassOf bae:BrendaTissues . # allantoic fluid
+obo:BTO_0001663 rdfs:subClassOf bae:BrendaTissues . # ameloblast
+obo:BTO_0001679 rdfs:subClassOf bae:BrendaTissues . # Th2-cell
+obo:BTO_0001680 rdfs:subClassOf bae:BrendaTissues . # anus
+obo:BTO_0001681 rdfs:subClassOf bae:BrendaTissues . # anal sac
+obo:BTO_0001682 rdfs:subClassOf bae:BrendaTissues . # byssus
+obo:BTO_0001684 rdfs:subClassOf bae:BrendaTissues . # antler
+obo:BTO_0001685 rdfs:subClassOf bae:BrendaTissues . # aortic smooth muscle
+obo:BTO_0001686 rdfs:subClassOf bae:BrendaTissues . # joint
+obo:BTO_0001687 rdfs:subClassOf bae:BrendaTissues . # asynchronous muscle
+obo:BTO_0001688 rdfs:subClassOf bae:BrendaTissues . # cochlear ganglion
+obo:BTO_0001689 rdfs:subClassOf bae:BrendaTissues . # axillary bud
+obo:BTO_0001691 rdfs:subClassOf bae:BrendaTissues . # spiral organ
+obo:BTO_0001692 rdfs:subClassOf bae:BrendaTissues . # cochlear duct
+obo:BTO_0001693 rdfs:subClassOf bae:BrendaTissues . # modiolus
+obo:BTO_0001694 rdfs:subClassOf bae:BrendaTissues . # urinary bladder epithelium
+obo:BTO_0001695 rdfs:subClassOf bae:BrendaTissues . # blastopore
+obo:BTO_0001696 rdfs:subClassOf bae:BrendaTissues . # archenteron
+obo:BTO_0001697 rdfs:subClassOf bae:BrendaTissues . # olfactory gland
+obo:BTO_0001698 rdfs:subClassOf bae:BrendaTissues . # bulbourethral gland
+obo:BTO_0001699 rdfs:subClassOf bae:BrendaTissues . # bursa of Fabricius
+obo:BTO_0001700 rdfs:subClassOf bae:BrendaTissues . # cancellous bone
+obo:BTO_0001701 rdfs:subClassOf bae:BrendaTissues . # carapace
+obo:BTO_0001702 rdfs:subClassOf bae:BrendaTissues . # left atrium
+obo:BTO_0001703 rdfs:subClassOf bae:BrendaTissues . # right atrium
+obo:BTO_0001704 rdfs:subClassOf bae:BrendaTissues . # twitch muscle
+obo:BTO_0001705 rdfs:subClassOf bae:BrendaTissues . # vallate papilla
+obo:BTO_0001706 rdfs:subClassOf bae:BrendaTissues . # cnidoblast
+obo:BTO_0001707 rdfs:subClassOf bae:BrendaTissues . # coelom
+obo:BTO_0001708 rdfs:subClassOf bae:BrendaTissues . # coelomic fluid
+obo:BTO_0001709 rdfs:subClassOf bae:BrendaTissues . # colonic epithelium
+obo:BTO_0001711 rdfs:subClassOf bae:BrendaTissues . # melanophore
+obo:BTO_0001713 rdfs:subClassOf bae:BrendaTissues . # dorsum
+obo:BTO_0001715 rdfs:subClassOf bae:BrendaTissues . # ectoplacental cone
+obo:BTO_0001716 rdfs:subClassOf bae:BrendaTissues . # eggshell
+obo:BTO_0001718 rdfs:subClassOf bae:BrendaTissues . # embryoid body
+obo:BTO_0001719 rdfs:subClassOf bae:BrendaTissues . # claw
+obo:BTO_0001720 rdfs:subClassOf bae:BrendaTissues . # floor plate
+obo:BTO_0001721 rdfs:subClassOf bae:BrendaTissues . # sternal cartilage
+obo:BTO_0001722 rdfs:subClassOf bae:BrendaTissues . # enamel organ
+obo:BTO_0001724 rdfs:subClassOf bae:BrendaTissues . # ependymocyte
+obo:BTO_0001725 rdfs:subClassOf bae:BrendaTissues . # floral meristem
+obo:BTO_0001726 rdfs:subClassOf bae:BrendaTissues . # inflorescence meristem
+obo:BTO_0001727 rdfs:subClassOf bae:BrendaTissues . # perianth
+obo:BTO_0001728 rdfs:subClassOf bae:BrendaTissues . # tepal
+obo:BTO_0001729 rdfs:subClassOf bae:BrendaTissues . # forelimb
+obo:BTO_0001732 rdfs:subClassOf bae:BrendaTissues . # gastric antrum
+obo:BTO_0001733 rdfs:subClassOf bae:BrendaTissues . # gynoecium
+obo:BTO_0001734 rdfs:subClassOf bae:BrendaTissues . # gut juice
+obo:BTO_0001735 rdfs:subClassOf bae:BrendaTissues . # cardiac Purkinje fiber
+obo:BTO_0001739 rdfs:subClassOf bae:BrendaTissues . # pars tuberalis
+obo:BTO_0001740 rdfs:subClassOf bae:BrendaTissues . # hypopharynx
+obo:BTO_0001741 rdfs:subClassOf bae:BrendaTissues . # incisor
+obo:BTO_0001742 rdfs:subClassOf bae:BrendaTissues . # jejunal mucosa
+obo:BTO_0001743 rdfs:subClassOf bae:BrendaTissues . # jejunal epithelium
+obo:BTO_0001744 rdfs:subClassOf bae:BrendaTissues . # jugular vein
+obo:BTO_0001745 rdfs:subClassOf bae:BrendaTissues . # renal inner medulla
+obo:BTO_0001746 rdfs:subClassOf bae:BrendaTissues . # renal outer medulla
+obo:BTO_0001747 rdfs:subClassOf bae:BrendaTissues . # palpus
+obo:BTO_0001748 rdfs:subClassOf bae:BrendaTissues . # mandible
+obo:BTO_0001749 rdfs:subClassOf bae:BrendaTissues . # jaw
+obo:BTO_0001752 rdfs:subClassOf bae:BrendaTissues . # invertebrate mandible
+obo:BTO_0001753 rdfs:subClassOf bae:BrendaTissues . # mandibular organ
+obo:BTO_0001754 rdfs:subClassOf bae:BrendaTissues . # cheek
+obo:BTO_0001755 rdfs:subClassOf bae:BrendaTissues . # masseter
+obo:BTO_0001758 rdfs:subClassOf bae:BrendaTissues . # ocellus
+obo:BTO_0001759 rdfs:subClassOf bae:BrendaTissues . # molaris
+obo:BTO_0001760 rdfs:subClassOf bae:BrendaTissues . # myotube
+obo:BTO_0001761 rdfs:subClassOf bae:BrendaTissues . # nasal vestibule
+obo:BTO_0001762 rdfs:subClassOf bae:BrendaTissues . # neonate
+obo:BTO_0001763 rdfs:subClassOf bae:BrendaTissues . # neural arch
+obo:BTO_0001764 rdfs:subClassOf bae:BrendaTissues . # neural crest
+obo:BTO_0001765 rdfs:subClassOf bae:BrendaTissues . # neural plate
+obo:BTO_0001766 rdfs:subClassOf bae:BrendaTissues . # neurula
+obo:BTO_0001768 rdfs:subClassOf bae:BrendaTissues . # notochord
+obo:BTO_0001769 rdfs:subClassOf bae:BrendaTissues . # odontoblast
+obo:BTO_0001770 rdfs:subClassOf bae:BrendaTissues . # ciliary epithelium
+obo:BTO_0001772 rdfs:subClassOf bae:BrendaTissues . # olfactory organ
+obo:BTO_0001773 rdfs:subClassOf bae:BrendaTissues . # oocyst
+obo:BTO_0001775 rdfs:subClassOf bae:BrendaTissues . # oral epithelium
+obo:BTO_0001776 rdfs:subClassOf bae:BrendaTissues . # plant ovule
+obo:BTO_0001777 rdfs:subClassOf bae:BrendaTissues . # megasporangium
+obo:BTO_0001778 rdfs:subClassOf bae:BrendaTissues . # microsporangium
+obo:BTO_0001779 rdfs:subClassOf bae:BrendaTissues . # palate
+obo:BTO_0001782 rdfs:subClassOf bae:BrendaTissues . # peritoneal cavity
+obo:BTO_0001783 rdfs:subClassOf bae:BrendaTissues . # pulvinus
+obo:BTO_0001784 rdfs:subClassOf bae:BrendaTissues . # Peyer's gland
+obo:BTO_0001785 rdfs:subClassOf bae:BrendaTissues . # branchial arch
+obo:BTO_0001786 rdfs:subClassOf bae:BrendaTissues . # pheromone gland
+obo:BTO_0001787 rdfs:subClassOf bae:BrendaTissues . # pars distalis
+obo:BTO_0001788 rdfs:subClassOf bae:BrendaTissues . # pars intermedia
+obo:BTO_0001790 rdfs:subClassOf bae:BrendaTissues . # pleopod
+obo:BTO_0001791 rdfs:subClassOf bae:BrendaTissues . # pleura
+obo:BTO_0001792 rdfs:subClassOf bae:BrendaTissues . # portal vein
+obo:BTO_0001793 rdfs:subClassOf bae:BrendaTissues . # tectum mesencephali
+obo:BTO_0001794 rdfs:subClassOf bae:BrendaTissues . # posterior silk gland
+obo:BTO_0001795 rdfs:subClassOf bae:BrendaTissues . # anterior silk gland
+obo:BTO_0001796 rdfs:subClassOf bae:BrendaTissues . # preoptic area
+obo:BTO_0001798 rdfs:subClassOf bae:BrendaTissues . # prothallium
+obo:BTO_0001799 rdfs:subClassOf bae:BrendaTissues . # pulmonary vein
+obo:BTO_0001805 rdfs:subClassOf bae:BrendaTissues . # saccule
+obo:BTO_0001807 rdfs:subClassOf bae:BrendaTissues . # utricle
+obo:BTO_0001808 rdfs:subClassOf bae:BrendaTissues . # saphenous vein
+obo:BTO_0001809 rdfs:subClassOf bae:BrendaTissues . # scalp
+obo:BTO_0001811 rdfs:subClassOf bae:BrendaTissues . # seminiferous epithelium
+obo:BTO_0001813 rdfs:subClassOf bae:BrendaTissues . # fast twitch muscle fiber
+obo:BTO_0001814 rdfs:subClassOf bae:BrendaTissues . # leaf tip
+obo:BTO_0001815 rdfs:subClassOf bae:BrendaTissues . # stellate ganglion
+obo:BTO_0001816 rdfs:subClassOf bae:BrendaTissues . # stem nodule
+obo:BTO_0001818 rdfs:subClassOf bae:BrendaTissues . # stomach smooth muscle
+obo:BTO_0001819 rdfs:subClassOf bae:BrendaTissues . # stria vascularis
+obo:BTO_0001820 rdfs:subClassOf bae:BrendaTissues . # subcommissural organ
+obo:BTO_0001821 rdfs:subClassOf bae:BrendaTissues . # subesophageal ganglion
+obo:BTO_0001822 rdfs:subClassOf bae:BrendaTissues . # suprachiasmatic nucleus
+obo:BTO_0001823 rdfs:subClassOf bae:BrendaTissues . # synovium
+obo:BTO_0001826 rdfs:subClassOf bae:BrendaTissues . # T-lymphoblast
+obo:BTO_0001827 rdfs:subClassOf bae:BrendaTissues . # tail fin
+obo:BTO_0001828 rdfs:subClassOf bae:BrendaTissues . # tapetum lucidum
+obo:BTO_0001829 rdfs:subClassOf bae:BrendaTissues . # choroid
+obo:BTO_0001830 rdfs:subClassOf bae:BrendaTissues . # tassel
+obo:BTO_0001831 rdfs:subClassOf bae:BrendaTissues . # thoracic ganglion
+obo:BTO_0001832 rdfs:subClassOf bae:BrendaTissues . # sympathetic nervous system
+obo:BTO_0001833 rdfs:subClassOf bae:BrendaTissues . # parasympathetic nervous system
+obo:BTO_0001834 rdfs:subClassOf bae:BrendaTissues . # sympathetic chain
+obo:BTO_0001835 rdfs:subClassOf bae:BrendaTissues . # vertebral ganglion
+obo:BTO_0001836 rdfs:subClassOf bae:BrendaTissues . # thymic epithelium
+obo:BTO_0001837 rdfs:subClassOf bae:BrendaTissues . # serous gland
+obo:BTO_0001838 rdfs:subClassOf bae:BrendaTissues . # tooth bud
+obo:BTO_0001839 rdfs:subClassOf bae:BrendaTissues . # dental papilla
+obo:BTO_0001840 rdfs:subClassOf bae:BrendaTissues . # trophectoderm
+obo:BTO_0001841 rdfs:subClassOf bae:BrendaTissues . # parietal ganglion
+obo:BTO_0001842 rdfs:subClassOf bae:BrendaTissues . # pleural ganglion
+obo:BTO_0001843 rdfs:subClassOf bae:BrendaTissues . # cerebral ganglion
+obo:BTO_0001844 rdfs:subClassOf bae:BrendaTissues . # tooth enamel
+obo:BTO_0001845 rdfs:subClassOf bae:BrendaTissues . # bronchial epithelium
+obo:BTO_0001846 rdfs:subClassOf bae:BrendaTissues . # bronchial mucosa
+obo:BTO_0001847 rdfs:subClassOf bae:BrendaTissues . # umbilical smooth muscle
+obo:BTO_0001848 rdfs:subClassOf bae:BrendaTissues . # urophysis
+obo:BTO_0001849 rdfs:subClassOf bae:BrendaTissues . # urinary bladder smooth muscle
+obo:BTO_0001850 rdfs:subClassOf bae:BrendaTissues . # portio vaginalis cervicis
+obo:BTO_0001852 rdfs:subClassOf bae:BrendaTissues . # cerebrovascular endothelium
+obo:BTO_0001853 rdfs:subClassOf bae:BrendaTissues . # vascular endothelium
+obo:BTO_0001855 rdfs:subClassOf bae:BrendaTissues . # venom duct
+obo:BTO_0001856 rdfs:subClassOf bae:BrendaTissues . # vestibular labyrinth
+obo:BTO_0001857 rdfs:subClassOf bae:BrendaTissues . # visual cortex
+obo:BTO_0001858 rdfs:subClassOf bae:BrendaTissues . # dermal papilla
+obo:BTO_0001859 rdfs:subClassOf bae:BrendaTissues . # wart
+obo:BTO_0001862 rdfs:subClassOf bae:BrendaTissues . # nucleus accumbens
+obo:BTO_0001863 rdfs:subClassOf bae:BrendaTissues . # body wall muscle
+obo:BTO_0001866 rdfs:subClassOf bae:BrendaTissues . # bronchiolar epithelium
+obo:BTO_0001868 rdfs:subClassOf bae:BrendaTissues . # occipital pole
+obo:BTO_0001871 rdfs:subClassOf bae:BrendaTissues . # synganglion
+obo:BTO_0001873 rdfs:subClassOf bae:BrendaTissues . # lens epithelium
+obo:BTO_0001886 rdfs:subClassOf bae:BrendaTissues . # primordium
+obo:BTO_0001887 rdfs:subClassOf bae:BrendaTissues . # heart primordium
+obo:BTO_0001893 rdfs:subClassOf bae:BrendaTissues . # ring stage
+obo:BTO_0001899 rdfs:subClassOf bae:BrendaTissues . # stationary phase culture
+obo:BTO_0001901 rdfs:subClassOf bae:BrendaTissues . # death phase culture
+obo:BTO_0001902 rdfs:subClassOf bae:BrendaTissues . # lag phase culture
+obo:BTO_0001903 rdfs:subClassOf bae:BrendaTissues . # logarithmic phase culture
+obo:BTO_0001905 rdfs:subClassOf bae:BrendaTissues . # tail muscle
+obo:BTO_0001906 rdfs:subClassOf bae:BrendaTissues . # cephalothorax
+obo:BTO_0001919 rdfs:subClassOf bae:BrendaTissues . # tube foot
+obo:BTO_0001921 rdfs:subClassOf bae:BrendaTissues . # compound eye
+obo:BTO_0001922 rdfs:subClassOf bae:BrendaTissues . # ommatidium
+obo:BTO_0001925 rdfs:subClassOf bae:BrendaTissues . # longissimus lumborum
+obo:BTO_0001940 rdfs:subClassOf bae:BrendaTissues . # cardiomyoblast
+obo:BTO_0001942 rdfs:subClassOf bae:BrendaTissues . # mandibular incisor
+obo:BTO_0001943 rdfs:subClassOf bae:BrendaTissues . # corneocyte
+obo:BTO_0001946 rdfs:subClassOf bae:BrendaTissues . # myofibroblast
+obo:BTO_0001953 rdfs:subClassOf bae:BrendaTissues . # tanycyte
+obo:BTO_0001954 rdfs:subClassOf bae:BrendaTissues . # median eminence
+obo:BTO_0001965 rdfs:subClassOf bae:BrendaTissues . # carcass
+obo:BTO_0001978 rdfs:subClassOf bae:BrendaTissues . # anal canal
+obo:BTO_0001979 rdfs:subClassOf bae:BrendaTissues . # mucous gland
+obo:BTO_0001980 rdfs:subClassOf bae:BrendaTissues . # sebaceous gland
+obo:BTO_0001981 rdfs:subClassOf bae:BrendaTissues . # sebum
+obo:BTO_0001982 rdfs:subClassOf bae:BrendaTissues . # chemostat culture
+obo:BTO_0001997 rdfs:subClassOf bae:BrendaTissues . # arteriole
+obo:BTO_0002009 rdfs:subClassOf bae:BrendaTissues . # artery wall
+obo:BTO_0002012 rdfs:subClassOf bae:BrendaTissues . # tunica intima vasorum
+obo:BTO_0002017 rdfs:subClassOf bae:BrendaTissues . # plant reproductive system
+obo:BTO_0002018 rdfs:subClassOf bae:BrendaTissues . # corpus cavernosum clitoridis
+obo:BTO_0002019 rdfs:subClassOf bae:BrendaTissues . # corpus cavernosum penis
+obo:BTO_0002020 rdfs:subClassOf bae:BrendaTissues . # clitoris
+obo:BTO_0002038 rdfs:subClassOf bae:BrendaTissues . # osteocyte
+obo:BTO_0002045 rdfs:subClassOf bae:BrendaTissues . # capillary
+obo:BTO_0002046 rdfs:subClassOf bae:BrendaTissues . # spermatozoid
+obo:BTO_0002051 rdfs:subClassOf bae:BrendaTissues . # preosteoblast
+obo:BTO_0002053 rdfs:subClassOf bae:BrendaTissues . # seminal vesicle fluid
+obo:BTO_0002056 rdfs:subClassOf bae:BrendaTissues . # siphon
+obo:BTO_0002065 rdfs:subClassOf bae:BrendaTissues . # venom apparatus
+obo:BTO_0002066 rdfs:subClassOf bae:BrendaTissues . # venom sac
+obo:BTO_0002067 rdfs:subClassOf bae:BrendaTissues . # stinger
+obo:BTO_0002068 rdfs:subClassOf bae:BrendaTissues . # scent gland
+obo:BTO_0002069 rdfs:subClassOf bae:BrendaTissues . # wax gland
+obo:BTO_0002072 rdfs:subClassOf bae:BrendaTissues . # squamous epithelium
+obo:BTO_0002073 rdfs:subClassOf bae:BrendaTissues . # pavement epithelium
+obo:BTO_0002074 rdfs:subClassOf bae:BrendaTissues . # stratified epithelium
+obo:BTO_0002075 rdfs:subClassOf bae:BrendaTissues . # mesenchymal epithelium
+obo:BTO_0002082 rdfs:subClassOf bae:BrendaTissues . # subdural space
+obo:BTO_0002083 rdfs:subClassOf bae:BrendaTissues . # perilymphatic space
+obo:BTO_0002084 rdfs:subClassOf bae:BrendaTissues . # anterior chamber of the eye
+obo:BTO_0002085 rdfs:subClassOf bae:BrendaTissues . # chamber of the eye
+obo:BTO_0002086 rdfs:subClassOf bae:BrendaTissues . # posterior chamber of the eye
+obo:BTO_0002087 rdfs:subClassOf bae:BrendaTissues . # vitreous chamber of the eye
+obo:BTO_0002096 rdfs:subClassOf bae:BrendaTissues . # nasal cavity
+obo:BTO_0002097 rdfs:subClassOf bae:BrendaTissues . # pharyngeal cavity
+obo:BTO_0002098 rdfs:subClassOf bae:BrendaTissues . # tympanum
+obo:BTO_0002099 rdfs:subClassOf bae:BrendaTissues . # middle ear
+obo:BTO_0002100 rdfs:subClassOf bae:BrendaTissues . # outer ear
+obo:BTO_0002105 rdfs:subClassOf bae:BrendaTissues . # perisympathetic organ
+obo:BTO_0002106 rdfs:subClassOf bae:BrendaTissues . # neurohemal organ
+obo:BTO_0002107 rdfs:subClassOf bae:BrendaTissues . # submucosa
+obo:BTO_0002119 rdfs:subClassOf bae:BrendaTissues . # spikelet
+obo:BTO_0002120 rdfs:subClassOf bae:BrendaTissues . # pyloric cecum
+obo:BTO_0002121 rdfs:subClassOf bae:BrendaTissues . # pyloric stomach
+obo:BTO_0002122 rdfs:subClassOf bae:BrendaTissues . # cardiac stomach
+obo:BTO_0002123 rdfs:subClassOf bae:BrendaTissues . # primitive endoderm
+obo:BTO_0002124 rdfs:subClassOf bae:BrendaTissues . # ampulla
+obo:BTO_0002125 rdfs:subClassOf bae:BrendaTissues . # water vascular system
+obo:BTO_0002149 rdfs:subClassOf bae:BrendaTissues . # gill raker
+obo:BTO_0002150 rdfs:subClassOf bae:BrendaTissues . # gill filament
+obo:BTO_0002152 rdfs:subClassOf bae:BrendaTissues . # gill arch
+obo:BTO_0002155 rdfs:subClassOf bae:BrendaTissues . # ceratobranchial
+obo:BTO_0002156 rdfs:subClassOf bae:BrendaTissues . # hypobranchial
+obo:BTO_0002157 rdfs:subClassOf bae:BrendaTissues . # endochondral bone
+obo:BTO_0002168 rdfs:subClassOf bae:BrendaTissues . # juvenile
+obo:BTO_0002169 rdfs:subClassOf bae:BrendaTissues . # anterior commissure
+obo:BTO_0002173 rdfs:subClassOf bae:BrendaTissues . # tubercle
+obo:BTO_0002191 rdfs:subClassOf bae:BrendaTissues . # fibre tract
+obo:BTO_0002217 rdfs:subClassOf bae:BrendaTissues . # culture supernatant
+obo:BTO_0002222 rdfs:subClassOf bae:BrendaTissues . # bract
+obo:BTO_0002224 rdfs:subClassOf bae:BrendaTissues . # cheek pouch
+obo:BTO_0002233 rdfs:subClassOf bae:BrendaTissues . # culture fluid
+obo:BTO_0002240 rdfs:subClassOf bae:BrendaTissues . # exodermis
+obo:BTO_0002241 rdfs:subClassOf bae:BrendaTissues . # eyelid
+obo:BTO_0002243 rdfs:subClassOf bae:BrendaTissues . # hypanthium
+obo:BTO_0002244 rdfs:subClassOf bae:BrendaTissues . # flower stalk
+obo:BTO_0002246 rdfs:subClassOf bae:BrendaTissues . # globus pallidus
+obo:BTO_0002249 rdfs:subClassOf bae:BrendaTissues . # cervical canal
+obo:BTO_0002250 rdfs:subClassOf bae:BrendaTissues . # nucleus lentiformis
+obo:BTO_0002252 rdfs:subClassOf bae:BrendaTissues . # subthalamic nucleus
+obo:BTO_0002254 rdfs:subClassOf bae:BrendaTissues . # vas efferens
+obo:BTO_0002272 rdfs:subClassOf bae:BrendaTissues . # merozoite
+obo:BTO_0002273 rdfs:subClassOf bae:BrendaTissues . # ileocecum
+obo:BTO_0002275 rdfs:subClassOf bae:BrendaTissues . # lateral hypodermal chord
+obo:BTO_0002277 rdfs:subClassOf bae:BrendaTissues . # melanotroph
+obo:BTO_0002294 rdfs:subClassOf bae:BrendaTissues . # solid substrate culture
+obo:BTO_0002295 rdfs:subClassOf bae:BrendaTissues . # podocyte
+obo:BTO_0002297 rdfs:subClassOf bae:BrendaTissues . # renal glomerular capsule
+obo:BTO_0002298 rdfs:subClassOf bae:BrendaTissues . # inferior olivary complex
+obo:BTO_0002299 rdfs:subClassOf bae:BrendaTissues . # oliva
+obo:BTO_0002302 rdfs:subClassOf bae:BrendaTissues . # inferior mesenteric artery
+obo:BTO_0002303 rdfs:subClassOf bae:BrendaTissues . # superior mesenteric artery
+obo:BTO_0002304 rdfs:subClassOf bae:BrendaTissues . # protoscolex
+obo:BTO_0002305 rdfs:subClassOf bae:BrendaTissues . # scolex
+obo:BTO_0002308 rdfs:subClassOf bae:BrendaTissues . # myoepithelium
+obo:BTO_0002310 rdfs:subClassOf bae:BrendaTissues . # mammary myoepithelium
+obo:BTO_0002317 rdfs:subClassOf bae:BrendaTissues . # slow muscle
+obo:BTO_0002318 rdfs:subClassOf bae:BrendaTissues . # fast muscle
+obo:BTO_0002319 rdfs:subClassOf bae:BrendaTissues . # skeletal muscle fiber
+obo:BTO_0002323 rdfs:subClassOf bae:BrendaTissues . # eccrine sweat gland
+obo:BTO_0002324 rdfs:subClassOf bae:BrendaTissues . # merocrine gland
+obo:BTO_0002325 rdfs:subClassOf bae:BrendaTissues . # holocrine gland
+obo:BTO_0002328 rdfs:subClassOf bae:BrendaTissues . # ventral nerve cord
+obo:BTO_0002329 rdfs:subClassOf bae:BrendaTissues . # dorsal nerve cord
+obo:BTO_0002330 rdfs:subClassOf bae:BrendaTissues . # lamina propria
+obo:BTO_0002340 rdfs:subClassOf bae:BrendaTissues . # plant collar
+obo:BTO_0002342 rdfs:subClassOf bae:BrendaTissues . # bradyzoite
+obo:BTO_0002343 rdfs:subClassOf bae:BrendaTissues . # tarsal bone
+obo:BTO_0002344 rdfs:subClassOf bae:BrendaTissues . # electrocyte
+obo:BTO_0002345 rdfs:subClassOf bae:BrendaTissues . # hindlimb
+obo:BTO_0002346 rdfs:subClassOf bae:BrendaTissues . # fibula
+obo:BTO_0002347 rdfs:subClassOf bae:BrendaTissues . # metatarsal bone
+obo:BTO_0002348 rdfs:subClassOf bae:BrendaTissues . # toe
+obo:BTO_0002349 rdfs:subClassOf bae:BrendaTissues . # hallux
+obo:BTO_0002354 rdfs:subClassOf bae:BrendaTissues . # talus
+obo:BTO_0002355 rdfs:subClassOf bae:BrendaTissues . # calcaneal bone
+obo:BTO_0002356 rdfs:subClassOf bae:BrendaTissues . # navicular bone
+obo:BTO_0002357 rdfs:subClassOf bae:BrendaTissues . # cuboid bone
+obo:BTO_0002360 rdfs:subClassOf bae:BrendaTissues . # medial cuneiform bone
+obo:BTO_0002362 rdfs:subClassOf bae:BrendaTissues . # pancreatic duct
+obo:BTO_0002364 rdfs:subClassOf bae:BrendaTissues . # gastric pit
+obo:BTO_0002366 rdfs:subClassOf bae:BrendaTissues . # extravillous trophoblast
+obo:BTO_0002370 rdfs:subClassOf bae:BrendaTissues . # colleterial gland
+obo:BTO_0002375 rdfs:subClassOf bae:BrendaTissues . # bronchiole
+obo:BTO_0002376 rdfs:subClassOf bae:BrendaTissues . # duodenal gland
+obo:BTO_0002397 rdfs:subClassOf bae:BrendaTissues . # prostate gland epithelium
+obo:BTO_0002407 rdfs:subClassOf bae:BrendaTissues . # spermary
+obo:BTO_0002417 rdfs:subClassOf bae:BrendaTissues . # helper T-lymphocyte
+obo:BTO_0002422 rdfs:subClassOf bae:BrendaTissues . # mesothelium
+obo:BTO_0002433 rdfs:subClassOf bae:BrendaTissues . # genital primordium
+obo:BTO_0002434 rdfs:subClassOf bae:BrendaTissues . # dorsal raphe nucleus
+obo:BTO_0002435 rdfs:subClassOf bae:BrendaTissues . # colorectal mucosa
+obo:BTO_0002436 rdfs:subClassOf bae:BrendaTissues . # myenteric plexus
+obo:BTO_0002437 rdfs:subClassOf bae:BrendaTissues . # enteric plexus
+obo:BTO_0002441 rdfs:subClassOf bae:BrendaTissues . # pericyte
+obo:BTO_0002444 rdfs:subClassOf bae:BrendaTissues . # basal forebrain
+obo:BTO_0002445 rdfs:subClassOf bae:BrendaTissues . # diagonal band
+obo:BTO_0002446 rdfs:subClassOf bae:BrendaTissues . # medial septum
+obo:BTO_0002448 rdfs:subClassOf bae:BrendaTissues . # basal telencephalon
+obo:BTO_0002450 rdfs:subClassOf bae:BrendaTissues . # anterior hypothalamic nucleus
+obo:BTO_0002451 rdfs:subClassOf bae:BrendaTissues . # dorsal hypothalamic nucleus
+obo:BTO_0002452 rdfs:subClassOf bae:BrendaTissues . # thalamic nucleus
+obo:BTO_0002459 rdfs:subClassOf bae:BrendaTissues . # nucleus reuniens
+obo:BTO_0002462 rdfs:subClassOf bae:BrendaTissues . # posterior nuclear complex of thalamus
+obo:BTO_0002473 rdfs:subClassOf bae:BrendaTissues . # infundibular nucleus
+obo:BTO_0002477 rdfs:subClassOf bae:BrendaTissues . # cecal epithelium
+obo:BTO_0002480 rdfs:subClassOf bae:BrendaTissues . # plume
+obo:BTO_0002483 rdfs:subClassOf bae:BrendaTissues . # interventricular septum
+obo:BTO_0002485 rdfs:subClassOf bae:BrendaTissues . # atrial appendage
+obo:BTO_0002486 rdfs:subClassOf bae:BrendaTissues . # lupulin gland
+obo:BTO_0002487 rdfs:subClassOf bae:BrendaTissues . # metacyclic form
+obo:BTO_0002492 rdfs:subClassOf bae:BrendaTissues . # vestimentum
+obo:BTO_0002494 rdfs:subClassOf bae:BrendaTissues . # mesangium
+obo:BTO_0002495 rdfs:subClassOf bae:BrendaTissues . # cerebral gyrus
+obo:BTO_0002501 rdfs:subClassOf bae:BrendaTissues . # trabecula
+obo:BTO_0002502 rdfs:subClassOf bae:BrendaTissues . # kinetoplastid
+obo:BTO_0002503 rdfs:subClassOf bae:BrendaTissues . # protozoan form
+obo:BTO_0002506 rdfs:subClassOf bae:BrendaTissues . # enteric nervous system
+obo:BTO_0002507 rdfs:subClassOf bae:BrendaTissues . # autonomic nervous system
+obo:BTO_0002516 rdfs:subClassOf bae:BrendaTissues . # odontoclast
+obo:BTO_0002525 rdfs:subClassOf bae:BrendaTissues . # cementum
+obo:BTO_0002536 rdfs:subClassOf bae:BrendaTissues . # feather vane
+obo:BTO_0002543 rdfs:subClassOf bae:BrendaTissues . # alveolar wall
+obo:BTO_0002608 rdfs:subClassOf bae:BrendaTissues . # vomeronasal organ
+obo:BTO_0002611 rdfs:subClassOf bae:BrendaTissues . # axopodium
+obo:BTO_0002613 rdfs:subClassOf bae:BrendaTissues . # lobopodium
+obo:BTO_0002614 rdfs:subClassOf bae:BrendaTissues . # reticulopodium
+obo:BTO_0002616 rdfs:subClassOf bae:BrendaTissues . # turion
+obo:BTO_0002617 rdfs:subClassOf bae:BrendaTissues . # thyroid nodule
+obo:BTO_0002619 rdfs:subClassOf bae:BrendaTissues . # posterior adductor muscle
+obo:BTO_0002621 rdfs:subClassOf bae:BrendaTissues . # spinal muscle
+obo:BTO_0002626 rdfs:subClassOf bae:BrendaTissues . # venule
+obo:BTO_0002631 rdfs:subClassOf bae:BrendaTissues . # glume
+obo:BTO_0002643 rdfs:subClassOf bae:BrendaTissues . # cortical collecting duct
+obo:BTO_0002651 rdfs:subClassOf bae:BrendaTissues . # piriform area
+obo:BTO_0002655 rdfs:subClassOf bae:BrendaTissues . # postlarva
+obo:BTO_0002660 rdfs:subClassOf bae:BrendaTissues . # inflorescence stalk
+obo:BTO_0002661 rdfs:subClassOf bae:BrendaTissues . # auditory vesicle
+obo:BTO_0002670 rdfs:subClassOf bae:BrendaTissues . # medial geniculate nucleus
+obo:BTO_0002674 rdfs:subClassOf bae:BrendaTissues . # medial geniculate body
+obo:BTO_0002675 rdfs:subClassOf bae:BrendaTissues . # mushroom body
+obo:BTO_0002678 rdfs:subClassOf bae:BrendaTissues . # testicular vein
+obo:BTO_0002681 rdfs:subClassOf bae:BrendaTissues . # renal vein
+obo:BTO_0002682 rdfs:subClassOf bae:BrendaTissues . # inferior vena cava
+obo:BTO_0002683 rdfs:subClassOf bae:BrendaTissues . # superior vena cava
+obo:BTO_0002684 rdfs:subClassOf bae:BrendaTissues . # lymphoid follicle
+obo:BTO_0002689 rdfs:subClassOf bae:BrendaTissues . # oviductal fluid
+obo:BTO_0002690 rdfs:subClassOf bae:BrendaTissues . # biofilm
+obo:BTO_0002697 rdfs:subClassOf bae:BrendaTissues . # supraoptic nucleus
+obo:BTO_0002698 rdfs:subClassOf bae:BrendaTissues . # bed nucleus of stria terminalis
+obo:BTO_0002699 rdfs:subClassOf bae:BrendaTissues . # lateral habenular nucleus
+obo:BTO_0002702 rdfs:subClassOf bae:BrendaTissues . # medial amygdaloid nucleus
+obo:BTO_0002704 rdfs:subClassOf bae:BrendaTissues . # lateral amygdaloid nucleus
+obo:BTO_0002705 rdfs:subClassOf bae:BrendaTissues . # septal area
+obo:BTO_0002738 rdfs:subClassOf bae:BrendaTissues . # cement gland
+obo:BTO_0002742 rdfs:subClassOf bae:BrendaTissues . # gynecophoral canal
+obo:BTO_0002743 rdfs:subClassOf bae:BrendaTissues . # schistosomulum
+obo:BTO_0002774 rdfs:subClassOf bae:BrendaTissues . # amyloid plaque
+obo:BTO_0002776 rdfs:subClassOf bae:BrendaTissues . # inflorescence apex
+obo:BTO_0002778 rdfs:subClassOf bae:BrendaTissues . # rostral ventrolateral medulla
+obo:BTO_0002780 rdfs:subClassOf bae:BrendaTissues . # visceral muscle
+obo:BTO_0002784 rdfs:subClassOf bae:BrendaTissues . # corpus albicans
+obo:BTO_0002807 rdfs:subClassOf bae:BrendaTissues . # prefrontal cortex
+obo:BTO_0002811 rdfs:subClassOf bae:BrendaTissues . # flag leaf
+obo:BTO_0002819 rdfs:subClassOf bae:BrendaTissues . # decidua basalis
+obo:BTO_0002840 rdfs:subClassOf bae:BrendaTissues . # bile ductule
+obo:BTO_0002841 rdfs:subClassOf bae:BrendaTissues . # bile canaliculus
+obo:BTO_0002845 rdfs:subClassOf bae:BrendaTissues . # mammary duct
+obo:BTO_0002851 rdfs:subClassOf bae:BrendaTissues . # theca interna
+obo:BTO_0002852 rdfs:subClassOf bae:BrendaTissues . # theca externa
+obo:BTO_0002854 rdfs:subClassOf bae:BrendaTissues . # corn silk
+obo:BTO_0002855 rdfs:subClassOf bae:BrendaTissues . # hepatic cecum
+obo:BTO_0002856 rdfs:subClassOf bae:BrendaTissues . # coelomocyte
+obo:BTO_0002857 rdfs:subClassOf bae:BrendaTissues . # eleocyte
+obo:BTO_0002858 rdfs:subClassOf bae:BrendaTissues . # cerebral subcortex
+obo:BTO_0002859 rdfs:subClassOf bae:BrendaTissues . # esophageal mucosa
+obo:BTO_0002860 rdfs:subClassOf bae:BrendaTissues . # oral mucosa
+obo:BTO_0002879 rdfs:subClassOf bae:BrendaTissues . # chorionic plate
+obo:BTO_0002925 rdfs:subClassOf bae:BrendaTissues . # tracheobronchial epithelium
+obo:BTO_0002930 rdfs:subClassOf bae:BrendaTissues . # fascia
+obo:BTO_0002934 rdfs:subClassOf bae:BrendaTissues . # thymic cortex
+obo:BTO_0002977 rdfs:subClassOf bae:BrendaTissues . # exocrine glandular secretion
+obo:BTO_0002978 rdfs:subClassOf bae:BrendaTissues . # internal secretion
+obo:BTO_0002984 rdfs:subClassOf bae:BrendaTissues . # antropyloric mucosa
+obo:BTO_0002990 rdfs:subClassOf bae:BrendaTissues . # gastric ulcer
+obo:BTO_0002991 rdfs:subClassOf bae:BrendaTissues . # glandular epithelium
+obo:BTO_0002994 rdfs:subClassOf bae:BrendaTissues . # lacteal cyst
+obo:BTO_0002996 rdfs:subClassOf bae:BrendaTissues . # cavernous artery
+obo:BTO_0003002 rdfs:subClassOf bae:BrendaTissues . # endocervix
+obo:BTO_0003003 rdfs:subClassOf bae:BrendaTissues . # epididymal fluid
+obo:BTO_0003015 rdfs:subClassOf bae:BrendaTissues . # macula lutea
+obo:BTO_0003048 rdfs:subClassOf bae:BrendaTissues . # neurolemma
+obo:BTO_0003080 rdfs:subClassOf bae:BrendaTissues . # pleural fluid
+obo:BTO_0003082 rdfs:subClassOf bae:BrendaTissues . # uterine epithelium
+obo:BTO_0003083 rdfs:subClassOf bae:BrendaTissues . # uterine wall
+obo:BTO_0003084 rdfs:subClassOf bae:BrendaTissues . # vaginal fluid
+obo:BTO_0003086 rdfs:subClassOf bae:BrendaTissues . # rosette leaf
+obo:BTO_0003087 rdfs:subClassOf bae:BrendaTissues . # subiculum
+obo:BTO_0003090 rdfs:subClassOf bae:BrendaTissues . # subventricular zone
+obo:BTO_0003091 rdfs:subClassOf bae:BrendaTissues . # urogenital system
+obo:BTO_0003092 rdfs:subClassOf bae:BrendaTissues . # urinary system
+obo:BTO_0003093 rdfs:subClassOf bae:BrendaTissues . # cardiofibroblast
+obo:BTO_0003094 rdfs:subClassOf bae:BrendaTissues . # secondary oocyte
+obo:BTO_0003095 rdfs:subClassOf bae:BrendaTissues . # normoblast
+obo:BTO_0003096 rdfs:subClassOf bae:BrendaTissues . # internal male genital organ
+obo:BTO_0003098 rdfs:subClassOf bae:BrendaTissues . # scrotum
+obo:BTO_0003101 rdfs:subClassOf bae:BrendaTissues . # female pudendum
+obo:BTO_0003102 rdfs:subClassOf bae:BrendaTissues . # pyramidal neuron
+obo:BTO_0003104 rdfs:subClassOf bae:BrendaTissues . # pro-B-lymphocyte
+obo:BTO_0003114 rdfs:subClassOf bae:BrendaTissues . # wound fluid
+obo:BTO_0003115 rdfs:subClassOf bae:BrendaTissues . # major vestibular gland
+obo:BTO_0003116 rdfs:subClassOf bae:BrendaTissues . # minor vestibular gland
+obo:BTO_0003118 rdfs:subClassOf bae:BrendaTissues . # glans penis
+obo:BTO_0003120 rdfs:subClassOf bae:BrendaTissues . # atherosclerotic plaque
+obo:BTO_0003121 rdfs:subClassOf bae:BrendaTissues . # villus
+obo:BTO_0003132 rdfs:subClassOf bae:BrendaTissues . # microsporidian
+obo:BTO_0003135 rdfs:subClassOf bae:BrendaTissues . # zona pellucida
+obo:BTO_0003141 rdfs:subClassOf bae:BrendaTissues . # true leaf
+obo:BTO_0003143 rdfs:subClassOf bae:BrendaTissues . # coculture
+obo:BTO_0003144 rdfs:subClassOf bae:BrendaTissues . # neuron-oligodendrocyte coculture
+obo:BTO_0003145 rdfs:subClassOf bae:BrendaTissues . # vestibulum vaginae
+obo:BTO_0003146 rdfs:subClassOf bae:BrendaTissues . # zona incerta
+obo:BTO_0003149 rdfs:subClassOf bae:BrendaTissues . # interalveolar septum
+obo:BTO_0003153 rdfs:subClassOf bae:BrendaTissues . # perineurium
+obo:BTO_0003155 rdfs:subClassOf bae:BrendaTissues . # pleural mesothelium
+obo:BTO_0003156 rdfs:subClassOf bae:BrendaTissues . # peritoneal mesothelium
+obo:BTO_0003163 rdfs:subClassOf bae:BrendaTissues . # prostatic urethra
+obo:BTO_0003164 rdfs:subClassOf bae:BrendaTissues . # cholangiocyte
+obo:BTO_0003168 rdfs:subClassOf bae:BrendaTissues . # cysticercus
+obo:BTO_0003173 rdfs:subClassOf bae:BrendaTissues . # endostyle
+obo:BTO_0003174 rdfs:subClassOf bae:BrendaTissues . # outer plexiform layer
+obo:BTO_0003175 rdfs:subClassOf bae:BrendaTissues . # inner plexiform layer
+obo:BTO_0003176 rdfs:subClassOf bae:BrendaTissues . # inner nuclear layer
+obo:BTO_0003177 rdfs:subClassOf bae:BrendaTissues . # semimembranosus
+obo:BTO_0003178 rdfs:subClassOf bae:BrendaTissues . # biceps
+obo:BTO_0003217 rdfs:subClassOf bae:BrendaTissues . # melanoblast
+obo:BTO_0003222 rdfs:subClassOf bae:BrendaTissues . # respiratory bronchiole
+obo:BTO_0003223 rdfs:subClassOf bae:BrendaTissues . # terminal bronchiole
+obo:BTO_0003248 rdfs:subClassOf bae:BrendaTissues . # brain endothelium
+obo:BTO_0003256 rdfs:subClassOf bae:BrendaTissues . # corpus amylaceum
+obo:BTO_0003257 rdfs:subClassOf bae:BrendaTissues . # granulation tissue
+obo:BTO_0003271 rdfs:subClassOf bae:BrendaTissues . # great saphenous vein
+obo:BTO_0003272 rdfs:subClassOf bae:BrendaTissues . # small saphenous vein
+obo:BTO_0003305 rdfs:subClassOf bae:BrendaTissues . # epipodite
+obo:BTO_0003358 rdfs:subClassOf bae:BrendaTissues . # groin
+obo:BTO_0003359 rdfs:subClassOf bae:BrendaTissues . # neointima
+obo:BTO_0003360 rdfs:subClassOf bae:BrendaTissues . # extraembryonic tissue
+obo:BTO_0003361 rdfs:subClassOf bae:BrendaTissues . # anterior visceral endoderm
+obo:BTO_0003364 rdfs:subClassOf bae:BrendaTissues . # gingival fluid
+obo:BTO_0003365 rdfs:subClassOf bae:BrendaTissues . # germinated grain
+obo:BTO_0003367 rdfs:subClassOf bae:BrendaTissues . # daphnid
+obo:BTO_0003368 rdfs:subClassOf bae:BrendaTissues . # frontal gland
+obo:BTO_0003369 rdfs:subClassOf bae:BrendaTissues . # face
+obo:BTO_0003370 rdfs:subClassOf bae:BrendaTissues . # craniofacial region
+obo:BTO_0003372 rdfs:subClassOf bae:BrendaTissues . # gametophore
+obo:BTO_0003374 rdfs:subClassOf bae:BrendaTissues . # antheridium
+obo:BTO_0003375 rdfs:subClassOf bae:BrendaTissues . # archegonium
+obo:BTO_0003377 rdfs:subClassOf bae:BrendaTissues . # periderm
+obo:BTO_0003378 rdfs:subClassOf bae:BrendaTissues . # phellem
+obo:BTO_0003380 rdfs:subClassOf bae:BrendaTissues . # phelloderm
+obo:BTO_0003381 rdfs:subClassOf bae:BrendaTissues . # vestibular system
+obo:BTO_0003382 rdfs:subClassOf bae:BrendaTissues . # inner ear vestibulum
+obo:BTO_0003383 rdfs:subClassOf bae:BrendaTissues . # semicircular canal
+obo:BTO_0003385 rdfs:subClassOf bae:BrendaTissues . # etiolated plant tissue
+obo:BTO_0003386 rdfs:subClassOf bae:BrendaTissues . # hypoglossal nerve
+obo:BTO_0003387 rdfs:subClassOf bae:BrendaTissues . # raphe nucleus
+obo:BTO_0003388 rdfs:subClassOf bae:BrendaTissues . # tegmentum
+obo:BTO_0003389 rdfs:subClassOf bae:BrendaTissues . # nidopallium
+obo:BTO_0003390 rdfs:subClassOf bae:BrendaTissues . # high vocal center
+obo:BTO_0003391 rdfs:subClassOf bae:BrendaTissues . # hepatic primordium
+obo:BTO_0003394 rdfs:subClassOf bae:BrendaTissues . # Brockmann body
+obo:BTO_0003396 rdfs:subClassOf bae:BrendaTissues . # pontine nucleus
+obo:BTO_0003398 rdfs:subClassOf bae:BrendaTissues . # ganglion cell layer
+obo:BTO_0003399 rdfs:subClassOf bae:BrendaTissues . # avian pallium
+obo:BTO_0003400 rdfs:subClassOf bae:BrendaTissues . # hyperpallium
+obo:BTO_0003401 rdfs:subClassOf bae:BrendaTissues . # subpallium
+obo:BTO_0003405 rdfs:subClassOf bae:BrendaTissues . # mesopallium
+obo:BTO_0003408 rdfs:subClassOf bae:BrendaTissues . # arcopallium
+obo:BTO_0003411 rdfs:subClassOf bae:BrendaTissues . # nucleus isthmo-opticus
+obo:BTO_0003412 rdfs:subClassOf bae:BrendaTissues . # rostral migratory stream
+obo:BTO_0003415 rdfs:subClassOf bae:BrendaTissues . # conjunctiva
+obo:BTO_0003418 rdfs:subClassOf bae:BrendaTissues . # biceps femoris
+obo:BTO_0003419 rdfs:subClassOf bae:BrendaTissues . # biceps brachii
+obo:BTO_0003425 rdfs:subClassOf bae:BrendaTissues . # area postrema
+obo:BTO_0003426 rdfs:subClassOf bae:BrendaTissues . # fourth ventricle
+obo:BTO_0003427 rdfs:subClassOf bae:BrendaTissues . # Barrett's esophagus
+obo:BTO_0003433 rdfs:subClassOf bae:BrendaTissues . # endometrial gland
+obo:BTO_0003434 rdfs:subClassOf bae:BrendaTissues . # choanomastigote
+obo:BTO_0003445 rdfs:subClassOf bae:BrendaTissues . # carotid atherosclerotic plaque
+obo:BTO_0003446 rdfs:subClassOf bae:BrendaTissues . # cholesteatoma tissue
+obo:BTO_0003447 rdfs:subClassOf bae:BrendaTissues . # cavum septum pellucidum
+obo:BTO_0003448 rdfs:subClassOf bae:BrendaTissues . # septum pellucidum
+obo:BTO_0003453 rdfs:subClassOf bae:BrendaTissues . # dentin
+obo:BTO_0003454 rdfs:subClassOf bae:BrendaTissues . # eosinophilic myelocyte
+obo:BTO_0003455 rdfs:subClassOf bae:BrendaTissues . # neutrophilic myelocyte
+obo:BTO_0003462 rdfs:subClassOf bae:BrendaTissues . # outer dental epithelium
+obo:BTO_0003463 rdfs:subClassOf bae:BrendaTissues . # inner dental epithelium
+obo:BTO_0003472 rdfs:subClassOf bae:BrendaTissues . # vagus nerve
+obo:BTO_0003487 rdfs:subClassOf bae:BrendaTissues . # visceral endoderm
+obo:BTO_0003488 rdfs:subClassOf bae:BrendaTissues . # vibrissa
+obo:BTO_0003489 rdfs:subClassOf bae:BrendaTissues . # vibrissal follicle
+obo:BTO_0003490 rdfs:subClassOf bae:BrendaTissues . # vestibulocochlear nerve
+obo:BTO_0003509 rdfs:subClassOf bae:BrendaTissues . # headfoot
+obo:BTO_0003594 rdfs:subClassOf bae:BrendaTissues . # hypnozoite
+obo:BTO_0003595 rdfs:subClassOf bae:BrendaTissues . # knee
+obo:BTO_0003603 rdfs:subClassOf bae:BrendaTissues . # respiratory mucus
+obo:BTO_0003604 rdfs:subClassOf bae:BrendaTissues . # renal parenchyma
+obo:BTO_0003606 rdfs:subClassOf bae:BrendaTissues . # airway fluid
+obo:BTO_0003607 rdfs:subClassOf bae:BrendaTissues . # chondroblast
+obo:BTO_0003616 rdfs:subClassOf bae:BrendaTissues . # peritoneal dialysis fluid
+obo:BTO_0003617 rdfs:subClassOf bae:BrendaTissues . # peritoneal exudate
+obo:BTO_0003623 rdfs:subClassOf bae:BrendaTissues . # uterine fluid
+obo:BTO_0003625 rdfs:subClassOf bae:BrendaTissues . # intervertebral disc
+obo:BTO_0003626 rdfs:subClassOf bae:BrendaTissues . # nucleus pulposus
+obo:BTO_0003627 rdfs:subClassOf bae:BrendaTissues . # annulus fibrosus
+obo:BTO_0003632 rdfs:subClassOf bae:BrendaTissues . # cervicovaginal fluid
+obo:BTO_0003634 rdfs:subClassOf bae:BrendaTissues . # esophageal gland
+obo:BTO_0003647 rdfs:subClassOf bae:BrendaTissues . # olfactory tract
+obo:BTO_0003648 rdfs:subClassOf bae:BrendaTissues . # olfactory nerve
+obo:BTO_0003649 rdfs:subClassOf bae:BrendaTissues . # anterior olfactory nucleus
+obo:BTO_0003650 rdfs:subClassOf bae:BrendaTissues . # optic ganglion
+obo:BTO_0003653 rdfs:subClassOf bae:BrendaTissues . # olfactory glomerulus
+obo:BTO_0003654 rdfs:subClassOf bae:BrendaTissues . # ventricular zone
+obo:BTO_0003655 rdfs:subClassOf bae:BrendaTissues . # thyroid cartilage
+obo:BTO_0003657 rdfs:subClassOf bae:BrendaTissues . # tergal gland
+obo:BTO_0003658 rdfs:subClassOf bae:BrendaTissues . # tergal gland secretion
+obo:BTO_0003660 rdfs:subClassOf bae:BrendaTissues . # laryngeal cartilage
+obo:BTO_0003661 rdfs:subClassOf bae:BrendaTissues . # ovary epithelium
+obo:BTO_0003662 rdfs:subClassOf bae:BrendaTissues . # nucleus recessus lateralis
+obo:BTO_0003668 rdfs:subClassOf bae:BrendaTissues . # leaf bud
+obo:BTO_0003669 rdfs:subClassOf bae:BrendaTissues . # keloid
+obo:BTO_0003670 rdfs:subClassOf bae:BrendaTissues . # microfilarial stage
+obo:BTO_0003671 rdfs:subClassOf bae:BrendaTissues . # germinal center
+obo:BTO_0003673 rdfs:subClassOf bae:BrendaTissues . # nephrotome
+obo:BTO_0003674 rdfs:subClassOf bae:BrendaTissues . # temporomandibular joint
+obo:BTO_0003678 rdfs:subClassOf bae:BrendaTissues . # placental disc
+obo:BTO_0003684 rdfs:subClassOf bae:BrendaTissues . # habenula
+obo:BTO_0003686 rdfs:subClassOf bae:BrendaTissues . # medial habenular nucleus
+obo:BTO_0003698 rdfs:subClassOf bae:BrendaTissues . # coronary atherosclerotic plaque
+obo:BTO_0003702 rdfs:subClassOf bae:BrendaTissues . # rheumatoid arthritis disease specific synovial tissue
+obo:BTO_0003703 rdfs:subClassOf bae:BrendaTissues . # rheumatoid arthritis disease specific fibroblast-like synoviocyte
+obo:BTO_0003705 rdfs:subClassOf bae:BrendaTissues . # cornu ammonis
+obo:BTO_0003717 rdfs:subClassOf bae:BrendaTissues . # vesicular gland
+obo:BTO_0003718 rdfs:subClassOf bae:BrendaTissues . # vasculature
+obo:BTO_0003737 rdfs:subClassOf bae:BrendaTissues . # tailbud stage
+obo:BTO_0003738 rdfs:subClassOf bae:BrendaTissues . # tenia tecta
+obo:BTO_0003747 rdfs:subClassOf bae:BrendaTissues . # superficial temporal artery
+obo:BTO_0003748 rdfs:subClassOf bae:BrendaTissues . # superficial temporal vein
+obo:BTO_0003749 rdfs:subClassOf bae:BrendaTissues . # pars compacta
+obo:BTO_0003750 rdfs:subClassOf bae:BrendaTissues . # pars reticulata
+obo:BTO_0003751 rdfs:subClassOf bae:BrendaTissues . # submucosal gland
+obo:BTO_0003752 rdfs:subClassOf bae:BrendaTissues . # lamina epithelialis mucosa
+obo:BTO_0003785 rdfs:subClassOf bae:BrendaTissues . # ray floret
+obo:BTO_0003787 rdfs:subClassOf bae:BrendaTissues . # intraparietal sulcus
+obo:BTO_0003788 rdfs:subClassOf bae:BrendaTissues . # splenial gyrus
+obo:BTO_0003791 rdfs:subClassOf bae:BrendaTissues . # glandular stomach
+obo:BTO_0003794 rdfs:subClassOf bae:BrendaTissues . # chlorenchyma
+obo:BTO_0003799 rdfs:subClassOf bae:BrendaTissues . # secretory trichome
+obo:BTO_0003801 rdfs:subClassOf bae:BrendaTissues . # ovum
+obo:BTO_0003802 rdfs:subClassOf bae:BrendaTissues . # macrogamete
+obo:BTO_0003805 rdfs:subClassOf bae:BrendaTissues . # alpha-motoneuron
+obo:BTO_0003810 rdfs:subClassOf bae:BrendaTissues . # enrichment culture
+obo:BTO_0003811 rdfs:subClassOf bae:BrendaTissues . # interneuron
+obo:BTO_0003833 rdfs:subClassOf bae:BrendaTissues . # buccal mucosa
+obo:BTO_0003834 rdfs:subClassOf bae:BrendaTissues . # conceptus
+obo:BTO_0003835 rdfs:subClassOf bae:BrendaTissues . # cerebellar nucleus
+obo:BTO_0003840 rdfs:subClassOf bae:BrendaTissues . # cerebrovascular system
+obo:BTO_0003844 rdfs:subClassOf bae:BrendaTissues . # inferior olivary nucleus
+obo:BTO_0003852 rdfs:subClassOf bae:BrendaTissues . # astroglia
+obo:BTO_0003867 rdfs:subClassOf bae:BrendaTissues . # deutocerebrum
+obo:BTO_0003868 rdfs:subClassOf bae:BrendaTissues . # protocerebrum
+obo:BTO_0003869 rdfs:subClassOf bae:BrendaTissues . # tritocerebrum
+obo:BTO_0003870 rdfs:subClassOf bae:BrendaTissues . # insect tracheal system
+obo:BTO_0003876 rdfs:subClassOf bae:BrendaTissues . # plant funiculus
+obo:BTO_0003882 rdfs:subClassOf bae:BrendaTissues . # blastocyte
+obo:BTO_0003906 rdfs:subClassOf bae:BrendaTissues . # uroepithelium
+obo:BTO_0003914 rdfs:subClassOf bae:BrendaTissues . # interstitial cell of Cajal
+obo:BTO_0003915 rdfs:subClassOf bae:BrendaTissues . # hairy root culture
+obo:BTO_0003925 rdfs:subClassOf bae:BrendaTissues . # renal papilla
+obo:BTO_0003926 rdfs:subClassOf bae:BrendaTissues . # renal pyramid
+obo:BTO_0003927 rdfs:subClassOf bae:BrendaTissues . # metacercaria
+obo:BTO_0003938 rdfs:subClassOf bae:BrendaTissues . # leaf disc
+obo:BTO_0003940 rdfs:subClassOf bae:BrendaTissues . # macula densa
+obo:BTO_0003948 rdfs:subClassOf bae:BrendaTissues . # distal tubular epithelium
+obo:BTO_0003951 rdfs:subClassOf bae:BrendaTissues . # medial longitudinal fasciculus
+obo:BTO_0003953 rdfs:subClassOf bae:BrendaTissues . # endomesoderm
+obo:BTO_0003954 rdfs:subClassOf bae:BrendaTissues . # dopaminergic system
+obo:BTO_0003963 rdfs:subClassOf bae:BrendaTissues . # nucleus solitarius
+obo:BTO_0003969 rdfs:subClassOf bae:BrendaTissues . # hair follicle outer root sheath
+obo:BTO_0003971 rdfs:subClassOf bae:BrendaTissues . # hair follicle inner root sheath
+obo:BTO_0003975 rdfs:subClassOf bae:BrendaTissues . # cingulate cortex
+obo:BTO_0003976 rdfs:subClassOf bae:BrendaTissues . # cingulate gyrus
+obo:BTO_0003977 rdfs:subClassOf bae:BrendaTissues . # retrosplenial region
+obo:BTO_0003987 rdfs:subClassOf bae:BrendaTissues . # root culture
+obo:BTO_0003994 rdfs:subClassOf bae:BrendaTissues . # hoof
+obo:BTO_0004014 rdfs:subClassOf bae:BrendaTissues . # embryonic cerebral cortex
+obo:BTO_0004024 rdfs:subClassOf bae:BrendaTissues . # neural cord
+obo:BTO_0004032 rdfs:subClassOf bae:BrendaTissues . # dopaminergic neuron
+obo:BTO_0004033 rdfs:subClassOf bae:BrendaTissues . # catecholaminergic neuron
+obo:BTO_0004041 rdfs:subClassOf bae:BrendaTissues . # abdominal adipose tissue
+obo:BTO_0004042 rdfs:subClassOf bae:BrendaTissues . # subcutaneous adipose tissue
+obo:BTO_0004043 rdfs:subClassOf bae:BrendaTissues . # intramuscular adipose tissue
+obo:BTO_0004045 rdfs:subClassOf bae:BrendaTissues . # air pouch
+obo:BTO_0004046 rdfs:subClassOf bae:BrendaTissues . # alveolar mucosa
+obo:BTO_0004047 rdfs:subClassOf bae:BrendaTissues . # apical hook
+obo:BTO_0004048 rdfs:subClassOf bae:BrendaTissues . # aril
+obo:BTO_0004053 rdfs:subClassOf bae:BrendaTissues . # umbilical cord blood
+obo:BTO_0004057 rdfs:subClassOf bae:BrendaTissues . # fruit juice
+obo:BTO_0004060 rdfs:subClassOf bae:BrendaTissues . # fibroblast-like synoviocyte
+obo:BTO_0004064 rdfs:subClassOf bae:BrendaTissues . # chloragocyte
+obo:BTO_0004074 rdfs:subClassOf bae:BrendaTissues . # cystocyte
+obo:BTO_0004084 rdfs:subClassOf bae:BrendaTissues . # epitrochlearis muscle
+obo:BTO_0004089 rdfs:subClassOf bae:BrendaTissues . # male urethra
+obo:BTO_0004101 rdfs:subClassOf bae:BrendaTissues . # fascicle
+obo:BTO_0004102 rdfs:subClassOf bae:BrendaTissues . # cerebral cortical neuron
+obo:BTO_0004103 rdfs:subClassOf bae:BrendaTissues . # leaf primordium
+obo:BTO_0004104 rdfs:subClassOf bae:BrendaTissues . # insect labium
+obo:BTO_0004107 rdfs:subClassOf bae:BrendaTissues . # antral mucosa
+obo:BTO_0004110 rdfs:subClassOf bae:BrendaTissues . # pyloric mucosa
+obo:BTO_0004128 rdfs:subClassOf bae:BrendaTissues . # lung endothelium
+obo:BTO_0004140 rdfs:subClassOf bae:BrendaTissues . # ethmoid bone
+obo:BTO_0004141 rdfs:subClassOf bae:BrendaTissues . # cribriform plate
+obo:BTO_0004147 rdfs:subClassOf bae:BrendaTissues . # lumbar spine
+obo:BTO_0004148 rdfs:subClassOf bae:BrendaTissues . # cervical spine
+obo:BTO_0004150 rdfs:subClassOf bae:BrendaTissues . # thoracic spine
+obo:BTO_0004165 rdfs:subClassOf bae:BrendaTissues . # meibomian gland
+obo:BTO_0004185 rdfs:subClassOf bae:BrendaTissues . # olfactory receptor neuron
+obo:BTO_0004195 rdfs:subClassOf bae:BrendaTissues . # pharyngeal organ
+obo:BTO_0004198 rdfs:subClassOf bae:BrendaTissues . # prostomium
+obo:BTO_0004209 rdfs:subClassOf bae:BrendaTissues . # seed vessel
+obo:BTO_0004211 rdfs:subClassOf bae:BrendaTissues . # sensillum trichodeum
+obo:BTO_0004212 rdfs:subClassOf bae:BrendaTissues . # seta
+obo:BTO_0004224 rdfs:subClassOf bae:BrendaTissues . # stomodeum
+obo:BTO_0004235 rdfs:subClassOf bae:BrendaTissues . # uterine horn
+obo:BTO_0004241 rdfs:subClassOf bae:BrendaTissues . # ovariole
+obo:BTO_0004242 rdfs:subClassOf bae:BrendaTissues . # vitellarium
+obo:BTO_0004249 rdfs:subClassOf bae:BrendaTissues . # anterior cingulate cortex
+obo:BTO_0004250 rdfs:subClassOf bae:BrendaTissues . # posterior cingulate cortex
+obo:BTO_0004253 rdfs:subClassOf bae:BrendaTissues . # plant candle
+obo:BTO_0004256 rdfs:subClassOf bae:BrendaTissues . # long bone
+obo:BTO_0004271 rdfs:subClassOf bae:BrendaTissues . # hyalocyte
+obo:BTO_0004280 rdfs:subClassOf bae:BrendaTissues . # peptonephridium
+obo:BTO_0004285 rdfs:subClassOf bae:BrendaTissues . # oviductal ampulla
+obo:BTO_0004291 rdfs:subClassOf bae:BrendaTissues . # umbilical vein smooth muscle
+obo:BTO_0004292 rdfs:subClassOf bae:BrendaTissues . # claustrum
+obo:BTO_0004304 rdfs:subClassOf bae:BrendaTissues . # cell lysate
+obo:BTO_0004305 rdfs:subClassOf bae:BrendaTissues . # hairy root
+obo:BTO_0004307 rdfs:subClassOf bae:BrendaTissues . # hepatic artery
+obo:BTO_0004342 rdfs:subClassOf bae:BrendaTissues . # agranular insular cortex
+obo:BTO_0004343 rdfs:subClassOf bae:BrendaTissues . # auditory cortex
+obo:BTO_0004345 rdfs:subClassOf bae:BrendaTissues . # entorhinal cortex
+obo:BTO_0004346 rdfs:subClassOf bae:BrendaTissues . # medial entorhinal cortex
+obo:BTO_0004347 rdfs:subClassOf bae:BrendaTissues . # lateral entorhinal cortex
+obo:BTO_0004348 rdfs:subClassOf bae:BrendaTissues . # motor cortex
+obo:BTO_0004353 rdfs:subClassOf bae:BrendaTissues . # somatosensory cortex
+obo:BTO_0004354 rdfs:subClassOf bae:BrendaTissues . # postcentral gyrus
+obo:BTO_0004355 rdfs:subClassOf bae:BrendaTissues . # perirhinal cortex
+obo:BTO_0004358 rdfs:subClassOf bae:BrendaTissues . # sinus node
+obo:BTO_0004359 rdfs:subClassOf bae:BrendaTissues . # paw
+obo:BTO_0004361 rdfs:subClassOf bae:BrendaTissues . # callus culture
+obo:BTO_0004362 rdfs:subClassOf bae:BrendaTissues . # colon muscle
+obo:BTO_0004364 rdfs:subClassOf bae:BrendaTissues . # gastroesophageal junction
+obo:BTO_0004366 rdfs:subClassOf bae:BrendaTissues . # lateral geniculate nucleus
+obo:BTO_0004367 rdfs:subClassOf bae:BrendaTissues . # lateral geniculate body
+obo:BTO_0004368 rdfs:subClassOf bae:BrendaTissues . # vestibular nucleus
+obo:BTO_0004370 rdfs:subClassOf bae:BrendaTissues . # lateral vestibular nucleus
+obo:BTO_0004371 rdfs:subClassOf bae:BrendaTissues . # medial vestibular nucleus
+obo:BTO_0004372 rdfs:subClassOf bae:BrendaTissues . # superior vestibular nucleus
+obo:BTO_0004373 rdfs:subClassOf bae:BrendaTissues . # ventral posterior nucleus
+obo:BTO_0004377 rdfs:subClassOf bae:BrendaTissues . # pup
+obo:BTO_0004378 rdfs:subClassOf bae:BrendaTissues . # blood vessel wall
+obo:BTO_0004379 rdfs:subClassOf bae:BrendaTissues . # parahippocampal region
+obo:BTO_0004380 rdfs:subClassOf bae:BrendaTissues . # parahippocampal gyrus
+obo:BTO_0004381 rdfs:subClassOf bae:BrendaTissues . # prelimbic cortex
+obo:BTO_0004382 rdfs:subClassOf bae:BrendaTissues . # skin epithelium
+obo:BTO_0004383 rdfs:subClassOf bae:BrendaTissues . # follicular fluid
+obo:BTO_0004385 rdfs:subClassOf bae:BrendaTissues . # cardinal vein
+obo:BTO_0004387 rdfs:subClassOf bae:BrendaTissues . # anterior cardinal vein
+obo:BTO_0004388 rdfs:subClassOf bae:BrendaTissues . # common cardinal vein
+obo:BTO_0004395 rdfs:subClassOf bae:BrendaTissues . # microvessel
+obo:BTO_0004396 rdfs:subClassOf bae:BrendaTissues . # femorotibial joint
+obo:BTO_0004418 rdfs:subClassOf bae:BrendaTissues . # Daltons lymphoma ascites
+obo:BTO_0004419 rdfs:subClassOf bae:BrendaTissues . # dermal fibroblast
+obo:BTO_0004421 rdfs:subClassOf bae:BrendaTissues . # salivary gland epithelium
+obo:BTO_0004422 rdfs:subClassOf bae:BrendaTissues . # pleural cavity
+obo:BTO_0004423 rdfs:subClassOf bae:BrendaTissues . # empyema fluid
+obo:BTO_0004425 rdfs:subClassOf bae:BrendaTissues . # stratum granulosum cerebelli
+obo:BTO_0004477 rdfs:subClassOf bae:BrendaTissues . # medial temporal lobe
+obo:BTO_0004480 rdfs:subClassOf bae:BrendaTissues . # nasopharynx epithelium
+obo:BTO_0004483 rdfs:subClassOf bae:BrendaTissues . # ovarian surface epithelium
+obo:BTO_0004496 rdfs:subClassOf bae:BrendaTissues . # preosteoclast
+obo:BTO_0004502 rdfs:subClassOf bae:BrendaTissues . # vascular cambium
+obo:BTO_0004503 rdfs:subClassOf bae:BrendaTissues . # submerged culture
+obo:BTO_0004518 rdfs:subClassOf bae:BrendaTissues . # uterine gland
+obo:BTO_0004520 rdfs:subClassOf bae:BrendaTissues . # regulatory T-lymphocyte
+obo:BTO_0004524 rdfs:subClassOf bae:BrendaTissues . # germinal epithelium
+obo:BTO_0004525 rdfs:subClassOf bae:BrendaTissues . # subcutaneous tissue
+obo:BTO_0004527 rdfs:subClassOf bae:BrendaTissues . # uterine luminal fluid
+obo:BTO_0004528 rdfs:subClassOf bae:BrendaTissues . # high endothelial venule
+obo:BTO_0004536 rdfs:subClassOf bae:BrendaTissues . # medullary collecting duct
+obo:BTO_0004538 rdfs:subClassOf bae:BrendaTissues . # initial collecting tubule
+obo:BTO_0004539 rdfs:subClassOf bae:BrendaTissues . # connecting tubule
+obo:BTO_0004544 rdfs:subClassOf bae:BrendaTissues . # inner medullary collecting duct
+obo:BTO_0004549 rdfs:subClassOf bae:BrendaTissues . # superficial inguinal lymph node
+obo:BTO_0004554 rdfs:subClassOf bae:BrendaTissues . # parotid gland duct
+obo:BTO_0004556 rdfs:subClassOf bae:BrendaTissues . # submandibular gland duct
+obo:BTO_0004560 rdfs:subClassOf bae:BrendaTissues . # thymic medulla
+obo:BTO_0004565 rdfs:subClassOf bae:BrendaTissues . # thymic medullary epithelium
+obo:BTO_0004569 rdfs:subClassOf bae:BrendaTissues . # ovarian fluid
+obo:BTO_0004570 rdfs:subClassOf bae:BrendaTissues . # ulcer tissue
+obo:BTO_0004579 rdfs:subClassOf bae:BrendaTissues . # parenchyma of thyroid gland
+obo:BTO_0004586 rdfs:subClassOf bae:BrendaTissues . # alevin
+obo:BTO_0004593 rdfs:subClassOf bae:BrendaTissues . # epiblast
+obo:BTO_0004597 rdfs:subClassOf bae:BrendaTissues . # nephrocyte
+obo:BTO_0004608 rdfs:subClassOf bae:BrendaTissues . # Henles loop
+obo:BTO_0004617 rdfs:subClassOf bae:BrendaTissues . # mucilage
+obo:BTO_0004628 rdfs:subClassOf bae:BrendaTissues . # aortic valve
+obo:BTO_0004629 rdfs:subClassOf bae:BrendaTissues . # metaphloem
+obo:BTO_0004630 rdfs:subClassOf bae:BrendaTissues . # middle midgut
+obo:BTO_0004634 rdfs:subClassOf bae:BrendaTissues . # thoracico-abdominal ganglion
+obo:BTO_0004638 rdfs:subClassOf bae:BrendaTissues . # peribronchial gland
+obo:BTO_0004642 rdfs:subClassOf bae:BrendaTissues . # abductor
+obo:BTO_0004650 rdfs:subClassOf bae:BrendaTissues . # dorsal fin
+obo:BTO_0004651 rdfs:subClassOf bae:BrendaTissues . # pelvic fin
+obo:BTO_0004652 rdfs:subClassOf bae:BrendaTissues . # anal fin
+obo:BTO_0004653 rdfs:subClassOf bae:BrendaTissues . # pectoral fin
+obo:BTO_0004657 rdfs:subClassOf bae:BrendaTissues . # premonocyte
+obo:BTO_0004658 rdfs:subClassOf bae:BrendaTissues . # imaginal disc
+obo:BTO_0004659 rdfs:subClassOf bae:BrendaTissues . # exoskeleton
+obo:BTO_0004665 rdfs:subClassOf bae:BrendaTissues . # iliac artery
+obo:BTO_0004666 rdfs:subClassOf bae:BrendaTissues . # external iliac artery
+obo:BTO_0004667 rdfs:subClassOf bae:BrendaTissues . # internal iliac artery
+obo:BTO_0004668 rdfs:subClassOf bae:BrendaTissues . # hand
+obo:BTO_0004669 rdfs:subClassOf bae:BrendaTissues . # finger
+obo:BTO_0004670 rdfs:subClassOf bae:BrendaTissues . # interdigit
+obo:BTO_0004671 rdfs:subClassOf bae:BrendaTissues . # hair medulla
+obo:BTO_0004672 rdfs:subClassOf bae:BrendaTissues . # hair shaft
+obo:BTO_0004673 rdfs:subClassOf bae:BrendaTissues . # dorsal aorta
+obo:BTO_0004674 rdfs:subClassOf bae:BrendaTissues . # ventral aorta
+obo:BTO_0004676 rdfs:subClassOf bae:BrendaTissues . # cerebral peduncle
+obo:BTO_0004679 rdfs:subClassOf bae:BrendaTissues . # capillary pericyte
+obo:BTO_0004680 rdfs:subClassOf bae:BrendaTissues . # stratum basale
+obo:BTO_0004681 rdfs:subClassOf bae:BrendaTissues . # bursa copulatrix
+obo:BTO_0004684 rdfs:subClassOf bae:BrendaTissues . # genital pore
+obo:BTO_0004685 rdfs:subClassOf bae:BrendaTissues . # bony labyrinth
+obo:BTO_0004687 rdfs:subClassOf bae:BrendaTissues . # orbit
+obo:BTO_0004688 rdfs:subClassOf bae:BrendaTissues . # regio orbitalis
+obo:BTO_0004689 rdfs:subClassOf bae:BrendaTissues . # external gill
+obo:BTO_0004690 rdfs:subClassOf bae:BrendaTissues . # arterial system
+obo:BTO_0004691 rdfs:subClassOf bae:BrendaTissues . # hippocampus minor
+obo:BTO_0004692 rdfs:subClassOf bae:BrendaTissues . # venous system
+obo:BTO_0004693 rdfs:subClassOf bae:BrendaTissues . # regio parietalis capitis
+obo:BTO_0004695 rdfs:subClassOf bae:BrendaTissues . # aortic root
+obo:BTO_0004696 rdfs:subClassOf bae:BrendaTissues . # external carotid artery
+obo:BTO_0004697 rdfs:subClassOf bae:BrendaTissues . # internal carotid artery
+obo:BTO_0004698 rdfs:subClassOf bae:BrendaTissues . # regio oralis
+obo:BTO_0004700 rdfs:subClassOf bae:BrendaTissues . # anterior pharynx
+obo:BTO_0004701 rdfs:subClassOf bae:BrendaTissues . # dorsal striatum
+obo:BTO_0004702 rdfs:subClassOf bae:BrendaTissues . # ventral striatum
+obo:BTO_0004703 rdfs:subClassOf bae:BrendaTissues . # striate cortex
+obo:BTO_0004704 rdfs:subClassOf bae:BrendaTissues . # extrastriate cortex
+obo:BTO_0004705 rdfs:subClassOf bae:BrendaTissues . # connecting stalk
+obo:BTO_0004706 rdfs:subClassOf bae:BrendaTissues . # ankle joint
+obo:BTO_0004708 rdfs:subClassOf bae:BrendaTissues . # thyroid follicle
+obo:BTO_0004709 rdfs:subClassOf bae:BrendaTissues . # thyroid primordium
+obo:BTO_0004711 rdfs:subClassOf bae:BrendaTissues . # head capsule
+obo:BTO_0004714 rdfs:subClassOf bae:BrendaTissues . # palatine tonsil
+obo:BTO_0004719 rdfs:subClassOf bae:BrendaTissues . # excretory canal
+obo:BTO_0004724 rdfs:subClassOf bae:BrendaTissues . # animal cap
+obo:BTO_0004725 rdfs:subClassOf bae:BrendaTissues . # embryonic fibroblast
+obo:BTO_0004726 rdfs:subClassOf bae:BrendaTissues . # embryonic brain
+obo:BTO_0004727 rdfs:subClassOf bae:BrendaTissues . # larval brain
+obo:BTO_0004728 rdfs:subClassOf bae:BrendaTissues . # rheumatoid arthritis disease specific synovial fluid
+obo:BTO_0004729 rdfs:subClassOf bae:BrendaTissues . # peripheral blood lymphocyte
+obo:BTO_0004732 rdfs:subClassOf bae:BrendaTissues . # bone marrow-derived macrophage
+obo:BTO_0004733 rdfs:subClassOf bae:BrendaTissues . # gravid adult
+obo:BTO_0004756 rdfs:subClassOf bae:BrendaTissues . # venous endothelium
+obo:BTO_0004757 rdfs:subClassOf bae:BrendaTissues . # arterial endothelium
+obo:BTO_0004769 rdfs:subClassOf bae:BrendaTissues . # teratocyte
+obo:BTO_0004776 rdfs:subClassOf bae:BrendaTissues . # striatonigral neuron
+obo:BTO_0004778 rdfs:subClassOf bae:BrendaTissues . # medium spiny neuron
+obo:BTO_0004789 rdfs:subClassOf bae:BrendaTissues . # ruminal fluid
+obo:BTO_0004791 rdfs:subClassOf bae:BrendaTissues . # root primordium
+obo:BTO_0004797 rdfs:subClassOf bae:BrendaTissues . # accessory olfactory bulb
+obo:BTO_0004798 rdfs:subClassOf bae:BrendaTissues . # accessory sex gland
+obo:BTO_0004800 rdfs:subClassOf bae:BrendaTissues . # amnioserosa
+obo:BTO_0004803 rdfs:subClassOf bae:BrendaTissues . # buccal epithelium
+obo:BTO_0004834 rdfs:subClassOf bae:BrendaTissues . # middle frontal gyrus
+obo:BTO_0004835 rdfs:subClassOf bae:BrendaTissues . # inferior frontal gyrus
+obo:BTO_0004836 rdfs:subClassOf bae:BrendaTissues . # superior frontal gyrus
+obo:BTO_0004838 rdfs:subClassOf bae:BrendaTissues . # muscular coat
+obo:BTO_0004849 rdfs:subClassOf bae:BrendaTissues . # pharyngeal gland
+obo:BTO_0004857 rdfs:subClassOf bae:BrendaTissues . # ookinete
+obo:BTO_0004875 rdfs:subClassOf bae:BrendaTissues . # labellum
+obo:BTO_0004876 rdfs:subClassOf bae:BrendaTissues . # distal tip
+obo:BTO_0004878 rdfs:subClassOf bae:BrendaTissues . # enteric muscle
+obo:BTO_0004882 rdfs:subClassOf bae:BrendaTissues . # ventral midbrain
+obo:BTO_0004902 rdfs:subClassOf bae:BrendaTissues . # cholinergic neuron
+obo:BTO_0004906 rdfs:subClassOf bae:BrendaTissues . # molecular layer
+obo:BTO_0004909 rdfs:subClassOf bae:BrendaTissues . # Purkinje layer
+obo:BTO_0004913 rdfs:subClassOf bae:BrendaTissues . # vastus medialis
+obo:BTO_0004914 rdfs:subClassOf bae:BrendaTissues . # rheumatoid arthritis disease specific synovial fibroblast
+obo:BTO_0004957 rdfs:subClassOf bae:BrendaTissues . # hydathode
+obo:BTO_0004977 rdfs:subClassOf bae:BrendaTissues . # nasal lavage fluid
+obo:BTO_0004978 rdfs:subClassOf bae:BrendaTissues . # carotid sinus nerve
+obo:BTO_0004979 rdfs:subClassOf bae:BrendaTissues . # glossopharyngeal nerve
+obo:BTO_0004982 rdfs:subClassOf bae:BrendaTissues . # gonocyte
+obo:BTO_0004984 rdfs:subClassOf bae:BrendaTissues . # alate adult
+obo:BTO_0004985 rdfs:subClassOf bae:BrendaTissues . # angioblast
+obo:BTO_0004995 rdfs:subClassOf bae:BrendaTissues . # osphradium
+obo:BTO_0004999 rdfs:subClassOf bae:BrendaTissues . # vaginal smooth muscle
+obo:BTO_0005003 rdfs:subClassOf bae:BrendaTissues . # villous trophoblast
+obo:BTO_0005008 rdfs:subClassOf bae:BrendaTissues . # psammoma body
+obo:BTO_0005024 rdfs:subClassOf bae:BrendaTissues . # gastrointestinal smooth muscle
+obo:BTO_0005035 rdfs:subClassOf bae:BrendaTissues . # Fanconi anemia disease specific cell type
+obo:BTO_0005053 rdfs:subClassOf bae:BrendaTissues . # midgut epithelium
+obo:BTO_0005055 rdfs:subClassOf bae:BrendaTissues . # scale
+obo:BTO_0005078 rdfs:subClassOf bae:BrendaTissues . # foot sole
+obo:BTO_0005081 rdfs:subClassOf bae:BrendaTissues . # periurethral tissue
+obo:BTO_0005082 rdfs:subClassOf bae:BrendaTissues . # skin mucus
+obo:BTO_0005084 rdfs:subClassOf bae:BrendaTissues . # vocal fold
+obo:BTO_0005085 rdfs:subClassOf bae:BrendaTissues . # common penile artery
+obo:BTO_0005086 rdfs:subClassOf bae:BrendaTissues . # arteria profunda penis
+obo:BTO_0005089 rdfs:subClassOf bae:BrendaTissues . # perichondrium
+obo:BTO_0005090 rdfs:subClassOf bae:BrendaTissues . # inner chondrogenic layer of perichondrium
+obo:BTO_0005094 rdfs:subClassOf bae:BrendaTissues . # leaf sheath
+obo:BTO_0005100 rdfs:subClassOf bae:BrendaTissues . # implantation fossa
+obo:BTO_0005115 rdfs:subClassOf bae:BrendaTissues . # salivary duct
+obo:BTO_0005122 rdfs:subClassOf bae:BrendaTissues . # ovarian cyst
+obo:BTO_0005123 rdfs:subClassOf bae:BrendaTissues . # ovarian cyst fluid
+obo:BTO_0005124 rdfs:subClassOf bae:BrendaTissues . # platysma muscle
+obo:BTO_0005125 rdfs:subClassOf bae:BrendaTissues . # sternocleidomastoid muscle
+obo:BTO_0005132 rdfs:subClassOf bae:BrendaTissues . # arrector pili muscle
+obo:BTO_0005142 rdfs:subClassOf bae:BrendaTissues . # ameloblastic layer
+obo:BTO_0005145 rdfs:subClassOf bae:BrendaTissues . # chorionic epithelium
+obo:BTO_0005151 rdfs:subClassOf bae:BrendaTissues . # anterior horn
+obo:BTO_0005157 rdfs:subClassOf bae:BrendaTissues . # juxtaglomerular apparatus
+obo:BTO_0005160 rdfs:subClassOf bae:BrendaTissues . # oil gland
+obo:BTO_0005170 rdfs:subClassOf bae:BrendaTissues . # keratocyte
+obo:BTO_0005180 rdfs:subClassOf bae:BrendaTissues . # pterygium
+obo:BTO_0005188 rdfs:subClassOf bae:BrendaTissues . # trunk kidney
+obo:BTO_0005189 rdfs:subClassOf bae:BrendaTissues . # head kidney
+obo:BTO_0005194 rdfs:subClassOf bae:BrendaTissues . # fine root
+obo:BTO_0005197 rdfs:subClassOf bae:BrendaTissues . # peltate gland
+obo:BTO_0005202 rdfs:subClassOf bae:BrendaTissues . # bulbil
+obo:BTO_0005205 rdfs:subClassOf bae:BrendaTissues . # cerebral artery
+obo:BTO_0005206 rdfs:subClassOf bae:BrendaTissues . # middle cerebral artery
+obo:BTO_0005208 rdfs:subClassOf bae:BrendaTissues . # right middle cerebral artery
+obo:BTO_0005211 rdfs:subClassOf bae:BrendaTissues . # choriodecidua
+obo:BTO_0005213 rdfs:subClassOf bae:BrendaTissues . # circular smooth muscle
+obo:BTO_0005214 rdfs:subClassOf bae:BrendaTissues . # longitudinal smooth muscle
+obo:BTO_0005216 rdfs:subClassOf bae:BrendaTissues . # keratocyst
+obo:BTO_0005219 rdfs:subClassOf bae:BrendaTissues . # osteophyte
+obo:BTO_0005226 rdfs:subClassOf bae:BrendaTissues . # medial pterygoid muscle
+obo:BTO_0005239 rdfs:subClassOf bae:BrendaTissues . # renal tubule epithelium
+obo:BTO_0005240 rdfs:subClassOf bae:BrendaTissues . # pharyngeal epithelium
+obo:BTO_0005257 rdfs:subClassOf bae:BrendaTissues . # oropharynx
+obo:BTO_0005268 rdfs:subClassOf bae:BrendaTissues . # neuropil
+obo:BTO_0005269 rdfs:subClassOf bae:BrendaTissues . # antennal lobe
+obo:BTO_0005273 rdfs:subClassOf bae:BrendaTissues . # adventitious root
+obo:BTO_0005278 rdfs:subClassOf bae:BrendaTissues . # cestode
+obo:BTO_0005281 rdfs:subClassOf bae:BrendaTissues . # intercostal muscle
+obo:BTO_0005305 rdfs:subClassOf bae:BrendaTissues . # corn ear
+obo:BTO_0005312 rdfs:subClassOf bae:BrendaTissues . # amoeba
+obo:BTO_0005313 rdfs:subClassOf bae:BrendaTissues . # nerve sheath
+obo:BTO_0005351 rdfs:subClassOf bae:BrendaTissues . # optic cup
+obo:BTO_0005385 rdfs:subClassOf bae:BrendaTissues . # root quiescent center
+obo:BTO_0005401 rdfs:subClassOf bae:BrendaTissues . # junctional zone
+obo:BTO_0005404 rdfs:subClassOf bae:BrendaTissues . # labyrinthine zone
+obo:BTO_0005405 rdfs:subClassOf bae:BrendaTissues . # velum
+obo:BTO_0005444 rdfs:subClassOf bae:BrendaTissues . # root nodule primordium

--- a/src/com/cdd/bao/axioms/BRENDAFix.java
+++ b/src/com/cdd/bao/axioms/BRENDAFix.java
@@ -1,0 +1,180 @@
+/*
+ * BioAssay Ontology Annotator Tools
+ * 
+ * (c) 2017-2018 Collaborative Drug Discovery Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License 2.0
+ * as published by the Free Software Foundation:
+ * 
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.cdd.bao.axioms;
+
+import com.cdd.bao.util.*;
+import com.cdd.bao.template.*;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import java.util.regex.*;
+import java.util.zip.*;
+
+import org.json.*;
+import org.apache.commons.lang3.*;
+import org.apache.jena.query.*;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.riot.*;
+
+/*
+	Looks at the BRENDA hierarchy, which is initially flat, and generates a patch file that splits it into two parts -
+	the cells and the non-cells (tissues).
+*/
+
+public class BRENDAFix 
+{
+	private Vocabulary vocab = null;
+	
+	private final static String URI_BRENDA_ROOT = "http://dto.org/DTO/DTO_000";
+	
+	private final static String URI_BRENDA_CELLLINES = "bae:BrendaCell";
+	private final static String URI_BRENDA_TISSUES = "bae:BrendaTissues";
+
+	// constructor parameters parsed from command-line
+	private PrintWriter out;
+
+	public static void main(String[] argv)
+	{
+		org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.OFF);
+
+		if (argv.length > 0 && (argv[0].equals("-h") || argv[0].equals("--help")))
+		{
+			printHelp();
+			return;
+		}
+
+		File outfile = null;
+		for (int n = 0; n < argv.length; n++)
+		{
+			if (argv[n].equals("--outfile") && n < argv.length - 1) outfile = new File(argv[++n]);
+		}
+		
+		if (outfile != null && outfile.exists() && !outfile.isFile())
+		{
+			System.err.println("Please specify a valid file location for --outfile.");
+			return;
+		}
+
+		Util.writeln("BRENDA Fix");
+		try {new BRENDAFix(outfile).exec();}
+		catch (Exception ex) {ex.printStackTrace();}
+		Util.writeln("Done.");
+	}
+	
+	private static void printHelp()
+	{
+		Util.writeln("BioAssay Ontology Annotator Tools: BRENDA Cell/Tissue Fix");
+		Util.writeln("Options:");
+		Util.writeln("    --outfile {fn}         output file for delta results");
+	}
+
+	public BRENDAFix(File outfile) throws FileNotFoundException
+	{
+		this.out = new PrintWriter(outfile);
+	}
+
+	public void exec() throws Exception
+	{
+		writeHeader();
+
+		Util.writeln("Loading vocab...");
+		vocab = new Vocabulary("data/ontology", null);
+		Util.writeln("... properties: " + vocab.numProperties() + ", values: " + vocab.numValues());		
+		
+		Vocabulary.Branch root = vocab.getValueHierarchy().uriToBranch.get(ModelSchema.expandPrefix(URI_BRENDA_ROOT));
+		
+		String skip1 = ModelSchema.expandPrefix(URI_BRENDA_CELLLINES), skip2 = ModelSchema.expandPrefix(URI_BRENDA_TISSUES); 
+		Set<String> cells = new TreeSet<>(), tissues = new TreeSet<>();
+		for (Vocabulary.Branch child : root.children)
+		{
+			if (child.uri.equals(skip1) || child.uri.equals(skip2)) continue;
+			
+			if (child.label.endsWith(" cell") || child.label.endsWith(" cell line"))
+				cells.add(child.uri);
+			else
+				tissues.add(child.uri);
+		}
+		
+		Util.writeln("Cells: " + cells.size());
+		Util.writeln("Tissues: " + tissues.size());
+		
+		out.println("# reparenting cells\n");
+		for (String uri : cells)
+		{
+			String abbrev = ModelSchema.collapsePrefix(uri), label = vocab.getLabel(uri);
+			out.println(abbrev + " rdfs:subClassOf " + URI_BRENDA_CELLLINES + " . # " + label);
+		}
+		
+		out.println("\n# reparenting tissues\n");
+		for (String uri : tissues)
+		{
+			String abbrev = ModelSchema.collapsePrefix(uri), label = vocab.getLabel(uri);
+			out.println(abbrev + " rdfs:subClassOf " + URI_BRENDA_TISSUES + " . # " + label);
+		}
+
+		out.close();
+	}
+	
+	private void writeHeader()
+	{
+		out.println("# auto-generated file that divides BRENDA terms into cell vs. tissue branches\n");
+		
+		out.println("@prefix bao:   <http://www.bioassayontology.org/bao#> .");
+		out.println("@prefix bat:   <http://www.bioassayontology.org/bat#> .");
+		out.println("@prefix bae:   <http://www.bioassayexpress.org/bae#>  .");
+		out.println("@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .");
+		out.println("@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .");
+		out.println("@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .");
+		out.println("@prefix owl:   <http://www.w3.org/2002/07/owl#> .");
+		out.println("@prefix obo:   <http://purl.obolibrary.org/obo/> .");
+		out.println();
+
+		out.println(URI_BRENDA_CELLLINES);
+		out.println("  rdfs:label \"cell lines\" ;");
+		out.println("  rdfs:subClassOf <" + URI_BRENDA_ROOT + "> ;");
+		out.println("  a bat:preferredParent ;");
+		out.println("  .\n");
+
+		out.println(URI_BRENDA_TISSUES);
+		out.println("  rdfs:label \"tissues\" ;");
+		out.println("  rdfs:subClassOf <" + URI_BRENDA_ROOT + "> ;");
+		out.println("  a bat:preferredParent ;");
+		out.println("  .\n");
+	}
+	
+	// a trivial escaping transform that needs to be applied to any Turtle-formatted string
+	private String escapeTurtleString(String str)
+	{
+		StringBuilder builder = new StringBuilder();
+		for (char ch : str.toCharArray())
+		{
+			if (ch == '"') builder.append("\\\"");
+			else if (ch == '\\') builder.append("\\\\");
+			else if (ch == '\t') builder.append("\\t");
+			else if (ch == '\r') {}
+			else if (ch == '\n') builder.append("\\n");
+			else builder.append(ch);
+		}
+		return builder.toString();
+	}
+}

--- a/src/com/cdd/bao/axioms/BRENDAFix.java
+++ b/src/com/cdd/bao/axioms/BRENDAFix.java
@@ -122,14 +122,16 @@ public class BRENDAFix
 		for (String uri : cells)
 		{
 			String abbrev = ModelSchema.collapsePrefix(uri), label = vocab.getLabel(uri);
-			out.println(abbrev + " rdfs:subClassOf " + URI_BRENDA_CELLLINES + " . # " + label);
+			out.println(abbrev + " rdfs:subClassOf " + URI_BRENDA_CELLLINES + " ;");
+			out.println("  bat:notSubClass <" + URI_BRENDA_ROOT + "> . # " + label);
 		}
 		
 		out.println("\n# reparenting tissues\n");
 		for (String uri : tissues)
 		{
 			String abbrev = ModelSchema.collapsePrefix(uri), label = vocab.getLabel(uri);
-			out.println(abbrev + " rdfs:subClassOf " + URI_BRENDA_TISSUES + " . # " + label);
+			out.println(abbrev + " rdfs:subClassOf " + URI_BRENDA_TISSUES + " ;");
+			out.println("  bat:notSubClass <" + URI_BRENDA_ROOT + "> . # " + label);
 		}
 
 		out.close();


### PR DESCRIPTION
The BRENDA ontology is almost all flat, but the labels end with "cell" or "cell line" for cells. Added and ran a script to separate them.